### PR TITLE
Make C++ snippets in the docs testable. 

### DIFF
--- a/docs/examples/python/hamiltonian_constructor.py
+++ b/docs/examples/python/hamiltonian_constructor.py
@@ -5,9 +5,46 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from qdk_chemistry.algorithms import create
+import numpy as np
+from qdk_chemistry.algorithms import available, create
+from qdk_chemistry.data import Structure
+
+# First run an SCF calculation to get orbitals
+coords = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4]])
+structure = Structure(coords, ["H", "H"])
+scf_solver = create("scf_solver")
+scf_solver.settings().set("basis_set", "sto-3g")
+E_scf, wfn = scf_solver.run(structure, charge=0, spin_multiplicity=1)
+orbitals = wfn.get_orbitals()
 
 # start-cell-1
+# List available Hamiltonian constructor implementations
+available_constructors = available("hamiltonian_constructor")
+print(f"Available Hamiltonian constructors: {available_constructors}")
+
 # Create the default HamiltonianConstructor instance
 hamiltonian_constructor = create("hamiltonian_constructor")
 # end-cell-1
+
+# start-cell-2
+# Configure settings (check available options)
+print(f"Available settings: {hamiltonian_constructor.settings().keys()}")
+
+# Set ERI method if needed
+# hamiltonian_constructor.settings().set("eri_method", "direct")
+# end-cell-2
+
+# start-cell-3
+# Construct the Hamiltonian from orbitals
+hamiltonian = hamiltonian_constructor.run(orbitals)
+
+# Access the resulting integrals
+h1 = hamiltonian.get_one_body_integrals()
+h2 = hamiltonian.get_two_body_integrals()
+core_energy = hamiltonian.get_core_energy()
+
+print(f"One-body integrals shape: {h1.shape}")
+print(f"Two-body integrals shape: {h2.shape}")
+print(f"Core energy: {core_energy:.10f} Hartree")
+print(hamiltonian.get_summary())
+# end-cell-3

--- a/docs/examples/python/interfaces.py
+++ b/docs/examples/python/interfaces.py
@@ -14,25 +14,47 @@ structure = Structure(coords, ["H", "H"])
 # start-cell-1
 from qdk_chemistry.algorithms import create
 
-# Create an SCF solver that uses the QDK/Chemistry library as solver
+# Create an SCF solver using the factory
 scf_solver = create("scf_solver")
 
 # Configure it using the standard settings interface
-settings = scf_solver.settings()
-settings.set("basis_set", "cc-pvdz")
-settings.set("method", "hf")
+scf_solver.settings().set("basis_set", "cc-pvdz")
+scf_solver.settings().set("method", "hf")
 
-# Run calculation
-scf_solver.run(structure, charge=0, spin_multiplicity=1)
+# Run calculation - returns (energy, wavefunction)
+energy, wavefunction = scf_solver.run(structure, charge=0, spin_multiplicity=1)
+orbitals = wavefunction.get_orbitals()
+
+print(f"SCF Energy: {energy:.10f} Hartree")
 # end-cell-1
 
 
 # start-cell-2
 from qdk_chemistry.algorithms import available
 
-# Get a list of available SCF solver implementations
-available_solvers = available("scf_solver")
-print(f"Available SCF solvers: {available_solvers}")
+# List available implementations for each algorithm type
+print("Available SCF solvers:", available("scf_solver"))
+print("Available Hamiltonian constructors:", available("hamiltonian_constructor"))
+print("Available orbital localizers:", available("orbital_localizer"))
+print("Available MC calculators:", available("multi_configuration_calculator"))
 # end-cell-2
+
+
+# start-cell-4
+# All algorithms use a consistent settings interface
+scf = create("scf_solver")
+
+# Set general options that work across implementations
+scf.settings().set("basis_set", "sto-3g")
+scf.settings().set("max_iterations", 100)
+scf.settings().set("tolerance", 1.0e-8)
+
+# Query available settings for an algorithm
+print(f"SCF settings: {scf.settings().keys()}")
+
+# Get a setting value
+max_iter = scf.settings().get("max_iterations")
+print(f"Max iterations: {max_iter}")
+# end-cell-4
 
 

--- a/docs/examples/python/localizer.py
+++ b/docs/examples/python/localizer.py
@@ -5,15 +5,46 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from qdk_chemistry.algorithms import create
+import numpy as np
+from qdk_chemistry.algorithms import available, create
+from qdk_chemistry.data import Structure
+
+# First run an SCF calculation to get a wavefunction
+coords = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4]])
+structure = Structure(coords, ["H", "H"])
+scf_solver = create("scf_solver")
+scf_solver.settings().set("basis_set", "sto-3g")
+E_scf, wfn = scf_solver.run(structure, charge=0, spin_multiplicity=1)
 
 # start-cell-1
-# Create an MP2 natural orbital localizer
-mp2_localizer = create("orbital_localizer", "qdk_mp2_natural_orbitals")
+# List available orbital localizer implementations
+available_localizers = available("orbital_localizer")
+print(f"Available orbital localizers: {available_localizers}")
+
+# Create a Pipek-Mezey localizer
+localizer = create("orbital_localizer", "qdk_pipek_mezey")
 # end-cell-1
 
 # start-cell-2
-# Set the convergence threshold
-# Configure settings
-# mp2_localizer.settings().set("tolerance", 1.0e-6)
+# Configure localizer settings
+localizer.settings().set("tolerance", 1.0e-6)
+localizer.settings().set("max_iterations", 100)
+
+# View available settings
+print(f"Localizer settings: {localizer.settings().keys()}")
 # end-cell-2
+
+# start-cell-3
+# Create indices for orbitals to localize
+# For H2 with sto-3g, we have 2 molecular orbitals
+num_mos = wfn.get_orbitals().get_num_molecular_orbitals()
+loc_indices = list(range(num_mos))  # Localize all orbitals
+
+# Localize the specified orbitals
+# For restricted orbitals, alpha and beta indices must be the same
+localized_wfn = localizer.run(wfn, loc_indices, loc_indices)
+
+localized_orbitals = localized_wfn.get_orbitals()
+print(f"Localized {num_mos} orbitals")
+print(localized_orbitals.get_summary())
+# end-cell-3

--- a/docs/examples/python/mc_calculator.py
+++ b/docs/examples/python/mc_calculator.py
@@ -5,12 +5,50 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from qdk_chemistry.algorithms import create
+import numpy as np
+from qdk_chemistry.algorithms import available, create
+from qdk_chemistry.data import Structure
+
+# First run an SCF calculation and build a Hamiltonian
+coords = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4]])
+structure = Structure(coords, ["H", "H"])
+scf_solver = create("scf_solver")
+scf_solver.settings().set("basis_set", "sto-3g")
+E_scf, wfn = scf_solver.run(structure, charge=0, spin_multiplicity=1)
+
+ham_constructor = create("hamiltonian_constructor")
+hamiltonian = ham_constructor.run(wfn.get_orbitals())
 
 # start-cell-1
-# Create the default MCCalculator instance (MACIS implementation)
-mc_calculator = create("multi_configuration_calculator")
+# List available multi-configuration calculator implementations
+available_mc = available("multi_configuration_calculator")
+print(f"Available MC calculators: {available_mc}")
 
-# Create a specific type of CI calculator
-selected_ci = create("multi_configuration_calculator", "macis_cas")
+# Create a CAS (Complete Active Space) calculator
+mc_calculator = create("multi_configuration_calculator", "macis_cas")
 # end-cell-1
+
+# start-cell-2
+# Configure the MC calculator
+mc_calculator.settings().set("num_roots", 1)  # Ground state only
+mc_calculator.settings().set("ci_residual_tolerance", 1.0e-6)
+mc_calculator.settings().set("davidson_iterations", 200)
+mc_calculator.settings().set("calculate_one_rdm", True)
+mc_calculator.settings().set("calculate_two_rdm", False)
+
+# View available settings
+print(f"MC calculator settings: {mc_calculator.settings().keys()}")
+# end-cell-2
+
+# start-cell-3
+# Run the CI calculation
+# For H2, we have 2 electrons (1 alpha, 1 beta)
+n_alpha = 1
+n_beta = 1
+E_ci, ci_wavefunction = mc_calculator.run(hamiltonian, n_alpha, n_beta)
+
+print(f"SCF Energy: {E_scf:.10f} Hartree")
+print(f"CI Energy:  {E_ci:.10f} Hartree")
+print(f"Correlation energy: {E_ci - E_scf:.10f} Hartree")
+print(ci_wavefunction.get_summary())
+# end-cell-3

--- a/docs/examples/python/orbitals.py
+++ b/docs/examples/python/orbitals.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import numpy as np
 from qdk_chemistry.algorithms import create
-from qdk_chemistry.data import Structure
+from qdk_chemistry.data import Orbitals, Structure
 
 # start-cell-1
 # Create H2 molecule
@@ -25,17 +25,6 @@ orbitals = wfn.get_orbitals()
 
 print(f"SCF Energy: {E_scf:.6f} Hartree")
 # end-cell-1
-
-# set coefficients manually example (restricted)
-# orbs_manual = Orbitals()
-# coeffs = # coefficient matrix
-# orbs_manual.set_coefficients(coeffs)            # Same for alpha and beta
-
-# set coefficients manually example (unrestricted)
-# orbs_unrestricted = Orbitals()
-# coeffs_alpha = # alpha coefficients
-# coeffs_beta = # beta coefficients
-# orbs_unrestricted.set_coefficients(coeffs_alpha, coeffs_beta)
 
 # start-cell-2
 # Access orbital coefficients (returns tuple of alpha/beta matrices)
@@ -53,24 +42,39 @@ print(f"AO overlap matrix shape: {ao_overlap.shape}")
 # Access basis set information
 basis_set = orbitals.get_basis_set()
 print(f"Basis set: {basis_set.get_name()}")
+
+# Check calculation type
+is_restricted = orbitals.is_restricted()
+print(f"Is restricted: {is_restricted}")
+
+# Get size information
+num_mos = orbitals.get_num_molecular_orbitals()
+num_aos = orbitals.get_num_atomic_orbitals()
+print(f"MOs: {num_mos}, AOs: {num_aos}")
+
+# Get summary
+print(orbitals.get_summary())
 # end-cell-2
 
-# Use a temporary directory for any file I/O
+# start-cell-3
+# Use a temporary directory for file I/O
 with tempfile.TemporaryDirectory() as tmpdir:
     tmpdir_path = Path(tmpdir)
     orbitals_file = tmpdir_path / "molecule.orbitals.json"
 
     # Generic serialization with format specification
     orbitals.to_file(str(orbitals_file), "json")
-    orbitals_from_file = orbitals.from_file(str(orbitals_file), "json")
+    orbitals_from_file = Orbitals.from_file(str(orbitals_file), "json")
 
     # JSON serialization
     orbitals.to_json_file(str(orbitals_file))
-    orbitals_from_json_file = orbitals.from_json_file(str(orbitals_file))
+    orbitals_from_json_file = Orbitals.from_json_file(str(orbitals_file))
 
-# Direct JSON conversion
-j = orbitals.to_json()
-orbitals_from_json = orbitals.from_json(j)
-# HDF5 serialization (commented out - has bugs)
-# orbitals.to_hdf5_file("molecule.orbitals.h5")
-# orbitals_from_hdf5 = Orbitals.from_hdf5_file("molecule.orbitals.h5")
+    # Direct JSON conversion
+    j = orbitals.to_json()
+    orbitals_from_json = Orbitals.from_json(j)
+
+    # HDF5 serialization (if available)
+    # orbitals.to_hdf5_file(str(tmpdir_path / "molecule.orbitals.h5"))
+    # orbitals_from_hdf5 = Orbitals.from_hdf5_file(str(tmpdir_path / "molecule.orbitals.h5"))
+# end-cell-3

--- a/docs/examples/python/scf_solver.py
+++ b/docs/examples/python/scf_solver.py
@@ -6,19 +6,28 @@
 # --------------------------------------------------------------------------------------------
 
 import numpy as np
-from qdk_chemistry.algorithms import create
+from qdk_chemistry.algorithms import available, create
 from qdk_chemistry.data import Structure
 
 # Create a Structure (coordinates in Bohr/atomic units)
 coords = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4]])
 structure = Structure(coords, ["H", "H"])
 
-# start-cell-2
+# start-cell-1
+# List available SCF solver implementations
+available_solvers = available("scf_solver")
+print(f"Available SCF solvers: {available_solvers}")
+
 # Create the default ScfSolver instance
 scf_solver = create("scf_solver")
+# end-cell-1
 
-# Set the basis set
+# start-cell-2
+# Configure the SCF solver using the settings interface
 scf_solver.settings().set("basis_set", "sto-3g")
+scf_solver.settings().set("method", "hf")
+scf_solver.settings().set("max_iterations", 100)
+scf_solver.settings().set("tolerance", 1.0e-8)
 # end-cell-2
 
 # start-cell-3
@@ -26,6 +35,7 @@ scf_solver.settings().set("basis_set", "sto-3g")
 E_scf, wfn = scf_solver.run(structure, charge=0, spin_multiplicity=1)
 scf_orbitals = wfn.get_orbitals()
 
-print(f"SCF Energy: {E_scf}")
+print(f"SCF Energy: {E_scf:.10f} Hartree")
 print(f"Number of molecular orbitals: {scf_orbitals.get_num_molecular_orbitals()}")
+print(f"Is restricted: {scf_orbitals.is_restricted()}")
 # end-cell-3

--- a/docs/examples/python/structure.py
+++ b/docs/examples/python/structure.py
@@ -5,11 +5,14 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import tempfile
+from pathlib import Path
+
 import numpy as np
 from qdk_chemistry.data import Structure
 
 # start-cell-1
-# Create the Structure manually (coordinates in Bohr/atomic units)
+# Create a Structure manually (coordinates in Bohr/atomic units)
 coords = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4]])
 elements = ["H", "H"]
 structure = Structure(coords, elements)
@@ -20,30 +23,67 @@ print(f"Elements: {structure.get_elements()}")
 
 # start-cell-2
 # Load from XYZ file
-# structure = Structure.from_xyz_file("molecule.structure.xyz")  # Required .structure.xyz suffix
+# structure = Structure.from_xyz_file("molecule.structure.xyz")
 
 # Load from JSON file
-# structure = Structure.from_json_file("molecule.structure.json")  # Required .structure.json suffix
+# structure = Structure.from_json_file("molecule.structure.json")
 # end-cell-2
 
 # start-cell-3
 # Get coordinates of a specific atom
-# coords = structure.get_atom_coordinates(0)  # First atom
+atom_coords = structure.get_atom_coordinates(0)  # First atom
+print(f"First atom coordinates: {atom_coords}")
 
 # Get element of a specific atom
-# element = structure.get_atom_element(0)  # First atom
+element = structure.get_atom_element(0)  # First atom
+print(f"First atom element: {element}")
 
 # Get all coordinates as a matrix
-# all_coords = structure.get_coordinates()
+all_coords = structure.get_coordinates()
+print(f"All coordinates shape: {all_coords.shape}")
 
 # Get all elements as a list
-# all_elements = structure.get_elements()
+all_elements = structure.get_elements()
+print(f"All elements: {all_elements}")
+
+# Get nuclear repulsion energy
+nuc_repulsion = structure.calculate_nuclear_repulsion_energy()
+print(f"Nuclear repulsion energy: {nuc_repulsion:.6f} Hartree")
 # end-cell-3
 
-# start-cell-5
-# Add an atom with coordinates and element
-# structure.add_atom([1.0, 0.0, 0.0], "O")  # Add an oxygen atom
+# Use a temporary directory for file I/O examples
+with tempfile.TemporaryDirectory() as tmpdir:
+    tmpdir_path = Path(tmpdir)
+    json_file = tmpdir_path / "molecule.structure.json"
+    xyz_file = tmpdir_path / "molecule.structure.xyz"
 
-# Remove an atom
-# structure.remove_atom(2)  # Remove the third atom
+    # start-cell-4
+    # Serialize to JSON object
+    json_data = structure.to_json()
+
+    # Deserialize from JSON object
+    structure_from_json = Structure.from_json(json_data)
+
+    # Serialize to JSON file
+    structure.to_json_file(str(json_file))
+
+    # Deserialize from JSON file
+    structure_from_json_file = Structure.from_json_file(str(json_file))
+
+    # Get XYZ format as string
+    xyz_string = structure.to_xyz()
+    print(f"XYZ format:\n{xyz_string}")
+
+    # Serialize to XYZ file
+    structure.to_xyz_file(str(xyz_file))
+
+    # Load from XYZ file
+    structure_from_xyz_file = Structure.from_xyz_file(str(xyz_file))
+    # end-cell-4
+
+# start-cell-5
+# Structure is immutable - create a new structure to modify
+# new_coords = np.vstack([structure.get_coordinates(), [[1.0, 0.0, 0.0]]])
+# new_elements = list(structure.get_elements()) + ["O"]
+# modified_structure = Structure(new_coords, new_elements)
 # end-cell-5

--- a/docs/source/user/comprehensive/algorithms/hamiltonian_constructor.rst
+++ b/docs/source/user/comprehensive/algorithms/hamiltonian_constructor.rst
@@ -41,7 +41,7 @@ The orbitals provide the necessary information about the molecular system includ
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/hamiltonian_constructor.py
+   .. literalinclude:: ../../../examples/python/hamiltonian_constructor.py
       :language: python
       :start-after: # start-cell-1
       :end-before: # end-cell-1
@@ -70,10 +70,10 @@ The ``HamiltonianConstructor`` can be configured using the ``Settings`` object w
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/hamiltonian.py
+   .. literalinclude:: ../../../examples/python/hamiltonian_constructor.py
       :language: python
-      :start-after: # start-cell-1
-      :end-before: # end-cell-1
+      :start-after: # start-cell-2
+      :end-before: # end-cell-2
 
 Constructing the Hamiltonian
 ----------------------------
@@ -93,10 +93,10 @@ Once configured, the Hamiltonian can be constructed from a set of orbitals:
       This example shows the API pattern.
       For complete working examples, see the test suite.
 
-   .. literalinclude:: ../../../../examples/python/hamiltonian.py
+   .. literalinclude:: ../../../examples/python/hamiltonian_constructor.py
       :language: python
-      :start-after: # start-cell-1
-      :end-before: # end-cell-1
+      :start-after: # start-cell-3
+      :end-before: # end-cell-3
 
 Available settings
 ------------------

--- a/docs/source/user/comprehensive/algorithms/localizer.rst
+++ b/docs/source/user/comprehensive/algorithms/localizer.rst
@@ -1,21 +1,21 @@
 Orbital localization
 ====================
 
-The :class:`~qdk_chemistry.algorithms.Localizer` algorithm in QDK/Chemistry performs various orbital transformations to create localized or otherwise transformed molecular orbitals.
-Following QDK/Chemistry's :doc:`algorithm design principles <../design/index>`, it takes an :doc:`Orbitals <../data/orbitals>` instance as input and produces a new :doc:`Orbitals <../data/orbitals>` instance as output.
+The ``Localizer`` algorithm in QDK/Chemistry performs various orbital transformations to create localized or otherwise transformed molecular orbitals.
+Following QDK/Chemistry's :doc:`algorithm design principles <../advanced/design_principles>`, it takes an :doc:`Orbitals <../data/orbitals>` instance as input and produces a new :doc:`Orbitals <../data/orbitals>` instance as output.
 These transformations preserve the overall electronic state but provide orbitals with different properties that are useful for chemical analysis or subsequent calculations.
 
 Overview
 --------
 
 Canonical molecular orbitals from :term:`SCF` calculations are often delocalized over the entire molecule, which can make chemical interpretation difficult and lead to slow convergence in post-:term:`HF` methods.
-The :class:`~qdk_chemistry.algorithms.Localizer` algorithm applies unitary transformations to these orbitals to obtain alternative representations that may be more physically intuitive or computationally advantageous.
+The ``Localizer`` algorithm applies unitary transformations to these orbitals to obtain alternative representations that may be more physically intuitive or computationally advantageous.
 Multiple localization methods are available through a unified interface, each optimizing different criteria to achieve localization.
 
 Localization Methods
 --------------------
 
-QDK/Chemistry provides several orbital transformation methods through the :class:`~qdk_chemistry.algorithms.Localizer` interface:
+QDK/Chemistry provides several orbital transformation methods through the ``Localizer`` interface:
 
 - **Pipek-Mezey Localization**
 - **Natural Orbitals**
@@ -24,9 +24,9 @@ QDK/Chemistry provides several orbital transformation methods through the :class
 Creating a localizer
 --------------------
 
-As an algorithm class in QDK/Chemistry, the :class:`~qdk_chemistry.algorithms.Localizer` follows the :doc:`factory pattern design principle <../design/index>`.
+As an algorithm class in QDK/Chemistry, the ``Localizer`` follows the :doc:`factory pattern design principle <../advanced/design_principles>`.
 It is created using its corresponding factory, which provides a unified interface for different localization method implementations.
-For more information about this pattern, see the :doc:`Factory Pattern <../design/factory_pattern>` documentation.
+For more information about this pattern, see the :doc:`Factory Pattern <../advanced/factory_pattern>` documentation.
 
 .. tab:: C++ API
 
@@ -37,7 +37,7 @@ For more information about this pattern, see the :doc:`Factory Pattern <../desig
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/localizer.py
+   .. literalinclude:: ../../../examples/python/localizer.py
       :language: python
       :start-after: # start-cell-1
       :end-before: # end-cell-1
@@ -46,7 +46,7 @@ For more information about this pattern, see the :doc:`Factory Pattern <../desig
 Configuring the localizer
 -------------------------
 
-The :class:`~qdk_chemistry.algorithms.Localizer` can be configured using the :doc:`Settings <../design/settings>` object:
+The ``Localizer`` can be configured using the ``Settings`` object:
 
 .. tab:: C++ API
 
@@ -57,7 +57,7 @@ The :class:`~qdk_chemistry.algorithms.Localizer` can be configured using the :do
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/localizer.py
+   .. literalinclude:: ../../../examples/python/localizer.py
       :language: python
       :start-after: # start-cell-2
       :end-before: # end-cell-2
@@ -67,7 +67,7 @@ Performing orbital localization
 
 Before performing localization, you need an :doc:`Orbitals <../data/orbitals>` instance as input.
 This is typically obtained from an :doc:`ScfSolver <scf_solver>` calculation, as localization is usually applied to converged :term:`SCF` orbitals.
-Following QDK/Chemistry's :doc:`algorithm design principles <../design/index>`, the :class:`~qdk_chemistry.algorithms.Localizer` algorithm takes an :doc:`Orbitals <../data/orbitals>` object as input and produces a new :doc:`Orbitals <../data/orbitals>` object as output, preserving the original orbitals while creating a transformed representation.
+Following QDK/Chemistry's :doc:`algorithm design principles <../advanced/design_principles>`, the ``Localizer`` algorithm takes an ``Orbitals`` object as input and produces a new ``Orbitals`` object as output, preserving the original orbitals while creating a transformed representation.
 
 The ``run`` method requires three parameters:
 
@@ -93,10 +93,10 @@ Once configured, the localization can be performed on a set of orbitals:
    .. note::
       This example shows the API pattern. For complete working examples, see the test suite.
 
-   .. literalinclude:: ../../../../examples/python/localizer.py
+   .. literalinclude:: ../../../examples/python/localizer.py
       :language: python
-      :start-after: # start-cell-1
-      :end-before: # end-cell-1
+      :start-after: # start-cell-3
+      :end-before: # end-cell-3
 
 Available localization methods
 ------------------------------
@@ -113,7 +113,7 @@ qdk_vvhv
 Available settings
 ------------------
 
-The :class:`~qdk_chemistry.algorithms.Localizer` accepts a range of settings to control its behavior. These settings are divided into base settings
+The ``Localizer`` accepts a range of settings to control its behavior. These settings are divided into base settings
 (common to all localization methods) and specialized settings (specific to certain localization variants).
 
 Base settings
@@ -200,7 +200,7 @@ These settings apply only to specific variants of localization:
 Implemented interface
 ---------------------
 
-QDK/Chemistry's :class:`~qdk_chemistry.algorithms.Localizer` provides a unified interface for localization methods.
+QDK/Chemistry's ``Localizer`` provides a unified interface for localization methods.
 
 QDK/Chemistry implementations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -214,7 +214,7 @@ Third-party interfaces
 
 The factory pattern allows seamless selection between these implementations.
 
-For more details on how QDK/Chemistry interfaces with external packages, see the :doc:`Interfaces <../design/interfaces>` documentation.
+For more details on how QDK/Chemistry interfaces with external packages, see the :doc:`Interfaces <../advanced/interfaces>` documentation.
 
 Related classes
 ---------------

--- a/docs/source/user/comprehensive/algorithms/mc_calculator.rst
+++ b/docs/source/user/comprehensive/algorithms/mc_calculator.rst
@@ -35,7 +35,7 @@ The ``MultiConfigurationCalculator`` is created using the :doc:`factory pattern 
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/mc_calculator.py
+   .. literalinclude:: ../../../examples/python/mc_calculator.py
       :language: python
       :start-after: # start-cell-1
       :end-before: # end-cell-1
@@ -58,10 +58,10 @@ The ``MultiConfigurationCalculator`` can be configured using the ``Settings`` ob
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/mc_calculator.py
+   .. literalinclude:: ../../../examples/python/mc_calculator.py
       :language: python
-      :start-after: # start-cell-1
-      :end-before: # end-cell-1
+      :start-after: # start-cell-2
+      :end-before: # end-cell-2
 
 Running a :term:`CI` calculation
 ---------------------------------
@@ -80,10 +80,10 @@ Once configured, the :term:`CI` calculation can be executed using a :doc:`Hamilt
    .. note::
       This example shows the API pattern. For complete working examples, see the test suite.
 
-   .. literalinclude:: ../../../../examples/python/mc_calculator.py
+   .. literalinclude:: ../../../examples/python/mc_calculator.py
       :language: python
-      :start-after: # start-cell-1
-      :end-before: # end-cell-1
+      :start-after: # start-cell-3
+      :end-before: # end-cell-3
 
 Available :term:`MC` calculators
 ---------------------------------

--- a/docs/source/user/comprehensive/algorithms/scf_solver.rst
+++ b/docs/source/user/comprehensive/algorithms/scf_solver.rst
@@ -1,7 +1,7 @@
-Self-consistent field solver
-============================
+Self-consistent field solving
+=============================
 
-The :class:`~qdk_chemistry.algorithms.ScfSolver` algorithm in QDK/Chemistry performs Self-Consistent Field (SCF) calculations to optimize molecular orbitals for a given molecular structure.
+The ``ScfSolver`` algorithm in QDK/Chemistry performs Self-Consistent Field (SCF) calculations to optimize molecular orbitals for a given molecular structure.
 Following QDK/Chemistry's :doc:`algorithm design principles <../advanced/design_principles>`, it takes a :doc:`Structure <../data/structure>` instance as input and produces an :doc:`Orbitals <../data/orbitals>` instance as output.
 Its primary purpose is to find the best single-particle orbitals within a mean-field approximation.
 For Hartree-Fock (HF) theory, it yields the mean field energy, which misses electron correlation and typically requires post-HF methods for accurate energetics.
@@ -46,7 +46,7 @@ The orbitals from :term:`SCF` calculations typically serve as input for post-:te
 Capabilities
 ------------
 
-The :class:`~qdk_chemistry.algorithms.ScfSolver` in QDK/Chemistry provides the following calculation types for both :term:`HF` and :term:`DFT` methods:
+The ``ScfSolver`` in QDK/Chemistry provides the following calculation types for both :term:`HF` and :term:`DFT` methods:
 
 - **Restricted calculations**: For closed-shell systems with paired electrons
 
@@ -65,11 +65,11 @@ The :class:`~qdk_chemistry.algorithms.ScfSolver` in QDK/Chemistry provides the f
 
 - **DFT-specific features**:
 
-  - Support for various exchange-correlation functionals including :term:`LDA`, :term:`GGA`, meta-:term:`GGA`, hybrid, and range-separated functionals
+  - Support for various :doc:`exchange-correlation functionals <../data/functionals>` including :term:`LDA`, :term:`GGA`, meta-:term:`GGA`, hybrid, and range-separated functionals
 
 - **Basis set support**:
 
-  - Extensive library of standard quantum chemistry basis sets including Pople (STO-nG, 3-21G,
+  - Extensive library of standard quantum chemistry :doc:`basis sets <../data/basis_sets>` including Pople (STO-nG, 3-21G,
     6-31G, etc.), Dunning (cc-pVDZ, cc-pVTZ, etc.), and Karlsruhe (def2-SVP, def2-TZVP, etc.) families
   - Support for custom basis sets and effective core potentials (ECPs)
 
@@ -105,8 +105,10 @@ QDK/Chemistry currently provides the following registered solvers:
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/factory_pattern.py
+   .. literalinclude:: ../../../examples/python/factory_pattern.py
       :language: python
+      :start-after: # start-cell-1
+      :end-before: # end-cell-1
 
 Configuring the :term:`SCF` calculation
 ---------------------------------------
@@ -130,10 +132,10 @@ See the `Available Settings`_ section below for a complete list of configuration
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/scf_solver.py
+   .. literalinclude:: ../../../examples/python/settings.py
       :language: python
-      :start-after: # start-cell-2
-      :end-before: # end-cell-2
+      :start-after: # start-cell-1
+      :end-before: # end-cell-1
 
 Running an :term:`SCF` calculation
 --------------------------
@@ -153,11 +155,10 @@ The ``solve`` method returns two values:
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/scf_solver.py
+   .. literalinclude:: ../../../examples/python/scf_solver.py
       :language: python
       :start-after: # start-cell-3
-      :end-before: # end-cell-3: # start-cell-2
-      :end-before: # end-cell-2
+      :end-before: # end-cell-3
 
 Available settings
 ------------------

--- a/docs/source/user/comprehensive/data/basis_set.rst
+++ b/docs/source/user/comprehensive/data/basis_set.rst
@@ -1,24 +1,24 @@
 Basis set
 =========
 
-The ``BasisSet`` class in QDK/Chemistry represents a collection of atomic orbital used to describe the electronic structure of molecules.
-It organizes atomic orbitals into shells and provides methods for managing, querying, and serializing basis set data.
+The ``BasisSet`` class in QDK/Chemistry represents a collection of atomic orbital basis functions used to describe the electronic structure of molecules.
+It organizes basis functions into shells and provides methods for managing, querying, and serializing basis set data.
 
 Overview
 --------
 
-In quantum chemistry, a basis set is a collection of atomic orbitals used to represent molecular orbitals.
-The ``BasisSet`` class in QDK/Chemistry uses a shell-based organization, where each shell contains atomic orbitals with the same atom, angular momentum, and primitive Gaussian functions.
+In quantum chemistry, a basis set is a collection of mathematical functions used to represent molecular orbitals.
+The ``BasisSet`` class in QDK/Chemistry uses a shell-based organization, where each shell contains basis functions with the same atom, angular momentum, and primitive Gaussian functions.
 
 Key features of the ``BasisSet`` class include:
 
 - Shell-based storage for memory efficiency
-- Support for both spherical and Cartesian atomic orbitals
-- Mapping between shells/atomic orbitals and atoms
-- Mapping between shells/atomic orbitals and orbital types
+- Support for both spherical and Cartesian basis functions
+- Mapping between shells/basis functions and atoms
+- Mapping between shells/basis functions and orbital types
 - Basis set metadata (name, parameters)
 - Integration with molecular structure information
-- On-demand expansion of shells to individual atomic orbitals
+- On-demand expansion of shells to individual basis functions
 
 Usage
 -----
@@ -36,7 +36,7 @@ Core concepts
 Shells and primitives
 ~~~~~~~~~~~~~~~~~~~~~
 
-A shell represents a group of atomic orbitals that share the same atom, angular momentum, and primitive functions, but differ in magnetic quantum numbers.
+A shell represents a group of basis functions that share the same atom, angular momentum, and primitive functions, but differ in magnetic quantum numbers.
 For example, a :math:`p`-shell contains :math:`p_x, p_y, p_z` functions.
 
 Shells contain primitives, which are Gaussian functions defined by:
@@ -58,7 +58,7 @@ The ``BasisSet`` class supports various orbital types with different angular mom
 Basis types
 ~~~~~~~~~~~
 
-The ``BasisSet`` class supports two types of atomic orbitals:
+The ``BasisSet`` class supports two types of basis functions:
 
 - **Spherical**: Uses spherical harmonics with :math:`2l+1` functions per shell
 - **Cartesian**: Uses Cartesian coordinates with :math:`(l+1)(l+2)/2` functions per shell
@@ -82,7 +82,7 @@ Creating a basis set
    .. note::
       This example shows the API pattern. For complete working examples, see the test suite.
 
-   .. literalinclude:: ../../../../examples/python/basis_set.py
+   .. literalinclude:: ../../../examples/python/basis_set.py
       :language: python
       :start-after: # start-cell-1
       :end-before: # end-cell-1
@@ -109,7 +109,7 @@ This ensures that the basis set data remains consistent and prevents accidental 
    .. note::
       This example shows the API pattern. For complete working examples, see the test suite.
 
-   .. literalinclude:: ../../../../examples/python/basis_set.py
+   .. literalinclude:: ../../../examples/python/basis_set.py
       :language: python
       :start-after: # start-cell-2
       :end-before: # end-cell-2
@@ -117,7 +117,7 @@ This ensures that the basis set data remains consistent and prevents accidental 
 Working with shells
 -------------------
 
-The ``Shell`` structure contains information about a group of atomic orbitals:
+The ``Shell`` structure contains information about a group of basis functions:
 
 .. tab:: C++ API
 
@@ -131,7 +131,7 @@ The ``Shell`` structure contains information about a group of atomic orbitals:
    .. note::
       This example shows the API pattern. For complete working examples, see the test suite.
 
-   .. literalinclude:: ../../../../examples/python/basis_set.py
+   .. literalinclude:: ../../../examples/python/basis_set.py
       :language: python
       :start-after: # start-cell-3
       :end-before: # end-cell-3
@@ -180,10 +180,10 @@ JSON representation of a ``BasisSet`` has the following structure (showing simpl
          "shells": ["..."]
        }
      ],
-     "atomic_orbital_type": "spherical",
+     "basis_type": "spherical",
      "name": "6-31G",
      "num_atoms": 2,
-     "num_atomic_orbitals": 9,
+     "num_basis_functions": 9,
      "num_shells": 3
    }
 
@@ -216,7 +216,7 @@ HDF5 representation of a ``BasisSet`` has the following structure (showing group
    .. note::
       This example shows the API pattern. For complete working examples, see the test suite.
 
-   .. literalinclude:: ../../../../examples/python/basis_set.py
+   .. literalinclude:: ../../../examples/python/basis_set.py
       :language: python
       :start-after: # start-cell-4
       :end-before: # end-cell-4
@@ -238,7 +238,7 @@ The ``BasisSet`` class provides several static utility functions:
    .. note::
       This example shows the API pattern. For complete working examples, see the test suite.
 
-   .. literalinclude:: ../../../../examples/python/basis_set.py
+   .. literalinclude:: ../../../examples/python/basis_set.py
       :language: python
       :start-after: # start-cell-5
       :end-before: # end-cell-5
@@ -247,7 +247,7 @@ Predefined basis sets
 ---------------------
 
 QDK/Chemistry provides access to a library of standard basis sets commonly used in quantum chemistry calculations.
-These predefined basis sets can be easily loaded without having to manually specify the atomic orbitals.
+These predefined basis sets can be easily loaded without having to manually specify the basis functions.
 For a complete list of available basis sets and their specifications, see the :doc:`Supported Basis Sets <../data/basis_sets>` documentation.
 
 .. tab:: C++ API
@@ -262,7 +262,7 @@ For a complete list of available basis sets and their specifications, see the :d
    .. note::
       This example shows the API pattern. For complete working examples, see the test suite.
 
-   .. literalinclude:: ../../../../examples/python/basis_set.py
+   .. literalinclude:: ../../../examples/python/basis_set.py
       :language: python
       :start-after: # start-cell-6
       :end-before: # end-cell-6

--- a/docs/source/user/comprehensive/data/hamiltonian.rst
+++ b/docs/source/user/comprehensive/data/hamiltonian.rst
@@ -51,10 +51,13 @@ Hamiltonian object should be considered constant and not modified:
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/hamiltonian.py
+   .. note::
+      This example shows the API pattern. For complete working examples, see the test suite.
+
+   .. literalinclude:: ../../../examples/python/hamiltonian.py
       :language: python
-      :start-after: # start-cell-2
-      :end-before: # end-cell-2
+      :start-after: # start-cell-1
+      :end-before: # end-cell-1
 
 Accessing Hamiltonian data
 --------------------------
@@ -101,7 +104,10 @@ When accessing specific elements with ``get_two_body_element(i, j, k, l)``, the 
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/hamiltonian.py
+   .. note::
+      This example shows the API pattern. For complete working examples, see the test suite.
+
+   .. literalinclude:: ../../../examples/python/hamiltonian.py
       :language: python
       :start-after: # start-cell-2
       :end-before: # end-cell-2
@@ -186,10 +192,20 @@ HDF5 representation of a ``Hamiltonian`` object has the following structure (sho
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/hamiltonian.py
+   .. note::
+      This example shows the API pattern.
+      For complete working examples, see the test suite.
+
+   .. literalinclude:: ../../../examples/python/hamiltonian.py
       :language: python
       :start-after: # start-cell-3
       :end-before: # end-cell-3
+
+      # Convert to/from JSON in Python
+      import json
+      j = hamiltonian.to_json()
+      j_str = json.dumps(j)
+      hamiltonian_from_json = Hamiltonian.from_json(json.loads(j_str))
 
 Active space Hamiltonian
 ------------------------
@@ -212,7 +228,10 @@ The ``Hamiltonian`` class provides methods to check the validity and consistency
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/hamiltonian.py
+   .. note::
+      This example shows the API pattern. For complete working examples, see the test suite.
+
+   .. literalinclude:: ../../../examples/python/hamiltonian.py
       :language: python
       :start-after: # start-cell-4
       :end-before: # end-cell-4

--- a/docs/source/user/comprehensive/data/orbitals.rst
+++ b/docs/source/user/comprehensive/data/orbitals.rst
@@ -63,7 +63,7 @@ However, for advanced use cases, you can create and populate orbitals directly:
    .. note::
       This example shows the API pattern. For complete working examples, see the test suite.
 
-   .. literalinclude:: ../../../../examples/python/orbitals.py
+   .. literalinclude:: ../../../examples/python/orbitals.py
       :language: python
       :start-after: # start-cell-1
       :end-before: # end-cell-1
@@ -87,7 +87,7 @@ For spin-dependent properties, methods return pairs of (alpha, beta) data.
    .. note::
       This example shows the API pattern. For complete working examples, see the test suite.
 
-   .. literalinclude:: ../../../../examples/python/orbitals.py
+   .. literalinclude:: ../../../examples/python/orbitals.py
       :language: python
       :start-after: # start-cell-2
       :end-before: # end-cell-2
@@ -182,7 +182,7 @@ HDF5 representation of an ``Orbitals`` object has the following structure (showi
    .. note::
       This example shows the API pattern. For complete working examples, see the test suite.
 
-   .. literalinclude:: ../../../../examples/python/orbitals.py
+   .. literalinclude:: ../../../examples/python/orbitals.py
       :language: python
       :start-after: # start-cell-3
       :end-before: # end-cell-3

--- a/docs/source/user/comprehensive/data/serialization.rst
+++ b/docs/source/user/comprehensive/data/serialization.rst
@@ -46,7 +46,7 @@ JSON serialization
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/serialization.py
+   .. literalinclude:: ../../../examples/python/serialization.py
       :language: python
       :start-after: # start-cell-1
       :end-before: # end-cell-1
@@ -63,7 +63,7 @@ HDF5 serialization
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/serialization.py
+   .. literalinclude:: ../../../examples/python/serialization.py
       :language: python
       :start-after: # start-cell-2
       :end-before: # end-cell-2

--- a/docs/source/user/comprehensive/data/structure.rst
+++ b/docs/source/user/comprehensive/data/structure.rst
@@ -1,13 +1,13 @@
 Structure
 =========
 
-The :class:`~qdk_chemistry.data.Structure` class in QDK/Chemistry represents a molecular structure, storing information about atomic positions, elements, and related properties for chemical systems of interest.
+The ``Structure`` class in QDK/Chemistry represents a molecular structure, storing information about atomic positions, elements, and related properties for chemical systems of interest.
 As a core :doc:`data class <../advanced/design_principles>`, it follows QDK/Chemistry's immutable data pattern.
 
 Overview
 --------
 
-The :class:`~qdk_chemistry.data.Structure` class is a fundamental data container in QDK/Chemistry that represents the geometric arrangement of atoms in a molecular system.
+The ``Structure`` class is a fundamental data container in QDK/Chemistry that represents the geometric arrangement of atoms in a molecular system.
 It provides the foundation for all quantum chemistry calculations by defining the nuclear framework on which electronic structure calculations are performed.
 
 Properties
@@ -23,7 +23,7 @@ Properties
 Usage
 -----
 
-The :class:`~qdk_chemistry.data.Structure` class is typically the starting point for any calculation workflow in QDK/Chemistry.
+The ``Structure`` class is typically the starting point for any calculation workflow in QDK/Chemistry.
 It is used to define the molecular system before performing electronic structure calculations.
 
 .. note::
@@ -32,7 +32,7 @@ It is used to define the molecular system before performing electronic structure
 Creating a structure object manually
 ------------------------------------
 
-A :class:`~qdk_chemistry.data.Structure` object can be created manually by adding atoms one by one:
+A ``Structure`` object can be created manually by adding atoms one by one:
 
 .. tab:: C++ API
 
@@ -43,7 +43,7 @@ A :class:`~qdk_chemistry.data.Structure` object can be created manually by addin
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/structure.py
+   .. literalinclude:: ../../../examples/python/structure.py
       :language: python
       :start-after: # start-cell-1
       :end-before: # end-cell-1
@@ -51,7 +51,7 @@ A :class:`~qdk_chemistry.data.Structure` object can be created manually by addin
 Loading from files
 ------------------
 
-The :class:`~qdk_chemistry.data.Structure` class can load molecular structures from various file formats.
+The ``Structure`` class can load molecular structures from various file formats.
 For detailed format specifications, see the `File Formats`_ section below.
 
 .. note::
@@ -70,7 +70,7 @@ For detailed format specifications, see the `File Formats`_ section below.
    .. note::
       These examples show the API pattern. For complete working examples, see the test suite.
 
-   .. literalinclude:: ../../../../examples/python/structure.py
+   .. literalinclude:: ../../../examples/python/structure.py
       :language: python
       :start-after: # start-cell-2
       :end-before: # end-cell-2
@@ -78,7 +78,7 @@ For detailed format specifications, see the `File Formats`_ section below.
 Accessing structure data
 ------------------------
 
-The :class:`~qdk_chemistry.data.Structure` class provides methods to access atomic data:
+The ``Structure`` class provides methods to access atomic data:
 
 .. note::
    Functions that deal with specific atoms include the word "atom" in their name (e.g., ``get_atom_coordinates``), while functions that return properties for all atoms omit this word (e.g., ``get_coordinates``).
@@ -94,7 +94,7 @@ The :class:`~qdk_chemistry.data.Structure` class provides methods to access atom
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/structure.py
+   .. literalinclude:: ../../../examples/python/structure.py
       :language: python
       :start-after: # start-cell-3
       :end-before: # end-cell-3
@@ -102,7 +102,7 @@ The :class:`~qdk_chemistry.data.Structure` class provides methods to access atom
 Serialization
 -------------
 
-The :class:`~qdk_chemistry.data.Structure` class supports serialization to and from various formats.
+The ``Structure`` class supports serialization to and from various formats.
 For detailed information about serialization in QDK/Chemistry, see the :doc:`Serialization <../advanced/serialization>` documentation.
 
 .. note::
@@ -117,7 +117,7 @@ QDK/Chemistry supports multiple serialization formats for molecular structures:
 JSON format
 ^^^^^^^^^^^
 
-JSON representation of a :class:`~qdk_chemistry.data.Structure` looks like:
+JSON representation of a ``Structure`` looks like:
 
 .. code-block:: json
 
@@ -135,7 +135,7 @@ JSON representation of a :class:`~qdk_chemistry.data.Structure` looks like:
 XYZ format
 ^^^^^^^^^^
 
-`XYZ representation <https://en.wikipedia.org/wiki/XYZ_file_format>`_ of the same :class:`~qdk_chemistry.data.Structure`:
+`XYZ representation <https://en.wikipedia.org/wiki/XYZ_file_format>`_ of the same ``Structure``:
 
 .. note::
    QDK/Chemistry uses the comment field (second line) of the XYZ format to store the charge and spin multiplicity information, as this data is not part of the standard XYZ specification.
@@ -156,7 +156,7 @@ XYZ format
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/serialization.py
+   .. literalinclude:: ../../../examples/python/serialization.py
       :language: python
       :start-after: # start-cell-1
       :end-before: # end-cell-1
@@ -164,7 +164,7 @@ XYZ format
 Molecular manipulation
 ----------------------
 
-The :class:`~qdk_chemistry.data.Structure` class provides methods for basic molecular manipulations:
+The ``Structure`` class provides methods for basic molecular manipulations:
 
 .. tab:: C++ API
 
@@ -178,7 +178,7 @@ The :class:`~qdk_chemistry.data.Structure` class provides methods for basic mole
    .. note::
       This example shows the API pattern. For complete working examples, see the test suite.
 
-   .. literalinclude:: ../../../../examples/python/structure.py
+   .. literalinclude:: ../../../examples/python/structure.py
       :language: python
       :start-after: # start-cell-5
       :end-before: # end-cell-5
@@ -186,7 +186,7 @@ The :class:`~qdk_chemistry.data.Structure` class provides methods for basic mole
 Units
 -----
 
-All internal coordinates in the :class:`~qdk_chemistry.data.Structure` class are in Bohr by default.
+All internal coordinates in the ``Structure`` class are in Bohr by default.
 This applies to all methods that return or accept coordinates.
 
 .. TODO:  restore the code snippets with working examples.

--- a/docs/source/user/comprehensive/design/index.rst
+++ b/docs/source/user/comprehensive/design/index.rst
@@ -71,7 +71,7 @@ QDK/Chemistry implements the :doc:`factory pattern <factory_pattern>` for algori
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/design_principles.py
+   .. literalinclude:: ../../../examples/python/factory_pattern.py
       :language: python
       :start-after: # start-cell-1
       :end-before: # end-cell-1
@@ -97,10 +97,10 @@ Algorithm configuration is managed through a consistent :doc:`Settings <settings
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/design_principles.py
+   .. literalinclude:: ../../../examples/python/settings.py
       :language: python
-      :start-after: # start-cell-2
-      :end-before: # end-cell-2
+      :start-after: # start-cell-1
+      :end-before: # end-cell-1
 
 This approach provides:
 
@@ -124,7 +124,7 @@ A typical workflow in QDK/Chemistry demonstrates the data-algorithm separation:
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/design_principles.py
+   .. literalinclude:: ../../../examples/python/design_principles.py
       :language: python
       :start-after: # start-cell-3
       :end-before: # end-cell-3

--- a/docs/source/user/comprehensive/design/interfaces.rst
+++ b/docs/source/user/comprehensive/design/interfaces.rst
@@ -54,7 +54,7 @@ This pattern is implemented across all major algorithm types in QDK/Chemistry.
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/interfaces.py
+   .. literalinclude:: ../../../examples/python/interfaces.py
       :language: python
       :start-after: # start-cell-1
       :end-before: # end-cell-1
@@ -73,7 +73,7 @@ You can discover what implementations are available for each algorithm type:
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/interfaces.py
+   .. literalinclude:: ../../../examples/python/interfaces.py
       :language: python
       :start-after: # start-cell-2
       :end-before: # end-cell-2
@@ -147,11 +147,11 @@ This approach leverages the flexibility of QDK/Chemistry's :doc:`settings system
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/interfaces.py
-      :language: python
-      :start-after: # start-cell-4
-      :end-before: # end-cell-4
+   .. code-block:: python
 
+      # Set general options that work across all backends
+      scf.settings().set("basis_set", "cc-pvdz")
+      scf.settings().set("max_iterations", 100)
 
 Each interface implementation typically documents its specific settings, including both the common settings that are
 translated to the backend and the backend-specific settings that are passed through directly.
@@ -165,11 +165,11 @@ This capability is built on QDK/Chemistry's robust :doc:`serialization <serializ
 
 The data types that are automatically converted include:
 
-- **Molecular structures**: Atoms, coordinates, charges, and multiplicity
-- **Basis sets**: Basis set specifications, primitive and contracted functions
-- **Orbitals and wavefunctions**: Coefficients, occupations, and energies
-- **Hamiltonians**: One and two-electron integrals, core Hamiltonians
-- **Calculation results**: Energies, gradients, properties
+- **:doc:`Molecular structures <../data/structure>`**: Atoms, coordinates, charges, and multiplicity
+- **:doc:`Basis sets <../data/basis_set>`**: Basis set specifications, primitive and contracted functions
+- **:doc:`Orbitals and wavefunctions <../data/orbitals>`**: Coefficients, occupations, and energies
+- **:doc:`Hamiltonians <../data/hamiltonian>`**: One and two-electron integrals, core Hamiltonians
+- **:doc:`Calculation results <../data/wavefunction>`**: Energies, gradients, properties
 
 The conversion process is optimized to minimize data copying when possible, especially for large data structures like
 electron repulsion integrals (ERIs).

--- a/docs/source/user/comprehensive/design/settings.rst
+++ b/docs/source/user/comprehensive/design/settings.rst
@@ -42,7 +42,7 @@ Most algorithms validate their settings only at execution time, so you can adjus
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/settings.py
+   .. literalinclude:: ../../../examples/python/settings.py
       :language: python
       :start-after: # start-cell-1
       :end-before: # end-cell-1
@@ -70,7 +70,7 @@ The ``set`` method is overloaded to handle various types including C-style strin
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/settings.py
+   .. literalinclude:: ../../../examples/python/settings.py
       :language: python
       :start-after: # start-cell-2
       :end-before: # end-cell-2
@@ -91,7 +91,7 @@ For cases where you want to provide a fallback value if the key doesn't exist, u
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/settings.py
+   .. literalinclude:: ../../../examples/python/settings.py
       :language: python
       :start-after: # start-cell-3
       :end-before: # end-cell-3
@@ -112,7 +112,7 @@ Additionally, the ``try_get`` method returns an ``std::optional`` that contains 
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/settings.py
+   .. literalinclude:: ../../../examples/python/settings.py
       :language: python
       :start-after: # start-cell-4
       :end-before: # end-cell-4
@@ -133,7 +133,7 @@ present), manipulation (merging with other settings objects), and more.
 
 .. tab:: Python API
 
-   .. Literalinclude:: ../../../../examples/python/settings.py
+   .. Literalinclude:: ../../../examples/python/settings.py
       :language: python
       :start-after: # start-cell-5
       :end-before: # end-cell-5
@@ -157,7 +157,7 @@ For more information on serialization throughout QDK/Chemistry, see the :doc:`Se
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/settings.py
+   .. literalinclude:: ../../../examples/python/settings.py
       :language: python
       :start-after: # start-cell-6
       :end-before: # end-cell-6
@@ -214,7 +214,7 @@ Here's how to extend the ``Settings`` class for a custom algorithm:
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/settings.py
+   .. literalinclude:: ../../../examples/python/settings.py
       :language: python
       :start-after: # start-cell-7
       :end-before: # end-cell-7
@@ -266,7 +266,7 @@ These exceptions can be caught and handled to provide graceful error recovery:
 
 .. tab:: Python API
 
-   .. literalinclude:: ../../../../examples/python/settings.py
+   .. literalinclude:: ../../../examples/python/settings.py
       :language: python
       :start-after: # start-cell-8
       :end-before: # end-cell-8


### PR DESCRIPTION
This pull request adds infrastructure to compile and validate C++ code examples used in the documentation for the QDK Chemistry library. It introduces an optional build target for documentation examples, ensuring that code snippets in the documentation are kept up-to-date and error-free. The main changes include updates to the build system and the addition of example files demonstrating usage of core library features. 

The result is to treat the C++ code snippets in a comparable way to the Python snippets, drawing the snippets from complete, syntactically correct files.

**Build system enhancements:**

* Added the `QDK_BUILD_DOC_EXAMPLES` option to `cpp/CMakeLists.txt` to enable or disable building documentation examples for validation.
* Included logic in `cpp/CMakeLists.txt` to conditionally add the documentation examples subdirectory and output a status message when enabled.
* Created `docs/examples/cpp/CMakeLists.txt` to automatically compile all `.cpp` example files as object libraries, ensuring they compile but are not linked as executables. This validates the correctness of documentation code snippets.

**Documentation example additions:**

* Added multiple new C++ example files (`basis_set.cpp`, `design_principles.cpp`, `factory_pattern.cpp`, `hamiltonian.cpp`, `hamiltonian_constructor.cpp`, `interfaces.cpp`, `localizer.cpp`, `mc_calculator.cpp`) in `docs/examples/cpp/`, each having been extracted from the RST files. 
* Added text-based markers, in the same way as had been done for the Python snippets previously. 
