### PR TITLE
Example RDKit Conversion.

### DIFF
--- a/examples/sample_rdkit_geometry.py
+++ b/examples/sample_rdkit_geometry.py
@@ -35,7 +35,9 @@ def create_structure_from_rdkit(molecule: Mol) -> Structure:
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse CLI options in the same order as the workflow steps."""
-    parser = argparse.ArgumentParser(description="Build QDK Chemistry structure from RDKit SMILES and run SCF")
+    parser = argparse.ArgumentParser(
+        description="Build QDK Chemistry structure from RDKit SMILES and run SCF"
+    )
 
     parser.add_argument(
         "--basis",


### PR DESCRIPTION
Added a test in pythin/tests/test_rdkit_structure.py which uses an example to show how to build a qdk structure from SMILES (and potentially other ways to generate structure from RDKit). 