### PR TITLE
Missing structure serialization to hdf5 in python

### DIFF
--- a/python/src/pybind11/data/structure.cpp
+++ b/python/src/pybind11/data/structure.cpp
@@ -54,6 +54,17 @@ std::shared_ptr<Structure> structure_from_file_wrapper(
       qdk::chemistry::python::utils::to_string_path(filename), format_type);
 }
 
+void structure_to_hdf5_file_wrapper(Structure &self,
+                                    const py::object &filename) {
+  self.to_hdf5_file(qdk::chemistry::python::utils::to_string_path(filename));
+}
+
+std::shared_ptr<Structure> structure_from_hdf5_file_wrapper(
+    const py::object &filename) {
+  return Structure::from_hdf5_file(
+      qdk::chemistry::python::utils::to_string_path(filename));
+}
+
 }  // namespace
 
 void bind_structure(py::module &m) {
@@ -771,6 +782,49 @@ Examples:
     >>> water = Structure.from_file(Path("water.structure.json"), "json")
 )",
                        py::arg("filename"), py::arg("format_type"));
+
+  structure.def("to_hdf5_file", structure_to_hdf5_file_wrapper,
+                R"(
+Save structure to HDF5 file.
+
+Args:
+    filename (str | pathlib.Path): Path to output file.
+        Must have '.structure' before the file extension (e.g., "water.structure.h5", "molecule.structure.hdf5")
+
+Raises:
+    ValueError: If filename doesn't follow the required naming convention
+    RuntimeError: If the file cannot be opened or written
+
+Examples:
+    >>> structure.to_hdf5_file("water.structure.h5")
+    >>> structure.to_hdf5_file("molecule.structure.hdf5")
+    >>> from pathlib import Path
+    >>> structure.to_hdf5_file(Path("water.structure.h5"))
+)",
+                py::arg("filename"));
+
+  structure.def_static("from_hdf5_file", structure_from_hdf5_file_wrapper,
+                       R"(
+Load structure from HDF5 file (static method).
+
+Args:
+    filename (str | pathlib.Path): Path to input file.
+        Must have '.structure' before the file extension (e.g., "water.structure.h5", "molecule.structure.hdf5")
+
+Returns:
+    Structure: New Structure object loaded from the file
+
+Raises:
+    ValueError: If filename doesn't follow the required naming convention
+    RuntimeError: If the file cannot be opened, read, or contains invalid structure data
+
+Examples:
+    >>> water = Structure.from_hdf5_file("water.structure.h5")
+    >>> molecule = Structure.from_hdf5_file("molecule.structure.hdf5")
+    >>> from pathlib import Path
+    >>> water = Structure.from_hdf5_file(Path("water.structure.h5"))
+)",
+                       py::arg("filename"));
 
   // Utility functions
   bind_getter_as_property(structure, "get_summary", &Structure::get_summary,

--- a/python/tests/test_structure.py
+++ b/python/tests/test_structure.py
@@ -554,6 +554,61 @@ class TestStructureFileIO:
         finally:
             Path(filename).unlink()
 
+    def test_hdf5_file_io(self):
+        """Test HDF5 file I/O round-trip."""
+        coords = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4]])
+        symbols = ["H", "H"]
+        custom_masses = np.array([1.001, 0.999])
+        custom_charges = np.array([0.9, 1.1])
+        s1 = Structure(coords, symbols, custom_masses, custom_charges)
+
+        with tempfile.NamedTemporaryFile(suffix=".structure.h5", delete=False) as f:
+            filename = f.name
+
+        try:
+            # Save to HDF5
+            s1.to_hdf5_file(filename)
+            assert Path(filename).exists()
+
+            # Load from HDF5
+            s2 = Structure.from_hdf5_file(filename)
+
+            # Verify structure properties
+            assert s2.get_num_atoms() == s1.get_num_atoms()
+            assert s2.get_atom_symbol(0) == s1.get_atom_symbol(0)
+            assert s2.get_atom_symbol(1) == s1.get_atom_symbol(1)
+
+            # Verify coordinates
+            assert np.allclose(
+                s2.get_atom_coordinates(0),
+                s1.get_atom_coordinates(0),
+                rtol=float_comparison_relative_tolerance,
+                atol=float_comparison_absolute_tolerance,
+            )
+            assert np.allclose(
+                s2.get_atom_coordinates(1),
+                s1.get_atom_coordinates(1),
+                rtol=float_comparison_relative_tolerance,
+                atol=float_comparison_absolute_tolerance,
+            )
+
+            # Verify custom masses and charges are preserved
+            assert np.allclose(
+                s2.get_masses(),
+                custom_masses,
+                rtol=float_comparison_relative_tolerance,
+                atol=float_comparison_absolute_tolerance,
+            )
+            assert np.allclose(
+                s2.get_nuclear_charges(),
+                custom_charges,
+                rtol=float_comparison_relative_tolerance,
+                atol=float_comparison_absolute_tolerance,
+            )
+        finally:
+            if Path(filename).exists():
+                Path(filename).unlink()
+
     def test_to_file_from_file_errors(self):
         """Test error handling for generic file methods."""
         coords = np.array([[0.0, 0.0, 0.0]])


### PR DESCRIPTION
Structure to hdf5 is available in c++ but not in python. 
I added the pybind binding, and a round-trip test.