### PR TITLE
Expose configurable eri_method for SCF solver

### DIFF
--- a/cpp/src/qdk/chemistry/algorithms/microsoft/scf.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/scf.cpp
@@ -114,11 +114,8 @@ std::pair<double, std::shared_ptr<data::Wavefunction>> ScfSolver::_run_impl(
   std::string eri_method = _settings->get<std::string>("eri_method");
   if (eri_method == "direct") {
     ms_scf_config->eri.method = qcs::ERIMethod::Libint2Direct;
-  } else if (eri_method == "incore") {
+  } else {  // Must be "incore" due to ListConstraint validation
     ms_scf_config->eri.method = qcs::ERIMethod::Incore;
-  } else {
-    throw std::invalid_argument("Unknown eri_method: " + eri_method +
-                                ". Valid options: direct, incore");
   }
 
   double eri_threshold = _settings->get<double>("eri_threshold");

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/scf.hpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/scf.hpp
@@ -55,7 +55,12 @@ class ScfSettings
     set_default("fock_reset_steps", 1073741824);
     set_default("eri_use_atomics", false);
     set_default("eri_threshold", -1.0);
-    set_default("eri_method", std::string("direct"));
+    set_default(
+        "eri_method", std::string("direct"),
+        "ERI evaluation method: 'direct' computes integrals on-the-fly, "
+        "'incore' stores all integrals in memory",
+        data::ListConstraint<std::string>{
+            {std::vector<std::string>{"direct", "incore"}}});
   }
 };
 

--- a/cpp/tests/test_scf.cpp
+++ b/cpp/tests/test_scf.cpp
@@ -457,12 +457,11 @@ TEST_F(ScfTest, EriMethodSetting) {
   // Both methods should give the same energy
   EXPECT_NEAR(energy_direct, energy_incore, testing::scf_energy_tolerance);
 
-  // Test invalid eri_method - should throw during solve
+  // Test invalid eri_method - should throw when setting invalid value
   EXPECT_THROW(
       {
         auto scf_solver = ScfSolverFactory::create();
         scf_solver->settings().set("eri_method", "not_a_method");
-        scf_solver->run(water, 0, 1);
       },
       std::invalid_argument);
 }


### PR DESCRIPTION
Allow selecting between direct and incore ERI evaluation via the eri_method setting and add tests to verify default, incore, and invalid values.

Fixes #152 