### PR TITLE
Implementation of first-party stability checker

### DIFF
--- a/python/tests/test_stability.py
+++ b/python/tests/test_stability.py
@@ -511,10 +511,8 @@ class TestStabilityChecker:
         smallest = (
             result.get_smallest_internal_eigenvalue() if is_internal else result.get_smallest_external_eigenvalue()
         )
-        expected_value = ref_value
-
         alg_tol = stability_checker.settings().get("davidson_tolerance")
-        assert abs(smallest - expected_value) < alg_tol, f"Eigenvalue mismatch: {smallest} vs {expected_value}"
+        assert abs(smallest - ref_value) < alg_tol, f"Eigenvalue mismatch: {smallest} vs {ref_value}"
 
     def test_stability_no_analysis_requested(self):
         """Test stability checker when no analysis is requested."""


### PR DESCRIPTION
This pull request introduces a first-party (QDK) implementation of the stability checker for quantum chemistry calculations, making it the new default algorithm. It adds the implementation, updates the factory and tests, and ensures correct file cleanup in tests. The changes also clarify documentation and indexing conventions for stability results.

**QDK Stability Checker Implementation:**

* Added a new internal stability checker implementation (`StabilityChecker`) and its settings (`StabilityCheckerSettings`) in `cpp/src/qdk/chemistry/algorithms/microsoft/stability.hpp`. This provides a first-party alternative to the previous default and supports both internal and external stability analysis.
* Registered the QDK stability checker as the default in the factory, replacing the previous "pyscf" default with "qdk", and implemented the factory registration in `cpp/src/qdk/chemistry/algorithms/stability.cpp`. [[1]](diffhunk://#diff-79c2e56ef3d5c69e9b756816667778cf497f1f02d8b2d3017a45a3abb3f003c7L130-R131) [[2]](diffhunk://#diff-1c4dd374a7057b135d94649c9976aafe4bccedf4b0b19d6e05688f7f9a797671R1-R21)

**Build System Updates:**

* Added the new stability checker source files to the build system in both the main and Microsoft-specific CMake files (`cpp/src/qdk/chemistry/algorithms/CMakeLists.txt`, `cpp/src/qdk/chemistry/algorithms/microsoft/CMakeLists.txt`). [[1]](diffhunk://#diff-4baa02d165e74962ef141e64ec9cd8e57e76051217b6721626617370917bee1aR9) [[2]](diffhunk://#diff-7579c93600122eb8d97ab1f2e9e30be07f5b9ef24e7ca055ef4ae4c68ea23b34R18)

**Testing Enhancements:**

* Expanded the stability checker tests in `cpp/tests/test_stability.cpp` to cover the QDK implementation, including tests for RHF water, UHF O₂, stretched N₂, and BN⁺ cation, with both internal and external stability checks.
* Updated the factory test to expect the new "qdk" checker as the default available implementation.
* Improved test hygiene by cleaning up temporary files after JSON and HDF5 IO tests. [[1]](diffhunk://#diff-cf8a2a6121de25acdfdf335d2d734859068125d2ac8b835683469d9f6a2d4caaR358-R360) [[2]](diffhunk://#diff-cf8a2a6121de25acdfdf335d2d734859068125d2ac8b835683469d9f6a2d4caaR396-R398) [[3]](diffhunk://#diff-cf8a2a6121de25acdfdf335d2d734859068125d2ac8b835683469d9f6a2d4caaR432-R435) [[4]](diffhunk://#diff-cf8a2a6121de25acdfdf335d2d734859068125d2ac8b835683469d9f6a2d4caaR477-R479)

**Documentation and Convention Clarifications:**

* Updated the documentation for the indexing convention in `StabilityResult` to clarify the ordering of occupied and virtual orbitals, aligning with row-major conventions.

**Test Infrastructure:**

* Added necessary includes for SCF solver usage in the stability checker tests.