### PR TITLE
Harden pre-commit for license header checks

### DIFF
--- a/.github/scripts/check_license_headers.py
+++ b/.github/scripts/check_license_headers.py
@@ -20,8 +20,8 @@ from typing import List, Optional, Tuple
 CPP_LICENSE_PATTERNS = [
     # Full MIT license header - standard C-style comment with line breaks
     re.compile(
-        r"^/\*\s*\n"
-        r"\s*\*\s*Copyright\s*\(c\)\s*Microsoft\s+Corporation\.\s+All\s+rights\s+reserved\.\s*\n"
+        r"\A/\*\s*\n"
+        r"\s*\*\s*Copyright \(c\) Microsoft\s+Corporation\.\s+All\s+rights\s+reserved\.\s*\n"
         r"\s*\*\s*Licensed\s+under\s+the\s+MIT\s+License\.\s+See\s+LICENSE\.txt\s+in\s+the\s+project\s+root\s+for\s*\n"
         r"\s*\*\s*license\s+information\.\s*\n"
         r"\s*\*/",
@@ -29,8 +29,8 @@ CPP_LICENSE_PATTERNS = [
     ),
     # Full MIT license header - Doxygen block style (/**) with line breaks
     re.compile(
-        r"^/\*\*\s*\n"
-        r"\s*\*\s*Copyright\s*\(c\)\s*Microsoft\s+Corporation\.\s+All\s+rights\s+reserved\.\s*\n"
+        r"\A/\*\*\s*\n"
+        r"\s*\*\s*Copyright \(c\) Microsoft\s+Corporation\.\s+All\s+rights\s+reserved\.\s*\n"
         r"\s*\*\s*Licensed\s+under\s+the\s+MIT\s+License\.\s+See\s+LICENSE\.txt\s+in\s+the\s+project\s+root\s+for\s*\n"
         r"\s*\*\s*license\s+information\.\s*\n"
         r"\s*\*/",
@@ -38,14 +38,14 @@ CPP_LICENSE_PATTERNS = [
     ),
     # Full MIT license header - Doxygen line style (///) with line breaks
     re.compile(
-        r"^///\s*Copyright\s*\(c\)\s*Microsoft\s+Corporation\.\s+All\s+rights\s+reserved\.\s*\n"
+        r"\A///\s*Copyright \(c\) Microsoft\s+Corporation\.\s+All\s+rights\s+reserved\.\s*\n"
         r"///\s*Licensed\s+under\s+the\s+MIT\s+License\.\s+See\s+LICENSE\.txt\s+in\s+the\s+project\s+root\s+for\s*\n"
         r"///\s*license\s+information\.",
         re.MULTILINE,
     ),
     # Full MIT license header - C++ line comment style (//) with line breaks
     re.compile(
-        r"^//\s*Copyright\s*\(c\)\s*Microsoft\s+Corporation\.\s+All\s+rights\s+reserved\.\s*\n"
+        r"\A//\s*Copyright \(c\) Microsoft\s+Corporation\.\s+All\s+rights\s+reserved\.\s*\n"
         r"//\s*Licensed\s+under\s+the\s+MIT\s+License\.\s+See\s+LICENSE\.txt\s+in\s+the\s+project\s+root\s+for\s*\n"
         r"//\s*license\s+information\.",
         re.MULTILINE,
@@ -55,11 +55,11 @@ CPP_LICENSE_PATTERNS = [
 PYTHON_LICENSE_PATTERNS = [
     # Hash-style comment header directly after module docstring or at top
     re.compile(
-        r"^(?:#!/usr/bin/env python3?\s*\n)?"  # Optional shebang
+        r"\A(?:#!/usr/bin/env python3?\s*\n)?"  # Optional shebang
         r'(?:""".*?"""\s*\n)?'  # Optional module docstring
-        r"\s*"  # Optional whitespace/blank lines
+        r"(?:[ \t]*\n)*"  # Optional blank lines only (no code allowed)
         r"#\s*-+\s*\n"  # Opening dashes
-        r"#\s*Copyright\s*\(c\)\s*Microsoft\s+Corporation\.\s+All\s+rights\s+reserved\.\s*\n"
+        r"#\s*Copyright \(c\) Microsoft\s+Corporation\.\s+All\s+rights\s+reserved\.\s*\n"
         r"#\s*Licensed\s+under\s+the\s+MIT\s+License\.\s+See\s+LICENSE\.txt\s+in\s+the\s+project\s+root\s+for\s+license\s+information\.\s*\n"
         r"#\s*-+",  # Closing dashes
         re.MULTILINE | re.DOTALL,
@@ -102,13 +102,8 @@ def check_file_header(filepath: Path) -> Tuple[bool, str]:
         # Unknown file type, skip
         return True, f"Unknown file type '{suffix}', skipping"
 
-    # Check if any pattern matches
-    # For Python files, check the first 2000 characters (allows for docstrings/imports before __copyright__)
-    # For C/C++ files, check the first 500 characters (header should be at top)
-    if suffix in PYTHON_EXTENSIONS:
-        header_section = content[:50000]
-    else:
-        header_section = content[:50000]
+    # Check if any pattern matches in the beginning of the file
+    header_section = content[:50000]
 
     for pattern in patterns:
         if pattern.search(header_section):

--- a/docs/source/_static/examples/cpp/active_space_selector.cpp
+++ b/docs/source/_static/examples/cpp/active_space_selector.cpp
@@ -1,11 +1,8 @@
-// Active space selection example.
-
-// --------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
-// --------------------------------------------------------------------------------------------
 
+// Active space selection example.
 #include <iostream>
 #include <qdk/chemistry/algorithms/active_space.hpp>
 #include <qdk/chemistry/algorithms/scf_solver.hpp>

--- a/docs/source/_static/examples/cpp/ansatz.cpp
+++ b/docs/source/_static/examples/cpp/ansatz.cpp
@@ -1,11 +1,8 @@
-// Ansatz usage examples.
-
-// --------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
-// --------------------------------------------------------------------------------------------
 
+// Ansatz usage examples.
 // --------------------------------------------------------------------------------------------
 // start-cell-create
 #include <iostream>

--- a/docs/source/_static/examples/cpp/basis_set.cpp
+++ b/docs/source/_static/examples/cpp/basis_set.cpp
@@ -1,11 +1,8 @@
-// Basis Set usage examples.
-
-// --------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
-// --------------------------------------------------------------------------------------------
 
+// Basis Set usage examples.
 // --------------------------------------------------------------------------------------------
 // start-cell-basis-set-create
 // Create an empty basis set with a name

--- a/docs/source/_static/examples/cpp/design_principles.cpp
+++ b/docs/source/_static/examples/cpp/design_principles.cpp
@@ -1,11 +1,8 @@
-// Design Principles usage examples.
-
-// --------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
-// --------------------------------------------------------------------------------------------
 
+// Design Principles usage examples.
 // -----------------------------------------------------------------------------
 // start-cell-scf-create
 #include <qdk/chemistry.hpp>

--- a/docs/source/_static/examples/cpp/dynamical_correlation.cpp
+++ b/docs/source/_static/examples/cpp/dynamical_correlation.cpp
@@ -1,11 +1,8 @@
-// Dynamical correlation examples.
-
-// --------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
-// --------------------------------------------------------------------------------------------
 
+// Dynamical correlation examples.
 // -----------------------------------------------------------------------------
 // start-cell-mp2-example
 #include <qdk/chemistry.hpp>

--- a/docs/source/_static/examples/cpp/factory_pattern.cpp
+++ b/docs/source/_static/examples/cpp/factory_pattern.cpp
@@ -1,11 +1,8 @@
-// Factory Pattern usage examples.
-
-// --------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
-// --------------------------------------------------------------------------------------------
 
+// Factory Pattern usage examples.
 // -----------------------------------------------------------------------------
 // start-cell-scf-localizer
 #include <qdk/chemistry.hpp>

--- a/docs/source/_static/examples/cpp/hamiltonian.cpp
+++ b/docs/source/_static/examples/cpp/hamiltonian.cpp
@@ -1,11 +1,8 @@
-// Hamiltonian usage examples.
-
-// --------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
-// --------------------------------------------------------------------------------------------
 
+// Hamiltonian usage examples.
 // --------------------------------------------------------------------------------------------
 // start-cell-hamiltonian-creation
 // Create a structure object

--- a/docs/source/_static/examples/cpp/hamiltonian_constructor.cpp
+++ b/docs/source/_static/examples/cpp/hamiltonian_constructor.cpp
@@ -1,11 +1,8 @@
-// Hamiltonian Constructor usage examples.
-
-// --------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
-// --------------------------------------------------------------------------------------------
-#include <iomanip>
+
+// Hamiltonian Constructor usage examples.
 #include <iostream>
 #include <qdk/chemistry.hpp>
 using namespace qdk::chemistry::algorithms;

--- a/docs/source/_static/examples/cpp/interfaces.cpp
+++ b/docs/source/_static/examples/cpp/interfaces.cpp
@@ -1,11 +1,8 @@
-// Interfaces usage examples.
-
-// --------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
-// --------------------------------------------------------------------------------------------
 
+// Interfaces usage examples.
 // -----------------------------------------------------------------------------
 // start-cell-scf
 #include <qdk/chemistry.hpp>

--- a/docs/source/_static/examples/cpp/localizer.cpp
+++ b/docs/source/_static/examples/cpp/localizer.cpp
@@ -1,11 +1,8 @@
-// Localizer usage examples.
-
-// --------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
-// --------------------------------------------------------------------------------------------
 
+// Localizer usage examples.
 // --------------------------------------------------------------------------------------------
 // start-cell-create
 #include <iostream>

--- a/docs/source/_static/examples/cpp/mc_calculator.cpp
+++ b/docs/source/_static/examples/cpp/mc_calculator.cpp
@@ -1,11 +1,8 @@
-// Mc Calculator usage examples.
-
-// --------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
-// --------------------------------------------------------------------------------------------
 
+// Mc Calculator usage examples.
 // --------------------------------------------------------------------------------------------
 // start-cell-create
 #include <qdk/chemistry.hpp>

--- a/docs/source/_static/examples/cpp/orbitals.cpp
+++ b/docs/source/_static/examples/cpp/orbitals.cpp
@@ -1,11 +1,8 @@
-// Orbitals usage examples.
-
-// --------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
-// --------------------------------------------------------------------------------------------
 
+// Orbitals usage examples.
 // --------------------------------------------------------------------------------------------
 // start-cell-create
 #include <iostream>

--- a/docs/source/_static/examples/cpp/scf_solver.cpp
+++ b/docs/source/_static/examples/cpp/scf_solver.cpp
@@ -1,11 +1,8 @@
-// Scf Solver usage examples.
-
-// --------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
-// --------------------------------------------------------------------------------------------
 
+// Scf Solver usage examples.
 // --------------------------------------------------------------------------------------------
 // start-cell-create
 #include <iostream>

--- a/docs/source/_static/examples/cpp/serialization.cpp
+++ b/docs/source/_static/examples/cpp/serialization.cpp
@@ -1,11 +1,8 @@
-// Serialization usage examples.
-
-// --------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
-// --------------------------------------------------------------------------------------------
 
+// Serialization usage examples.
 // --------------------------------------------------------------------------------------------
 // start-cell-json
 #include <filesystem>

--- a/docs/source/_static/examples/cpp/settings.cpp
+++ b/docs/source/_static/examples/cpp/settings.cpp
@@ -1,11 +1,8 @@
-// Settings usage examples.
-
-// --------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
-// --------------------------------------------------------------------------------------------
 
+// Settings usage examples.
 // --------------------------------------------------------------------------------------------
 // start-cell-get-settings
 // Get the settings object

--- a/docs/source/_static/examples/cpp/structure.cpp
+++ b/docs/source/_static/examples/cpp/structure.cpp
@@ -1,11 +1,8 @@
-// Structure usage examples.
-
-// --------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
-// --------------------------------------------------------------------------------------------
 
+// Structure usage examples.
 // --------------------------------------------------------------------------------------------
 // start-cell-create
 #include <qdk/chemistry.hpp>

--- a/docs/source/_static/examples/cpp/wavefunction_container.cpp
+++ b/docs/source/_static/examples/cpp/wavefunction_container.cpp
@@ -1,11 +1,8 @@
-// Wavefunction container examples
-
-// --------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
-// --------------------------------------------------------------------------------------------
 
+// Wavefunction container examples
 #include <qdk/chemistry.hpp>
 using namespace qdk::chemistry::data;
 


### PR DESCRIPTION
  Make license header regex stricter and fix non-compliant files
  
  Regex fixes:
  - Use exact spacing around (c): 'Copyright (c) Microsoft' instead of
    allowing arbitrary whitespace with \s*\(c\)\s*
  - Use \A anchor instead of ^ to enforce license header appears at start
    of file, not just at start of any line
  - Change Python pattern to only allow blank lines between docstring and
    license (not arbitrary content)
  - Remove redundant code and fix misleading comments
  
  File fixes:
  - Move license headers to top of 17 example files in docs/source/_static/
    that had description comments before the license
  - Remove decorative dashed lines to match standard format
  
  Fixes: #213 