### PR TITLE
Add upper bound on numpy version

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
   "Topic :: Education",
 ]
 dependencies = [
-  "numpy>=1.20.0",
+  "numpy>=1.20.0,<2.4.0",
   "scipy>=1.7.0",
   "matplotlib==3.10.0",
   "qiskit[qasm3-import]>=2.2.0",


### PR DESCRIPTION
Qiskit's bravyi_kitaev_mapper function is broken by an API change in numpy==2.4.0. This PR adds an upper bound on the numpy version in the pyproject.toml to prevent this error from occurring. 

Closes #239 