### PR TITLE
Fix Sample SCI Workflow

### DIFF
--- a/examples/sample_sci_workflow.py
+++ b/examples/sample_sci_workflow.py
@@ -121,7 +121,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     e_scf, scf_wavefunction = scf_solver.run(
         structure, args.charge, args.spin, args.basis
     )
-    Logger.info(f"SCF Energy: {e_scf:.8f} Hartree")
+    Logger.info(f"SCF energy = {e_scf:.8f} Hartree")
 
     ########################################################################################
     # 3. Select the valence active space (heuristic or user overrides).
@@ -209,7 +209,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         max_determinants=args.max_determinants,
     )
 
-    Logger.info(f"Sparse CI energy values {sparse_ci_energy:.3f} Hartree")
+    Logger.info(f"Sparse CI energy = {sparse_ci_energy:.8f} Hartree")
     Logger.info(get_active_determinants_info(sparse_ci_wavefunction))
 
 

--- a/python/tests/test_sample_workflow_sci.py
+++ b/python/tests/test_sample_workflow_sci.py
@@ -17,7 +17,9 @@ import numpy as np
 import pytest
 
 from .reference_tolerances import (
+    ci_energy_tolerance,
     float_comparison_relative_tolerance,
+    scf_energy_tolerance,
     sci_energy_tolerance,
 )
 from .test_sample_workflow_utils import (
@@ -137,6 +139,11 @@ def test_sample_sci_workflow_scenarios(case: WorkflowCase) -> None:
 
     lines = _collect_output_lines(result)
 
+    sparse_ci_energy = float(_find_line(lambda line: "Sparse CI energy = " in line, lines).split()[-2])
+    assert np.isclose(
+        sparse_ci_energy, case.expected_energy, rtol=float_comparison_relative_tolerance, atol=sci_energy_tolerance
+    )
+
     det_count, energy, _ = _extract_sparse_ci_summary(lines)
     assert np.isclose(energy, case.expected_energy, rtol=float_comparison_relative_tolerance, atol=sci_energy_tolerance)
     if case.expected_det_count is not None:
@@ -155,6 +162,12 @@ def test_sample_sci_workflow_scenarios(case: WorkflowCase) -> None:
 )
 def test_sample_sci_workflow_macis_asci_autocas_with_limits():
     """Run workflow with MACIS ASCI initial solver and capped determinants."""
+    expected_scf_energy = -76.02286895
+    expected_casci_energy = -76.19140008
+    expected_autocas_energy = -76.11649731
+    expected_sparse_ci_energy = -76.10308087
+    expected_active_space_indices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+
     repo_root = Path(__file__).resolve().parents[2]
     cmd = [
         sys.executable,
@@ -185,5 +198,30 @@ def test_sample_sci_workflow_macis_asci_autocas_with_limits():
 
     lines = _collect_output_lines(result)
 
+    scf_energy = float(_find_line(lambda line: "SCF energy = " in line, lines).split()[-2])
+    assert np.isclose(
+        scf_energy, expected_scf_energy, rtol=float_comparison_relative_tolerance, atol=scf_energy_tolerance
+    )
+
+    casci_energy = float(_find_line(lambda line: "CASCI energy = " in line, lines).split()[-2])
+    assert np.isclose(
+        casci_energy, expected_casci_energy, rtol=float_comparison_relative_tolerance, atol=ci_energy_tolerance
+    )
+
+    autocas_energy = float(_find_line(lambda line: "AutoCAS energy = " in line, lines).split()[-2])
+    assert np.isclose(
+        autocas_energy, expected_autocas_energy, rtol=float_comparison_relative_tolerance, atol=ci_energy_tolerance
+    )
+
+    sparse_ci_energy = float(_find_line(lambda line: "Sparse CI energy = " in line, lines).split()[-2])
+    assert np.isclose(
+        sparse_ci_energy, expected_sparse_ci_energy, rtol=float_comparison_relative_tolerance, atol=sci_energy_tolerance
+    )
+
+    _, energy, _ = _extract_sparse_ci_summary(lines)
+    assert np.isclose(
+        energy, expected_sparse_ci_energy, rtol=float_comparison_relative_tolerance, atol=sci_energy_tolerance
+    )
+
     indices_line = _find_line(lambda line: "AutoCAS selected active space with indices:" in line, lines)
-    assert "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]" in indices_line
+    assert str(expected_active_space_indices) in indices_line


### PR DESCRIPTION
Fixes:
- Resolve double counting of nuclear repulsion and core energy in `sample_sci_workflow.py`