### PR TITLE
Docs: restructure `algorithm` classes `toctree` to match `data` classes pattern

### DIFF
--- a/docs/source/user/comprehensive/algorithms/index.rst
+++ b/docs/source/user/comprehensive/algorithms/index.rst
@@ -1,31 +1,6 @@
 Algorithm classes
 =================
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Creation, Configuration and Extension of Algorithm Classes
-
-   factory_pattern
-   settings
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Available Algorithms
-
-   active_space
-   energy_estimator
-   hamiltonian_constructor
-   localizer
-   mc_calculator
-   mcscf
-   pmc
-   qubit_mapper
-   scf_solver
-   stability_checker
-   state_preparation
-
 QDK/Chemistry provides a comprehensive set of algorithm classes which express core methodological primitives for quantum and classical chemistry calculations.
 All algorithms follow a :doc:`factory pattern <factory_pattern>` design, allowing you to create instances by name and configured through a unified :doc:`settings <settings>` interface.
 
@@ -74,6 +49,23 @@ The following table summarizes the available algorithm classes in QDK/Chemistry 
    * - :doc:`StabilityChecker <stability_checker>`
      - :term:`SCF` stability analysis
      - Orbitals → Stability
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents
+
+   factory_pattern
+   settings
+   active_space
+   energy_estimator
+   hamiltonian_constructor
+   localizer
+   mc_calculator
+   mcscf
+   qubit_mapper
+   scf_solver
+   stability_checker
+   state_preparation
 
 Discovering implementations
 ---------------------------


### PR DESCRIPTION
Move `toctree` inside 'Quick reference' section so `algorithm` pages expand under that heading in the sidebar navigation, matching the behavior of the `data` classes documentation.

Fixes #306