### PR TITLE
Improve robustness of Python CI/CD

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   check-up-to-date:
     name: Check if branch is up to date with main
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -32,7 +33,6 @@ jobs:
         submodules: recursive
 
     - name: Check if branch is up to date with main (Pull Request)
-      if: github.event_name == 'pull_request'
       run: |
         # Ensure origin/main is present
         git fetch --no-tags --prune origin +refs/heads/main:refs/remotes/origin/main
@@ -48,24 +48,8 @@ jobs:
 
         echo "Branch is up to date, starting Build and Test workflow."
 
-    - name: Check if branch is up to date with main (Push)
-      if: github.event_name == 'push'
-      run: |
-        # Ensure origin/main is present
-        git fetch --no-tags --prune origin +refs/heads/main:refs/remotes/origin/main
-
-        # Check if the current commit is ahead of main
-        # Kills pipeline if branch is not up to date with main
-        if ! git merge-base --is-ancestor origin/main "${{ github.sha }}"; then
-          echo "This branch is not up to date with main. Please merge the latest changes from main into your branch to continue."
-          exit 1
-        fi
-
-        echo "Branch is up to date, starting Build and Test workflow."
-
   coverage:
     name: ${{ matrix.os-name }} Build, Test, and Coverage Analysis
-    needs: check-up-to-date
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:


### PR DESCRIPTION
Some recent PRs exposed weaknesses in the pipeline when running computationally intensive pytests on x86 nodes. This PR limits the number of OMP threads to 8. It also makes the output of the pytests more transparent by splitting the output of the test suite between the terminal and the output file, this makes sure that any test failures can be analyzed after the fact instead of being lost to the output file. To reduce further downtime, this PR will contain the bugfixes from #304 and #307.

Fixes/changes: 
- No more silent pytest hangs/failures with pytest output sent to the terminal + bound on OMP_NUM_THREADS
- Prevent pushes to main from PRs with CI/CD out of date with main
- Adds qdk::chemistry::algorithms::HamiltonianConstructor to nitpick_ignore_regex in doc build
