### PR TITLE
Style 'AutoCAS' as 'autoCAS' in user-facing text

### DIFF
--- a/cpp/src/qdk/chemistry/algorithms/microsoft/active_space/autocas_active_space.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/active_space/autocas_active_space.cpp
@@ -15,7 +15,7 @@ namespace qdk::chemistry::algorithms::microsoft {
 std::shared_ptr<data::Wavefunction> AutocasActiveSpaceSelector::_run_impl(
     std::shared_ptr<data::Wavefunction> wavefunction) const {
   QDK_LOG_TRACE_ENTERING();
-  QDK_LOGGER().info("AutoCAS::Starting active space selection.");
+  QDK_LOGGER().info("autoCAS::Starting active space selection.");
 
   // get settings
   const int64_t min_plateau_size = _settings->get<int64_t>("min_plateau_size");
@@ -149,7 +149,7 @@ std::shared_ptr<data::Wavefunction> AutocasActiveSpaceSelector::_run_impl(
     if (i > 0) oss << ", ";
     oss << selected_active_space_indices[i];
   }
-  QDK_LOGGER().info("AutoCAS::Selected active space of {} orbitals: {}",
+  QDK_LOGGER().info("autoCAS::Selected active space of {} orbitals: {}",
                     selected_active_space_indices.size(), oss.str());
 
   // create new orbitals with active space

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/active_space/entropy_active_space.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/active_space/entropy_active_space.cpp
@@ -14,7 +14,7 @@ namespace qdk::chemistry::algorithms::microsoft {
 std::shared_ptr<data::Wavefunction> AutocasEosActiveSpaceSelector::_run_impl(
     std::shared_ptr<data::Wavefunction> wavefunction) const {
   QDK_LOG_TRACE_ENTERING();
-  QDK_LOGGER().info("AutoCAS-EOS::Starting active space selection.");
+  QDK_LOGGER().info("autoCAS-EOS::Starting active space selection.");
 
   // get settings
   const double entropy_threshold = _settings->get<double>("entropy_threshold");
@@ -67,7 +67,7 @@ std::shared_ptr<data::Wavefunction> AutocasEosActiveSpaceSelector::_run_impl(
     if (i > 0) oss2 << ", ";
     oss2 << selected_active_space_indices[i];
   }
-  QDK_LOGGER().info("AutoCAS-EOS::Selected active space of {} orbitals: {}",
+  QDK_LOGGER().info("autoCAS-EOS::Selected active space of {} orbitals: {}",
                     selected_active_space_indices.size(), oss2.str());
 
   // create new orbitals with active space

--- a/docs/source/_static/diagrams/plugin_architecture.dot
+++ b/docs/source/_static/diagrams/plugin_architecture.dot
@@ -5,7 +5,7 @@ digraph PluginArchitecture {
     edge [color="#1976D2", penwidth=2];
 
     Interface [label="QDK/Chemistry Interface\n(ScfSolver, Localizer,\nMCCalculator, etc.)", fillcolor="#E3F2FD", color="#42A5F5", penwidth=2, fontcolor="#1976D2"];
-    QDK [label="QDK Implementation\n(AutoCAS, etc.)", fillcolor="#E0F2F1", color="#26A69A", penwidth=2, fontcolor="#00796B"];
+    QDK [label="QDK Implementation\n(autoCAS, etc.)", fillcolor="#E0F2F1", color="#26A69A", penwidth=2, fontcolor="#00796B"];
     ThirdParty [label="Third-Party Interfaces\n(PySCF, etc.)", fillcolor="#F3E5F5", color="#AB47BC", penwidth=2, fontcolor="#7B1FA2"];
 
     Interface -> QDK;

--- a/docs/source/_static/examples/cpp/active_space_selector.cpp
+++ b/docs/source/_static/examples/cpp/active_space_selector.cpp
@@ -82,7 +82,7 @@ int main() {
   auto [mc_energy, mc_wavefunction] = mc_calculator->run(
       active_hamiltonian, num_electrons / 2, num_electrons / 2);
 
-  // Print single orbital entropies which are used by AutoCAS to determine the
+  // Print single orbital entropies which are used by autoCAS to determine the
   // active space
   auto entropies = mc_wavefunction->get_single_orbital_entropies();
   std::cout << "Single orbital entropies:" << std::endl;
@@ -90,10 +90,10 @@ int main() {
     std::cout << "Orbital " << (idx + 1) << ": " << entropies[idx] << std::endl;
   }
 
-  // Select active space using AutoCAS
+  // Select active space using autoCAS
   auto autocas_selector = ActiveSpaceSelectorFactory::create("qdk_autocas_eos");
   auto active_autocas_wfn = autocas_selector->run(mc_wavefunction);
-  std::cout << "AutoCAS selected active orbitals summary:\n"
+  std::cout << "autoCAS selected active orbitals summary:\n"
             << active_autocas_wfn->get_orbitals()->get_summary() << std::endl;
   // end-cell-autocas
   // --------------------------------------------------------------------------------------------

--- a/docs/source/_static/examples/python/active_space_selector.py
+++ b/docs/source/_static/examples/python/active_space_selector.py
@@ -84,16 +84,16 @@ mc_energy, mc_wavefunction = mc_calculator.run(
     active_hamiltonian, num_electrons // 2, num_electrons // 2
 )
 
-# Print single orbital entropies which are used by AutoCAS to determine the active space
+# Print single orbital entropies which are used by autoCAS to determine the active space
 entropies = mc_wavefunction.get_single_orbital_entropies()
 print("Single orbital entropies:")
 for idx, entropy in enumerate(entropies):
     print(f"Orbital {idx + 1}: {entropy:.6f}")
 
-# Select active space using AutoCAS
+# Select active space using autoCAS
 autocas_selector = create("active_space_selector", "qdk_autocas_eos")
 active_autocas_wfn = autocas_selector.run(mc_wavefunction)
-print("AutoCAS selected active orbitals summary:")
+print("autoCAS selected active orbitals summary:")
 print(active_autocas_wfn.get_orbitals().get_summary())
 # end-cell-autocas
 ################################################################################

--- a/docs/source/user/comprehensive/algorithms/active_space.rst
+++ b/docs/source/user/comprehensive/algorithms/active_space.rst
@@ -167,13 +167,13 @@ Automatic selection based on orbital occupation numbers, identifying orbitals wi
 
 .. _autocas-algorithm:
 
-QDK AutoCAS
+QDK autoCAS
 ~~~~~~~~~~~
 
 .. rubric:: Factory name: ``"qdk_autocas"``
 
 Entropy-based automatic selection using histogram-based plateau detection to identify strongly correlated orbitals.
-See :ref:`AutoCAS Algorithm <autocas-algorithm-details>` below for a detailed description.
+See :ref:`autoCAS Algorithm <autocas-algorithm-details>` below for a detailed description.
 
 .. note::
 
@@ -209,13 +209,13 @@ See :ref:`AutoCAS Algorithm <autocas-algorithm-details>` below for a detailed de
      - ``True``
      - Whether to normalize entropy values
 
-QDK AutoCAS EOS
+QDK autoCAS EOS
 ~~~~~~~~~~~~~~~
 
 .. rubric:: Factory name: ``"qdk_autocas_eos"``
 
 Entropy-based selection using consecutive entropy differences to identify plateau boundaries.
-See :ref:`AutoCAS Algorithm <autocas-algorithm-details>` below for a detailed description.
+See :ref:`autoCAS Algorithm <autocas-algorithm-details>` below for a detailed description.
 
 .. note::
 
@@ -247,36 +247,36 @@ See :ref:`AutoCAS Algorithm <autocas-algorithm-details>` below for a detailed de
 
 .. _autocas-algorithm-details:
 
-AutoCAS Algorithm
+autoCAS Algorithm
 ^^^^^^^^^^^^^^^^^
 
 Selecting an appropriate active space is one of the most challenging aspects of multi-configuration calculations.
 Traditional approaches rely on chemical intuition and trial-and-error, which can be unreliable for complex systems.
-The AutoCAS algorithm :cite:`Stein2016,Stein2019` provides a systematic, black-box approach to active space selection.
+The autoCAS algorithm :cite:`Stein2016,Stein2019` provides a systematic, black-box approach to active space selection.
 
-AutoCAS leverages concepts from quantum information theory to quantify orbital correlation.
+autoCAS leverages concepts from quantum information theory to quantify orbital correlation.
 The key insight is that strongly correlated orbitals are highly *entangled* with the rest of the electronic system.
 This entanglement can be measured using the single-orbital entropy :math:`s_i^{(1)}`, which quantifies how much information about orbital :math:`i` is "shared" with all other orbitals.
 
-Single orbital entropies can be calculated for many-body systems given access to (approximate) one- and two-particle reduced density matrices (:term:`RDM`) :cite:`Boguslawski2015`, which are easily accessible in QDK/Chemistry through multi-configuration wavefunction data structures. As such, single orbital entropies are computed by default when RDMs are requested in :doc:`multi-configuration calculations <mc_calculator>`. The QDK/Chemistry implementation of AutoCAS is agnostic to the underlying wavefunction method, as long as the required RDMs are available, thus allowing for comparisons across different multi-configuration approaches.
+Single orbital entropies can be calculated for many-body systems given access to (approximate) one- and two-particle reduced density matrices (:term:`RDM`) :cite:`Boguslawski2015`, which are easily accessible in QDK/Chemistry through multi-configuration wavefunction data structures. As such, single orbital entropies are computed by default when RDMs are requested in :doc:`multi-configuration calculations <mc_calculator>`. The QDK/Chemistry implementation of autoCAS is agnostic to the underlying wavefunction method, as long as the required RDMs are available, thus allowing for comparisons across different multi-configuration approaches.
 
-.. rubric:: QDK/Chemistry AutoCAS Variants
+.. rubric:: QDK/Chemistry autoCAS Variants
 
 QDK/Chemistry provides two entropy-based selection methods:
 
-AutoCAS (Histogram-Based Plateau Detection)
-  As described in the original AutoCAS protocol :cite:`Stein2016,Stein2019`, this method discretizes the entropy distribution into histogram bins and identifies plateaus—contiguous regions where the count of orbitals above each entropy threshold remains constant.
+autoCAS (Histogram-Based Plateau Detection)
+  As described in the original autoCAS protocol :cite:`Stein2016,Stein2019`, this method discretizes the entropy distribution into histogram bins and identifies plateaus—contiguous regions where the count of orbitals above each entropy threshold remains constant.
   This approach is robust for systems with clear entropy gaps but requires tuning of ``num_bins`` and ``min_plateau_size`` parameters.
   If none of the entropies exceed the ``entropy_threshold``, the system is considered single configurational and all orbitals are excluded from the active space.
 
-AutoCAS-EOS (Entropy Difference Detection)
+autoCAS-EOS (Entropy Difference Detection)
   Uses a direct approach that examines consecutive differences in the sorted entropy values. When the difference between adjacent entropies exceeds ``diff_threshold`` and the entropy is above ``entropy_threshold``, a plateau boundary is identified.
 
 Both methods sort orbitals by decreasing entropy and select the largest identified group of strongly correlated orbitals for the active space.
 
 .. rubric:: Populating Orbital Entropies
 
-The entropy-based AutoCAS methods require orbital entropies as input, which are computed from the one- and two-electron reduced density matrices (RDMs).
+The entropy-based autoCAS methods require orbital entropies as input, which are computed from the one- and two-electron reduced density matrices (RDMs).
 These RDMs must be obtained from a :doc:`multi-configuration calculation <mc_calculator>` that captures static correlation.
 A key practical consideration is balancing the cost of this initial calculation against the quality of the resulting entropies.
 

--- a/docs/source/user/comprehensive/algorithms/mc_calculator.rst
+++ b/docs/source/user/comprehensive/algorithms/mc_calculator.rst
@@ -167,7 +167,7 @@ The Adaptive Sampling Configuration Interaction (:term:`ASCI`) algorithm :cite:`
 
 The :term:`ASCI` works by growing the determinant space adaptively: at each iteration, it samples the space of possible determinants and selects those with the largest contributions to the wavefunction. This approach achieves near-:term:`CASCI` accuracy at a fraction of the computational cost, making it possible to treat active spaces that are intractable for conventional :term:`CASCI`.
 
-:term:`ASCI` is especially useful for generating approximate wavefunctions and RDMs for use in automated active space selection protocols (such as AutoCAS), as it provides a good balance between computational cost and accuracy. For best practices, see the :ref:`AutoCAS Algorithm <autocas-algorithm-details>` section in the active space selector documentation.
+:term:`ASCI` is especially useful for generating approximate wavefunctions and RDMs for use in automated active space selection protocols (such as autoCAS), as it provides a good balance between computational cost and accuracy. For best practices, see the :ref:`autoCAS Algorithm <autocas-algorithm-details>` section in the active space selector documentation.
 
 The :term:`ASCI` algorithm proceeds as a two-phase optimization:
 

--- a/docs/source/user/features.rst
+++ b/docs/source/user/features.rst
@@ -78,7 +78,7 @@ The challenge lies in balancing accuracy and computational cost: an ideal active
 
 Entropy-Based Methods
    Using concepts from quantum information theory, these methods identify strongly correlated orbitals based on their entanglement with the rest of the system.
-   QDK/Chemistry includes a native implementation of the AutoCAS algorithm :cite:`Stein2019`, which leverages single-orbital entropies computed from reduced density matrices to systematically select active spaces (see below for details).
+   QDK/Chemistry includes a native implementation of the autoCAS algorithm :cite:`Stein2019`, which leverages single-orbital entropies computed from reduced density matrices to systematically select active spaces (see below for details).
 
 Occupation-based Methods
    Automatic selection based on natural orbital occupation numbers obtained from correlated many-body methods.
@@ -100,11 +100,11 @@ See :doc:`comprehensive/algorithms/active_space` for further details about avail
 Implementation Highlights
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-AutoCAS
-   QDK/Chemistry includes a native implementation of the AutoCAS algorithm :cite:`Stein2019`, which leverages quantum information concepts to identify strongly correlated orbitals.
+autoCAS
+   QDK/Chemistry includes a native implementation of the autoCAS algorithm :cite:`Stein2019`, which leverages quantum information concepts to identify strongly correlated orbitals.
    The method computes single-orbital entropies—measures of how entangled each orbital is with the rest of the system—from the one- and two-electron reduced density matrices of a multi-configurational wavefunction.
-   Orbitals with high entropy are strongly entangled and should be treated explicitly within the active space. QDK/Chemistry's implementation includes both standard AutoCAS and an enhanced variant (AutoCAS-EOS) for improved robustness.
-   See the :ref:`AutoCAS Algorithm <autocas-algorithm-details>` documentation for further details.
+   Orbitals with high entropy are strongly entangled and should be treated explicitly within the active space. QDK/Chemistry's implementation includes both standard autoCAS and an enhanced variant (autoCAS-EOS) for improved robustness.
+   See the :ref:`autoCAS Algorithm <autocas-algorithm-details>` documentation for further details.
 
 
 Multi-Configuration Methods

--- a/examples/language/sample_sci_workflow.py
+++ b/examples/language/sample_sci_workflow.py
@@ -74,14 +74,14 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--autocas",
         action="store_true",
-        help="Run AutoCAS active space refinement after the initial CASCI step.",
+        help="Run autoCAS active space refinement after the initial CASCI step.",
     )
     parser.add_argument(
         "--autocas-parameters",
         type=str,
         default=None,
         help=(
-            "JSON object with AutoCAS overrides (only used when --autocas is supplied). "
+            "JSON object with autoCAS overrides (only used when --autocas is supplied). "
             "e.g., '{\"entropy_threshold\": 0.01}'"
         ),
     )
@@ -176,7 +176,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     Logger.info(f"CASCI energy = {e_cas:.8f} Hartree")
 
     ########################################################################################
-    # 6. Optional AutoCAS refinement of active space size.
+    # 6. Optional autoCAS refinement of active space size.
     ########################################################################################
     if args.autocas:
         autocas_selector = create("active_space_selector", "qdk_autocas")
@@ -186,10 +186,10 @@ def main(argv: Sequence[str] | None = None) -> None:
                 autocas_selector.settings().set(key, value)
         refined_wfn = autocas_selector.run(wfn_cas)
         indices, _ = refined_wfn.get_orbitals().get_active_space_indices()
-        Logger.info(f"AutoCAS selected active space with indices: {indices}")
+        Logger.info(f"autoCAS selected active space with indices: {indices}")
         if len(indices) == 0:
             Logger.warn(
-                "AutoCAS did not identify correlated orbitals; retaining the initial space."
+                "autoCAS did not identify correlated orbitals; retaining the initial space."
             )
         else:
             refined_orbitals = refined_wfn.get_orbitals()
@@ -198,7 +198,7 @@ def main(argv: Sequence[str] | None = None) -> None:
                 active_hamiltonian, *refined_wfn.get_active_num_electrons()
             )
             Logger.info(active_hamiltonian.get_summary())
-            Logger.info(f"AutoCAS energy = {e_cas:.8f} Hartree")
+            Logger.info(f"autoCAS energy = {e_cas:.8f} Hartree")
 
     ########################################################################################
     # 7. Perform sparse-CI screening.

--- a/examples/qpe_stretched_n2.ipynb
+++ b/examples/qpe_stretched_n2.ipynb
@@ -139,7 +139,7 @@
             "id": "c1bd22f0",
             "metadata": {},
             "source": [
-                "### Optimizing active space with AutoCAS-EOS active space selection"
+                "### Optimizing active space with autoCAS-EOS active space selection"
             ]
         },
         {
@@ -152,7 +152,7 @@
                 "autocas = create(\"active_space_selector\", \"qdk_autocas_eos\")\n",
                 "autocas_wfn = autocas.run(wfn)\n",
                 "indices, _ = autocas_wfn.get_orbitals().get_active_space_indices()\n",
-                "print(f\"AutoCAS-EOS active space: {len(indices)} orbitals, indices={list(indices)}\")"
+                "print(f\"autoCAS-EOS active space: {len(indices)} orbitals, indices={list(indices)}\")"
             ]
         },
         {
@@ -160,7 +160,7 @@
             "id": "93144fd9",
             "metadata": {},
             "source": [
-                "### Building Hamiltonian for the AutoCAS selected active space and calculate CASCI energy"
+                "### Building Hamiltonian for the autoCAS selected active space and calculate CASCI energy"
             ]
         },
         {

--- a/python/src/pybind11/algorithms/active_space.cpp
+++ b/python/src/pybind11/algorithms/active_space.cpp
@@ -253,7 +253,7 @@ QDK entropy-based active space selector.
 This class selects active space orbitals based on orbital entropy measures.
 It identifies orbitals with high entropy, which indicates strong electron
 correlation and multi-reference character.
-This method is a variant of the AutoCAS method that uses entropy as the primary
+This method is a variant of the autoCAS method that uses entropy as the primary
 criterion for selecting active orbitals :cite:`Stein2019`.
 
 Typical usage:
@@ -286,7 +286,7 @@ Initializes an entropy-based active space selector with default settings.
   // Bind concrete microsoft::AutocasActiveSpaceSelector implementation
   py::class_<microsoft::AutocasActiveSpaceSelector, ActiveSpaceSelector,
              py::smart_holder>(m, "QdkAutocasActiveSpaceSelector", R"(
-QDK Automated Complete Active Space (AutoCAS) selector.
+QDK Automated Complete Active Space (autoCAS) selector.
 
 This class provides an automated approach to selecting active space orbitals
 based on various criteria including occupation numbers, orbital energies,
@@ -298,7 +298,7 @@ Typical usage:
 
     import qdk_chemistry.algorithms as alg
 
-    # Create an AutoCAS selector
+    # Create an autoCAS selector
     selector = alg.QdkAutocasActiveSpaceSelector()
 
     # Select active space automatically
@@ -312,7 +312,7 @@ See Also:
       .def(py::init<>(), R"(
 Default constructor.
 
-Initializes an AutoCAS selector with default settings.
+Initializes an autoCAS selector with default settings.
 
 )");
 }

--- a/python/tests/test_sample_workflow_sci.py
+++ b/python/tests/test_sample_workflow_sci.py
@@ -100,7 +100,7 @@ TEST_CASES: tuple[WorkflowCase, ...] = (
         ],
         cwd_relative=Path("."),
         expected_energy=-76.02623746,
-        expected_warning="AutoCAS did not identify correlated orbitals; retaining the initial space.",
+        expected_warning="autoCAS did not identify correlated orbitals; retaining the initial space.",
     ),
     WorkflowCase(
         identifier="valence_autocas_threshold",
@@ -208,7 +208,7 @@ def test_sample_sci_workflow_macis_asci_autocas_with_limits():
         casci_energy, expected_casci_energy, rtol=float_comparison_relative_tolerance, atol=ci_energy_tolerance
     )
 
-    autocas_energy = float(_find_line(lambda line: "AutoCAS energy = " in line, lines).split()[-2])
+    autocas_energy = float(_find_line(lambda line: "autoCAS energy = " in line, lines).split()[-2])
     assert np.isclose(
         autocas_energy, expected_autocas_energy, rtol=float_comparison_relative_tolerance, atol=ci_energy_tolerance
     )
@@ -223,5 +223,5 @@ def test_sample_sci_workflow_macis_asci_autocas_with_limits():
         energy, expected_sparse_ci_energy, rtol=float_comparison_relative_tolerance, atol=sci_energy_tolerance
     )
 
-    indices_line = _find_line(lambda line: "AutoCAS selected active space with indices:" in line, lines)
+    indices_line = _find_line(lambda line: "autoCAS selected active space with indices:" in line, lines)
     assert str(expected_active_space_indices) in indices_line


### PR DESCRIPTION
Fixes the stylization of "autoCAS" in doc strings, docs, loggers, etc, to respect the branding of autoCAS. 
Leaves case in code untouched. 

Fixes #329 