### PR TITLE
Bump version to 1.0.2 and update changelog

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(qdk VERSION 1.0.1 LANGUAGES CXX C)
+project(qdk VERSION 1.0.2 LANGUAGES CXX C)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+Version 1.0.2
+=============
+
+- Make qiskit-aer and qiskit-nature optional dependencies
+- Loosen matplotlib version requirement to >=3.10.0
+- Fixed installation instructions for Ubuntu compatibility
+- Improved iQPE demo notebook
+
 Version 1.0.1
 =============
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,7 @@ from pathlib import Path
 project = "qdk-chemistry"
 copyright = "Microsoft Corporation. All rights reserved. Licensed under the MIT License"
 author = "QDK/Chemistry Team"
-release = "1.0.1"
+release = "1.0.2"
 
 # -----------------------------------------------------------------------------
 # Perform initial setup and tests

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(qdk_chemistry_python VERSION 1.0.1 LANGUAGES CXX)
+project(qdk_chemistry_python VERSION 1.0.2 LANGUAGES CXX)
 
 # Set default build type to Release if not specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 ]
 description = "Quantum Development Kit - Chemistry Library"
 license = { file = "LICENSE.txt" }
-version = "1.0.1"
+version = "1.0.2"
 name = "qdk-chemistry"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/src/qdk_chemistry/__init__.py
+++ b/python/src/qdk_chemistry/__init__.py
@@ -5,7 +5,7 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 import contextlib
 import os


### PR DESCRIPTION
- Update version numbers to 1.0.2 across all project files
- Add changelog entry for v1.0.2 release:
  - Make qiskit-aer and qiskit-nature optional dependencies
  - Loosen matplotlib version requirement to >=3.10.0
  - Fixed installation instructions for Ubuntu compatibility
  - Improved iQPE demo notebook