### PR TITLE
Original CI/CD Build Order

### DIFF
--- a/.pipelines/python-wheels.yaml
+++ b/.pipelines/python-wheels.yaml
@@ -115,9 +115,6 @@ extends:
             LD_LIBRARY_PATH: $LD_LIBRARY_PATH:/usr/local/lib
           strategy:
             matrix:
-              Python3.14:
-                pythonVersion: '3.14'
-                buildMarch: ${{ target.march }}
               Python3.10:
                 pythonVersion: '3.10'
                 buildMarch: ${{ target.march }}
@@ -130,7 +127,10 @@ extends:
               Python3.13:
                 pythonVersion: '3.13'
                 buildMarch: ${{ target.march }}
-            maxParallel: 5
+              Python3.14:
+                pythonVersion: '3.14'
+                buildMarch: ${{ target.march }}
+            maxParallel: 3
           templateContext:
             outputs:
             - output: pipelineArtifact


### PR DESCRIPTION
In preparation for the 1.1.0.dev0 release, there were some temporary changes made to the release pipeline to assist in fixing errors in the Python 3.14 build process. This PR reverts to the previous sequential build order and sets the maximum number of parallel jobs back to 3 to prevent the pipeline from hogging resources during the nightly build. 