### PR TITLE
Transpile to IBM fake backends

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -111,6 +111,7 @@ autodoc_mock_imports = [  # Configure autodoc to handle C++ extension modules an
     "qiskit",
     "qiskit_nature",
     "qiskit_aer",
+    "qiskit_ibm_runtime",
     "openfermion",
     "cirq",
     "cirq_core",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -86,7 +86,7 @@ plugins = [
 qiskit-extras = [
   "qiskit[qasm3-import]>=2.2.0",
   "qiskit-aer",
-  "qiskit-ibm-runtime",
+  "qiskit-ibm-runtime>=0.46.1",
   "qiskit-nature",
   "pylatexenc==2.10"
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -86,6 +86,7 @@ plugins = [
 qiskit-extras = [
   "qiskit[qasm3-import]>=2.2.0",
   "qiskit-aer",
+  "qiskit-ibm-runtime",
   "qiskit-nature",
   "pylatexenc==2.10"
 ]

--- a/python/src/qdk_chemistry/algorithms/circuit_executor/base.py
+++ b/python/src/qdk_chemistry/algorithms/circuit_executor/base.py
@@ -44,7 +44,9 @@ class CircuitExecutor(Algorithm):
             circuit: The circuit that prepares the initial state.
             shots: The number of shots to execute the circuit.
             noise: Optional noise profile to apply during execution.
-            device_backend_name: Optional name of an IBM device backend to transpile to.
+            device_backend_name: Optional name of an IBM fake device backend
+                from ``qiskit_ibm_runtime.fake_provider`` to transpile to
+                (for example, ``fake_manila``). Requires ``qiskit-ibm-runtime``.
 
         Returns:
             CircuitExecutorData: Object containing the results of the circuit execution.

--- a/python/src/qdk_chemistry/algorithms/circuit_executor/base.py
+++ b/python/src/qdk_chemistry/algorithms/circuit_executor/base.py
@@ -36,6 +36,7 @@ class CircuitExecutor(Algorithm):
         circuit: Circuit,
         shots: int,
         noise: QuantumErrorProfile | None = None,
+        device_backend_name: str | None = None,
     ) -> CircuitExecutorData:
         """Execute the given quantum circuit and get measurement results.
 
@@ -43,6 +44,7 @@ class CircuitExecutor(Algorithm):
             circuit: The circuit that prepares the initial state.
             shots: The number of shots to execute the circuit.
             noise: Optional noise profile to apply during execution.
+            device_backend_name: Optional name of an IBM device backend to transpile to.
 
         Returns:
             CircuitExecutorData: Object containing the results of the circuit execution.

--- a/python/src/qdk_chemistry/plugins/qiskit/__init__.py
+++ b/python/src/qdk_chemistry/plugins/qiskit/__init__.py
@@ -17,13 +17,15 @@ _loaded = False
 QDK_CHEMISTRY_HAS_QISKIT = False
 QDK_CHEMISTRY_HAS_QISKIT_NATURE = False
 QDK_CHEMISTRY_HAS_QISKIT_AER = False
+QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME = False
 
 
 def load():
     """Load the Qiskit related plugins into QDK/Chemistry."""
     Logger.trace_entering()
     global _loaded  # noqa: PLW0603
-    global QDK_CHEMISTRY_HAS_QISKIT, QDK_CHEMISTRY_HAS_QISKIT_NATURE, QDK_CHEMISTRY_HAS_QISKIT_AER  # noqa: PLW0603
+    global QDK_CHEMISTRY_HAS_QISKIT, QDK_CHEMISTRY_HAS_QISKIT_NATURE  # noqa: PLW0603
+    global QDK_CHEMISTRY_HAS_QISKIT_AER, QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME  # noqa: PLW0603
     if _loaded:
         return
     _loaded = True
@@ -36,6 +38,8 @@ def load():
     if importlib.util.find_spec("qiskit_aer") is not None:
         QDK_CHEMISTRY_HAS_QISKIT_AER = True
         qiskit_aer_load()
+    if importlib.util.find_spec("qiskit_ibm_runtime") is not None:
+        QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME = True
 
 
 def qiskit_load():

--- a/python/src/qdk_chemistry/plugins/qiskit/__init__.py
+++ b/python/src/qdk_chemistry/plugins/qiskit/__init__.py
@@ -36,7 +36,10 @@ def load():
         QDK_CHEMISTRY_HAS_QISKIT_NATURE = True
     if importlib.util.find_spec("qiskit_aer") is not None:
         QDK_CHEMISTRY_HAS_QISKIT_AER = True
-    if importlib.util.find_spec("qiskit_ibm_runtime") is not None:
+    if (
+        importlib.util.find_spec("qiskit_ibm_runtime") is not None
+        and importlib.util.find_spec("qiskit_ibm_runtime.fake_provider") is not None
+    ):
         QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME = True
 
     if QDK_CHEMISTRY_HAS_QISKIT:

--- a/python/src/qdk_chemistry/plugins/qiskit/__init__.py
+++ b/python/src/qdk_chemistry/plugins/qiskit/__init__.py
@@ -29,17 +29,24 @@ def load():
     if _loaded:
         return
     _loaded = True
+
     if importlib.util.find_spec("qiskit") is not None:
         QDK_CHEMISTRY_HAS_QISKIT = True
-        qiskit_load()
     if importlib.util.find_spec("qiskit_nature") is not None:
         QDK_CHEMISTRY_HAS_QISKIT_NATURE = True
-        qiskit_nature_load()
     if importlib.util.find_spec("qiskit_aer") is not None:
         QDK_CHEMISTRY_HAS_QISKIT_AER = True
-        qiskit_aer_load()
     if importlib.util.find_spec("qiskit_ibm_runtime") is not None:
         QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME = True
+
+    if QDK_CHEMISTRY_HAS_QISKIT:
+        qiskit_load()
+    if QDK_CHEMISTRY_HAS_QISKIT_NATURE:
+        qiskit_nature_load()
+    if QDK_CHEMISTRY_HAS_QISKIT_AER:
+        qiskit_aer_load()
+    if QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME:
+        qiskit_ibm_runtime_load()
 
 
 def qiskit_load():
@@ -69,6 +76,15 @@ def qiskit_nature_load():
 
     register(lambda: QiskitQubitMapper())
     Logger.debug(f"Qiskit Nature plugin loaded: [{QiskitQubitMapper().type_name()}: {QiskitQubitMapper().name()}].")
+
+
+def qiskit_ibm_runtime_load():
+    """Load the Qiskit IBM Runtime fake provider into QDK/Chemistry."""
+    Logger.trace_entering()
+
+    import qiskit_ibm_runtime.fake_provider  # noqa: PLC0415
+
+    Logger.debug("Qiskit IBM Runtime fake provider loaded.")
 
 
 def qiskit_aer_load():

--- a/python/src/qdk_chemistry/plugins/qiskit/__init__.py
+++ b/python/src/qdk_chemistry/plugins/qiskit/__init__.py
@@ -36,14 +36,10 @@ def load():
         QDK_CHEMISTRY_HAS_QISKIT_NATURE = True
     if importlib.util.find_spec("qiskit_aer") is not None:
         QDK_CHEMISTRY_HAS_QISKIT_AER = True
-<<<<<<< HEAD
     if (
         importlib.util.find_spec("qiskit_ibm_runtime") is not None
         and importlib.util.find_spec("qiskit_ibm_runtime.fake_provider") is not None
     ):
-=======
-    if importlib.util.find_spec("qiskit_ibm_runtime") is not None:
->>>>>>> origin/feature/agamshayit/transpile_to_backend
         QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME = True
 
     if QDK_CHEMISTRY_HAS_QISKIT:

--- a/python/src/qdk_chemistry/plugins/qiskit/circuit_executor.py
+++ b/python/src/qdk_chemistry/plugins/qiskit/circuit_executor.py
@@ -18,10 +18,10 @@ from qiskit.transpiler import PassManager
 from qiskit_aer import AerSimulator
 from qiskit_aer.noise import NoiseModel
 
+import qdk_chemistry.plugins.qiskit as qiskit_plugin
 from qdk_chemistry.algorithms.circuit_executor.base import CircuitExecutor
-from qdk_chemistry.plugins.qiskit import QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME
 
-if QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME:
+if qiskit_plugin.QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME:
     import qiskit_ibm_runtime.fake_provider
 
 from qdk_chemistry.data import (
@@ -116,9 +116,9 @@ class QiskitAerSimulator(CircuitExecutor):
         ).run(meas_circuit)
 
         if device_backend_name is not None:
-            if not QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME:
+            if not qiskit_plugin.QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME:
                 raise ImportError(
-                    "qiskit_ibm_runtime is required for device backend simulation. "
+                    "The fake_provider module from qiskit_ibm_runtime is required for device backend simulation. "
                     "Install it with: pip install qiskit-ibm-runtime"
                 )
 

--- a/python/src/qdk_chemistry/plugins/qiskit/circuit_executor.py
+++ b/python/src/qdk_chemistry/plugins/qiskit/circuit_executor.py
@@ -12,13 +12,17 @@ data classes and returns measurement bitstring results via CircuitExecutorData.
 
 from __future__ import annotations
 
-import qiskit_ibm_runtime.fake_provider
 from qiskit import transpile
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit_aer import AerSimulator
 from qiskit_aer.noise import NoiseModel
 
 from qdk_chemistry.algorithms.circuit_executor.base import CircuitExecutor
+from qdk_chemistry.plugins.qiskit import QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME
+
+if QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME:
+    import qiskit_ibm_runtime.fake_provider
+
 from qdk_chemistry.data import (
     Circuit,
     CircuitExecutorData,
@@ -97,13 +101,20 @@ class QiskitAerSimulator(CircuitExecutor):
         opt_level = self._settings.get("transpile_optimization_level")
 
         if device_backend_name is not None:
+            if not QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME:
+                raise ImportError(
+                    "qiskit_ibm_runtime is required for device backend simulation. "
+                    "Install it with: pip install qiskit-ibm-runtime"
+                )
+
             provider = qiskit_ibm_runtime.fake_provider.FakeProviderForBackendV2()
             try:
                 device_backend = provider.backend(device_backend_name)
             except QiskitBackendNotFoundError:
-                available = [b.name for b in provider.backends()]
+                available = sorted(b.name for b in provider.backends())
+                available_backends = ", ".join(available)
                 raise ValueError(
-                    f"Unknown device backend '{device_backend_name}'. Available backends: {available}"
+                    f"Unknown device backend '{device_backend_name}'. Available backends: {available_backends}"
                 ) from None
 
             backend = AerSimulator.from_backend(device_backend)

--- a/python/src/qdk_chemistry/plugins/qiskit/circuit_executor.py
+++ b/python/src/qdk_chemistry/plugins/qiskit/circuit_executor.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 from qiskit import transpile
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
-from qiskit.transpiler import PassManager
 from qiskit_aer import AerSimulator
 from qiskit_aer.noise import NoiseModel
 
@@ -32,12 +31,6 @@ from qdk_chemistry.data import (
 )
 from qdk_chemistry.plugins.qiskit._interop.noise_model import (
     get_noise_model_from_profile,
-)
-from qdk_chemistry.plugins.qiskit._interop.transpiler import (
-    FactorCliffordFromRz,
-    FactorPauliFromRotation,
-    MergeZBasisRotations,
-    SubstituteCliffordRz,
 )
 from qdk_chemistry.utils import Logger
 
@@ -108,13 +101,6 @@ class QiskitAerSimulator(CircuitExecutor):
 
         opt_level = self._settings.get("transpile_optimization_level")
 
-        meas_circuit = PassManager(
-            [
-                FactorCliffordFromRz(),
-                FactorPauliFromRotation(),
-            ]
-        ).run(meas_circuit)
-
         if device_backend_name is not None:
             if not qiskit_plugin.QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME:
                 raise ImportError(
@@ -164,13 +150,6 @@ class QiskitAerSimulator(CircuitExecutor):
                     basis_gates=NoiseModel().basis_gates,
                     optimization_level=opt_level,
                 )
-
-        transpiled_circuit = PassManager(
-            [
-                MergeZBasisRotations(),
-                SubstituteCliffordRz(),
-            ]
-        ).run(transpiled_circuit)
 
         raw_results = backend.run(transpiled_circuit, shots=shots).result()
         counts = raw_results.get_counts()

--- a/python/src/qdk_chemistry/plugins/qiskit/circuit_executor.py
+++ b/python/src/qdk_chemistry/plugins/qiskit/circuit_executor.py
@@ -10,7 +10,11 @@ data classes and returns measurement bitstring results via CircuitExecutorData.
 # Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from __future__ import annotations
+
+import qiskit_ibm_runtime.fake_provider
 from qiskit import transpile
+from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit_aer import AerSimulator
 from qiskit_aer.noise import NoiseModel
 
@@ -70,6 +74,7 @@ class QiskitAerSimulator(CircuitExecutor):
         circuit: Circuit,
         shots: int,
         noise: QuantumErrorProfile | None = None,
+        device_backend_name: str | None = None,
     ) -> CircuitExecutorData:
         """Execute the given quantum circuit using the Qiskit Aer Simulator.
 
@@ -85,25 +90,54 @@ class QiskitAerSimulator(CircuitExecutor):
         Logger.trace_entering()
         meas_circuit = circuit.get_qiskit_circuit()
         Logger.debug("Qiskit QuantumCircuit loaded.")
-        noise_model = get_noise_model_from_profile(noise) if noise else None
-        backend = AerSimulator(
-            method=self._settings.get("method"),
-            seed_simulator=self._settings.get("seed"),
-            noise_model=noise_model,
-        )
-        if noise_model:
+        if noise is not None and device_backend_name is not None:
+            raise ValueError("Cannot specify both a noise model and a device backend. Please choose one or the other.")
+
+        opt_level = self._settings.get("transpile_optimization_level")
+
+        if device_backend_name is not None:
+            provider = qiskit_ibm_runtime.fake_provider.FakeProviderForBackendV2()
+            try:
+                device_backend = provider.backend(device_backend_name)
+            except QiskitBackendNotFoundError:
+                available = [b.name for b in provider.backends()]
+                raise ValueError(
+                    f"Unknown device backend '{device_backend_name}'. "
+                    f"Available backends: {available}"
+                ) from None
+
+            backend = AerSimulator.from_backend(device_backend)
+            backend.set_options(
+                method=self._settings.get("method"),
+                seed_simulator=self._settings.get("seed"),
+            )
+
             transpiled_circuit = transpile(
                 meas_circuit,
-                basis_gates=noise_model.basis_gates,
-                optimization_level=self._settings.get("transpile_optimization_level"),
+                backend=device_backend,
+                optimization_level=opt_level,
             )
+
         else:
-            # Use qiskit_aer NoiseModel() default basis gates if no noise model is provided
-            transpiled_circuit = transpile(
-                meas_circuit,
-                basis_gates=NoiseModel().basis_gates,
-                optimization_level=self._settings.get("transpile_optimization_level"),
+            noise_model = get_noise_model_from_profile(noise) if noise else None
+            backend = AerSimulator(
+                method=self._settings.get("method"),
+                seed_simulator=self._settings.get("seed"),
+                noise_model=noise_model,
             )
+            if noise_model:
+                transpiled_circuit = transpile(
+                    meas_circuit,
+                    basis_gates=noise_model.basis_gates,
+                    optimization_level=opt_level,
+                )
+            else:
+                # Use qiskit_aer NoiseModel() default basis gates if no noise model is provided
+                transpiled_circuit = transpile(
+                    meas_circuit,
+                    basis_gates=NoiseModel().basis_gates,
+                    optimization_level=opt_level,
+                )
         raw_results = backend.run(transpiled_circuit, shots=shots).result()
         counts = raw_results.get_counts()
         Logger.debug(f"Measurement results obtained: {counts}")

--- a/python/src/qdk_chemistry/plugins/qiskit/circuit_executor.py
+++ b/python/src/qdk_chemistry/plugins/qiskit/circuit_executor.py
@@ -12,13 +12,18 @@ data classes and returns measurement bitstring results via CircuitExecutorData.
 
 from __future__ import annotations
 
-import qiskit_ibm_runtime.fake_provider
 from qiskit import transpile
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
+from qiskit.transpiler import PassManager
 from qiskit_aer import AerSimulator
 from qiskit_aer.noise import NoiseModel
 
 from qdk_chemistry.algorithms.circuit_executor.base import CircuitExecutor
+from qdk_chemistry.plugins.qiskit import QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME
+
+if QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME:
+    import qiskit_ibm_runtime.fake_provider
+
 from qdk_chemistry.data import (
     Circuit,
     CircuitExecutorData,
@@ -27,6 +32,12 @@ from qdk_chemistry.data import (
 )
 from qdk_chemistry.plugins.qiskit._interop.noise_model import (
     get_noise_model_from_profile,
+)
+from qdk_chemistry.plugins.qiskit._interop.transpiler import (
+    FactorCliffordFromRz,
+    FactorPauliFromRotation,
+    MergeZBasisRotations,
+    SubstituteCliffordRz,
 )
 from qdk_chemistry.utils import Logger
 
@@ -91,19 +102,34 @@ class QiskitAerSimulator(CircuitExecutor):
         Logger.trace_entering()
         meas_circuit = circuit.get_qiskit_circuit()
         Logger.debug("Qiskit QuantumCircuit loaded.")
+
         if noise is not None and device_backend_name is not None:
             raise ValueError("Cannot specify both a noise model and a device backend. Please choose one or the other.")
 
         opt_level = self._settings.get("transpile_optimization_level")
 
+        meas_circuit = PassManager(
+            [
+                FactorCliffordFromRz(),
+                FactorPauliFromRotation(),
+            ]
+        ).run(meas_circuit)
+
         if device_backend_name is not None:
+            if not QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME:
+                raise ImportError(
+                    "qiskit_ibm_runtime is required for device backend simulation. "
+                    "Install it with: pip install qiskit-ibm-runtime"
+                )
+
             provider = qiskit_ibm_runtime.fake_provider.FakeProviderForBackendV2()
             try:
                 device_backend = provider.backend(device_backend_name)
             except QiskitBackendNotFoundError:
-                available = [b.name for b in provider.backends()]
+                available = sorted(b.name for b in provider.backends())
+                available_backends = ", ".join(available)
                 raise ValueError(
-                    f"Unknown device backend '{device_backend_name}'. Available backends: {available}"
+                    f"Unknown device backend '{device_backend_name}'. Available backends: {available_backends}"
                 ) from None
 
             backend = AerSimulator.from_backend(device_backend)
@@ -138,6 +164,14 @@ class QiskitAerSimulator(CircuitExecutor):
                     basis_gates=NoiseModel().basis_gates,
                     optimization_level=opt_level,
                 )
+
+        transpiled_circuit = PassManager(
+            [
+                MergeZBasisRotations(),
+                SubstituteCliffordRz(),
+            ]
+        ).run(transpiled_circuit)
+
         raw_results = backend.run(transpiled_circuit, shots=shots).result()
         counts = raw_results.get_counts()
         Logger.debug(f"Measurement results obtained: {counts}")

--- a/python/src/qdk_chemistry/plugins/qiskit/circuit_executor.py
+++ b/python/src/qdk_chemistry/plugins/qiskit/circuit_executor.py
@@ -82,6 +82,7 @@ class QiskitAerSimulator(CircuitExecutor):
             circuit: The quantum circuit to execute.
             shots: The number of shots to execute the circuit.
             noise: Optional noise profile to apply during execution.
+            device_backend_name: Optional name of a fake device backend to use for noise modeling.
 
         Returns:
             CircuitExecutorData: Object containing the results of the circuit execution.
@@ -102,8 +103,7 @@ class QiskitAerSimulator(CircuitExecutor):
             except QiskitBackendNotFoundError:
                 available = [b.name for b in provider.backends()]
                 raise ValueError(
-                    f"Unknown device backend '{device_backend_name}'. "
-                    f"Available backends: {available}"
+                    f"Unknown device backend '{device_backend_name}'. Available backends: {available}"
                 ) from None
 
             backend = AerSimulator.from_backend(device_backend)

--- a/python/src/qdk_chemistry/plugins/qiskit/circuit_executor.py
+++ b/python/src/qdk_chemistry/plugins/qiskit/circuit_executor.py
@@ -20,14 +20,8 @@ from qiskit_aer.noise import NoiseModel
 
 import qdk_chemistry.plugins.qiskit as qiskit_plugin
 from qdk_chemistry.algorithms.circuit_executor.base import CircuitExecutor
-<<<<<<< HEAD
 
 if qiskit_plugin.QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME:
-=======
-from qdk_chemistry.plugins.qiskit import QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME
-
-if QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME:
->>>>>>> origin/feature/agamshayit/transpile_to_backend
     import qiskit_ibm_runtime.fake_provider
 
 from qdk_chemistry.data import (
@@ -122,15 +116,9 @@ class QiskitAerSimulator(CircuitExecutor):
         ).run(meas_circuit)
 
         if device_backend_name is not None:
-<<<<<<< HEAD
             if not qiskit_plugin.QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME:
                 raise ImportError(
                     "The fake_provider module from qiskit_ibm_runtime is required for device backend simulation. "
-=======
-            if not QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME:
-                raise ImportError(
-                    "qiskit_ibm_runtime is required for device backend simulation. "
->>>>>>> origin/feature/agamshayit/transpile_to_backend
                     "Install it with: pip install qiskit-ibm-runtime"
                 )
 

--- a/python/tests/test_interop_qiskit_circuit_executor.py
+++ b/python/tests/test_interop_qiskit_circuit_executor.py
@@ -88,3 +88,12 @@ class TestQiskitAerCircuitExecutor:
         assert counts.get("00", 0) > 0
         assert counts.get("11", 0) > 0
         assert counts.get("01", 0) + counts.get("10", 0) > 0  # Expect some errors to occur
+
+    def test_circuit_executor_with_device_backend(self, test_circuit_2: Circuit):
+        """Test the Qiskit Aer circuit executor with a device backend name string."""
+        executor = QiskitAerSimulator()
+        result = executor.run(test_circuit_2, shots=100, device_backend_name="fake_manila")
+        counts = result.bitstring_counts
+        # Circuit applies X on q[0], so only "01" (little-endian) should appear
+        assert counts.get("01", 0) > 0
+        assert result.total_shots == 100

--- a/python/tests/test_interop_qiskit_circuit_executor.py
+++ b/python/tests/test_interop_qiskit_circuit_executor.py
@@ -98,3 +98,17 @@ class TestQiskitAerCircuitExecutor:
         # Circuit applies X on q[0], so only "01" (little-endian) should appear
         assert counts.get("01", 0) > 0
         assert result.total_shots == 100
+
+    @pytest.mark.skipif(not QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME, reason="qiskit_ibm_runtime not installed")
+    def test_noise_and_device_backend_raises(self, test_circuit_1: Circuit, simple_error_profile: QuantumErrorProfile):
+        """Test that specifying both noise and device_backend_name raises ValueError."""
+        executor = QiskitAerSimulator()
+        with pytest.raises(ValueError, match="Cannot specify both a noise model and a device backend"):
+            executor.run(test_circuit_1, shots=10, noise=simple_error_profile, device_backend_name="fake_manila")
+
+    @pytest.mark.skipif(not QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME, reason="qiskit_ibm_runtime not installed")
+    def test_invalid_device_backend_name_raises(self, test_circuit_1: Circuit):
+        """Test that an invalid device_backend_name raises ValueError with a helpful message."""
+        executor = QiskitAerSimulator()
+        with pytest.raises(ValueError, match="Unknown device backend 'not_a_real_backend'"):
+            executor.run(test_circuit_1, shots=10, device_backend_name="not_a_real_backend")

--- a/python/tests/test_interop_qiskit_circuit_executor.py
+++ b/python/tests/test_interop_qiskit_circuit_executor.py
@@ -8,7 +8,7 @@
 import pytest
 
 from qdk_chemistry.data import Circuit, QuantumErrorProfile
-from qdk_chemistry.plugins.qiskit import QDK_CHEMISTRY_HAS_QISKIT_AER
+from qdk_chemistry.plugins.qiskit import QDK_CHEMISTRY_HAS_QISKIT_AER, QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME
 
 if QDK_CHEMISTRY_HAS_QISKIT_AER:
     from qdk_chemistry.plugins.qiskit.circuit_executor import QiskitAerSimulator
@@ -89,6 +89,7 @@ class TestQiskitAerCircuitExecutor:
         assert counts.get("11", 0) > 0
         assert counts.get("01", 0) + counts.get("10", 0) > 0  # Expect some errors to occur
 
+    @pytest.mark.skipif(not QDK_CHEMISTRY_HAS_QISKIT_IBM_RUNTIME, reason="qiskit_ibm_runtime not installed")
     def test_circuit_executor_with_device_backend(self, test_circuit_2: Circuit):
         """Test the Qiskit Aer circuit executor with a device backend name string."""
         executor = QiskitAerSimulator()


### PR DESCRIPTION
Added the ability to pass a device backend string to the Qiskit Aer circuit executor. If received as an argument, the circuit is transpiled to the backend and the simulator uses the backend's noise profile.