### PR TITLE
Store Cholesky MO integrals and save them in serialization

### DIFF
--- a/cpp/include/qdk/chemistry/data/hamiltonian.hpp
+++ b/cpp/include/qdk/chemistry/data/hamiltonian.hpp
@@ -262,10 +262,11 @@ class HamiltonianContainer {
    * @param filename Path to FCIDUMP file to create/overwrite
    * @param nalpha Number of alpha electrons
    * @param nbeta Number of beta electrons
-   * @throws std::runtime_error if I/O error occurs
+   * @throws std::runtime_error if I/O error occurs or Hamiltonian is
+   * unrestricted
    */
   virtual void to_fcidump_file(const std::string& filename, size_t nalpha,
-                               size_t nbeta) const = 0;
+                               size_t nbeta) const;
 
   /**
    * @brief Check if the Hamiltonian data is complete and consistent

--- a/cpp/include/qdk/chemistry/data/hamiltonian_containers/canonical_four_center.hpp
+++ b/cpp/include/qdk/chemistry/data/hamiltonian_containers/canonical_four_center.hpp
@@ -182,16 +182,6 @@ class CanonicalFourCenterHamiltonianContainer : public HamiltonianContainer {
       const nlohmann::json& j);
 
   /**
-   * @brief Save Hamiltonian to an FCIDUMP file
-   * @param filename Path to FCIDUMP file to create/overwrite
-   * @param nalpha Number of alpha electrons
-   * @param nbeta Number of beta electrons
-   * @throws std::runtime_error if I/O error occurs
-   */
-  void to_fcidump_file(const std::string& filename, size_t nalpha,
-                       size_t nbeta) const override;
-
-  /**
    * @brief Check if the Hamiltonian data is complete and consistent
    * @return True if all required data is set and dimensions are consistent
    */
@@ -214,16 +204,6 @@ class CanonicalFourCenterHamiltonianContainer : public HamiltonianContainer {
                     std::shared_ptr<Eigen::VectorXd>,
                     std::shared_ptr<Eigen::VectorXd>>
   make_restricted_two_body_integrals(const Eigen::VectorXd& integrals);
-
-  /**
-   * @brief Save FCIDUMP file without filename validation (internal use)
-   * @param filename Path to FCIDUMP file to create/overwrite
-   * @param nalpha Number of alpha electrons
-   * @param nbeta Number of beta electrons
-   * @throws std::runtime_error if I/O error occurs
-   */
-  void _to_fcidump_file(const std::string& filename, size_t nalpha,
-                        size_t nbeta) const;
 
   /// Serialization version
   static constexpr const char* SERIALIZATION_VERSION = "0.1.0";

--- a/cpp/include/qdk/chemistry/data/hamiltonian_containers/cholesky.hpp
+++ b/cpp/include/qdk/chemistry/data/hamiltonian_containers/cholesky.hpp
@@ -42,6 +42,8 @@ class CholeskyHamiltonianContainer : public HamiltonianContainer {
    * energy)
    * @param inactive_fock_matrix Inactive Fock matrix for the selected active
    * space
+   * @param ao_cholesky_vectors Optional AO Cholesky vectors for potential reuse
+   * (default: std::nullopt)
    * @param type Type of Hamiltonian (Hermitian by default)
    *
    * @throws std::invalid_argument if orbitals pointer is nullptr
@@ -51,6 +53,7 @@ class CholeskyHamiltonianContainer : public HamiltonianContainer {
       const Eigen::MatrixXd& three_center_integrals,
       std::shared_ptr<Orbitals> orbitals, double core_energy,
       const Eigen::MatrixXd& inactive_fock_matrix,
+      std::optional<Eigen::MatrixXd> ao_cholesky_vectors = std::nullopt,
       HamiltonianType type = HamiltonianType::Hermitian);
 
   /**
@@ -74,6 +77,8 @@ class CholeskyHamiltonianContainer : public HamiltonianContainer {
    * the selected active space
    * @param inactive_fock_matrix_beta Inactive Fock matrix for beta spin in the
    * selected active space
+   * @param ao_cholesky_vectors Optional AO Cholesky vectors for potential reuse
+   * (default: std::nullopt)
    * @param type Type of Hamiltonian (Hermitian by default)
    *
    * @throws std::invalid_argument if orbitals pointer is nullptr
@@ -86,6 +91,7 @@ class CholeskyHamiltonianContainer : public HamiltonianContainer {
       std::shared_ptr<Orbitals> orbitals, double core_energy,
       const Eigen::MatrixXd& inactive_fock_matrix_alpha,
       const Eigen::MatrixXd& inactive_fock_matrix_beta,
+      std::optional<Eigen::MatrixXd> ao_cholesky_vectors = std::nullopt,
       HamiltonianType type = HamiltonianType::Hermitian);
 
   /**
@@ -126,6 +132,13 @@ class CholeskyHamiltonianContainer : public HamiltonianContainer {
    */
   std::pair<const Eigen::MatrixXd&, const Eigen::MatrixXd&>
   get_three_center_integrals() const;
+
+  /**
+   * @brief Get the optional AO Cholesky vectors
+   * @return Const reference to the optional AO Cholesky vectors matrix
+   * [nao^2 x nchol]. Empty if not stored.
+   */
+  const std::optional<Eigen::MatrixXd>& get_ao_cholesky_vectors() const;
 
   /**
    * @brief Get specific four-center two-electron integral element
@@ -227,6 +240,9 @@ class CholeskyHamiltonianContainer : public HamiltonianContainer {
 
   /** Validation helper for integral dimensions */
   void validate_integral_dimensions() const override final;
+
+  /** Optional AO Cholesky vectors for potential reuse */
+  const std::optional<Eigen::MatrixXd> _ao_cholesky_vectors;
 
   static std::pair<std::shared_ptr<Eigen::MatrixXd>,
                    std::shared_ptr<Eigen::MatrixXd>>

--- a/cpp/include/qdk/chemistry/data/hamiltonian_containers/cholesky.hpp
+++ b/cpp/include/qdk/chemistry/data/hamiltonian_containers/cholesky.hpp
@@ -8,89 +8,72 @@
 #include <Eigen/Dense>
 #include <memory>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <qdk/chemistry/data/hamiltonian.hpp>
 #include <qdk/chemistry/data/orbitals.hpp>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
-#include "canonical_four_center.hpp"
-
 namespace qdk::chemistry::data {
 
 /**
  * @class CholeskyHamiltonianContainer
- * @brief Contains a molecular Hamiltonian and AO Cholesky vectors
+ * @brief Contains a molecular Hamiltonian using three-center
+ * integrals.
  *
- * This class stores molecular Hamiltonian data for quantum chemistry
- * calculations, specifically designed for active space methods. It contains:
- * - One-electron integrals (kinetic + nuclear attraction) in MO representation
- * - Two-electron integrals (electron-electron repulsion) in MO representation
- * - Cholesky vectors in AO representation for reconstructing integrals
- * - Molecular orbital information for the active space
- * - Inactive Fock matrix
- * - Core energy contributions from inactive orbitals and nuclear repulsion
+ * In addition to those contained in HamiltonianContainer, this subclass also
+ * contains:
+ * - Three-center two-electron integrals (electron-electron repulsion) in MO
+ * representation.
  *
- * This class implies that all inactive orbitals are fully occupied for the
- * purpose of computing the core energy and inactive Fock matrix.
- *
- * The Hamiltonian is immutable after construction, meaning all data must be
- * provided during construction and cannot be modified afterwards. The
- * Hamiltonian supports both restricted and unrestricted calculations and
- * integrates with the broader quantum chemistry framework for active space
- * methods.
  */
-// TODO: Change Cholesky container to only store MO cholesky vectors and
-// optionally AO cholesky vecs. Make two body ints evaluated on request
-class CholeskyHamiltonianContainer
-    : public CanonicalFourCenterHamiltonianContainer {
+class CholeskyHamiltonianContainer : public HamiltonianContainer {
  public:
   /**
-   * @brief Constructor for restricted Cholesky Hamiltonian
-   *
-   * Creates a restricted Hamiltonian where alpha and beta spin components
-   * share the same integrals.
+   * @brief Constructor for active space Hamiltonian with three center integrals
+   * (ij|Q)
    *
    * @param one_body_integrals One-electron integrals in MO basis [norb x norb]
-   * @param two_body_integrals Two-electron integrals in MO basis [norb x norb x
-   * norb x norb]
+   * @param three_center_integrals Three-center two-electron integrals in MO
+   * basis [(norb x norb) x naux]
    * @param orbitals Shared pointer to molecular orbital data for the system
    * @param core_energy Core energy (nuclear repulsion + inactive orbital
    * energy)
    * @param inactive_fock_matrix Inactive Fock matrix for the selected active
    * space
-   * @param L_ao AO Cholesky vectors for reconstructing integrals
    * @param type Type of Hamiltonian (Hermitian by default)
    *
    * @throws std::invalid_argument if orbitals pointer is nullptr
    */
   CholeskyHamiltonianContainer(
       const Eigen::MatrixXd& one_body_integrals,
-      const Eigen::VectorXd& two_body_integrals,
+      const Eigen::MatrixXd& three_center_integrals,
       std::shared_ptr<Orbitals> orbitals, double core_energy,
-      const Eigen::MatrixXd& inactive_fock_matrix, const Eigen::MatrixXd& L_ao,
+      const Eigen::MatrixXd& inactive_fock_matrix,
       HamiltonianType type = HamiltonianType::Hermitian);
 
   /**
-   * @brief Constructor for unrestricted Cholesky Hamiltonian
-   *
-   * Creates an unrestricted Hamiltonian with separate alpha and beta spin
-   * components.
+   * @brief Constructor for active space Hamiltonian with three center integrals
+   * using separate spin components
    *
    * @param one_body_integrals_alpha One-electron integrals for alpha spin in MO
    * basis
    * @param one_body_integrals_beta One-electron integrals for beta spin in MO
    * basis
-   * @param two_body_integrals_aaaa Two-electron alpha-alpha-alpha-alpha
-   * integrals
-   * @param two_body_integrals_aabb Two-electron alpha-beta-alpha-beta integrals
-   * @param two_body_integrals_bbbb Two-electron beta-beta-beta-beta integrals
+   * @param three_center_integrals_aa Three-center two-electron alpha-alpha
+   * integrals (ij|Q), where the orbital pair index ij are stored in row-major
+   * order
+   * @param three_center_integrals_bb Three-center two-electron beta-beta
+   * integrals (ij|Q), where the orbital pair index ij are stored in row-major
+   * order
    * @param orbitals Shared pointer to molecular orbital data for the system
    * @param core_energy Core energy (nuclear repulsion + inactive orbital
    * energy)
-   * @param inactive_fock_matrix_alpha Inactive Fock matrix for alpha spin
-   * @param inactive_fock_matrix_beta Inactive Fock matrix for beta spin
-   * @param L_ao AO Cholesky vectors for reconstructing integrals
+   * @param inactive_fock_matrix_alpha Inactive Fock matrix for alpha spin in
+   * the selected active space
+   * @param inactive_fock_matrix_beta Inactive Fock matrix for beta spin in the
+   * selected active space
    * @param type Type of Hamiltonian (Hermitian by default)
    *
    * @throws std::invalid_argument if orbitals pointer is nullptr
@@ -98,19 +81,17 @@ class CholeskyHamiltonianContainer
   CholeskyHamiltonianContainer(
       const Eigen::MatrixXd& one_body_integrals_alpha,
       const Eigen::MatrixXd& one_body_integrals_beta,
-      const Eigen::VectorXd& two_body_integrals_aaaa,
-      const Eigen::VectorXd& two_body_integrals_aabb,
-      const Eigen::VectorXd& two_body_integrals_bbbb,
+      const Eigen::MatrixXd& three_center_integrals_aa,
+      const Eigen::MatrixXd& three_center_integrals_bb,
       std::shared_ptr<Orbitals> orbitals, double core_energy,
       const Eigen::MatrixXd& inactive_fock_matrix_alpha,
       const Eigen::MatrixXd& inactive_fock_matrix_beta,
-      const Eigen::MatrixXd& L_ao,
       HamiltonianType type = HamiltonianType::Hermitian);
 
   /**
    * @brief Destructor
    */
-  ~CholeskyHamiltonianContainer() = default;
+  ~CholeskyHamiltonianContainer() override = default;
 
   /**
    * @brief Create a deep copy of this container
@@ -120,9 +101,58 @@ class CholeskyHamiltonianContainer
 
   /**
    * @brief Get the type of the underlying container
-   * @return String "cholesky" identifying this container type
+   * @return String identifying the container type (e.g.,
+   * "canonical_four_center", "cholesky")
    */
   std::string get_container_type() const override final;
+
+  /**
+   * @brief Get four-center two-electron integrals in MO basis for all spin
+   * channels
+   * @return Tuple of references to (aaaa, aabb, bbbb) four-center two-electron
+   * integrals vectors
+   * @throws std::runtime_error if integrals are not set
+   */
+  std::tuple<const Eigen::VectorXd&, const Eigen::VectorXd&,
+             const Eigen::VectorXd&>
+  get_two_body_integrals() const override;
+
+  /**
+   * @brief Get three-center integrals in MO basis for all spin channels
+   * @return Pair of references to (aa, bb) three-center two-electron
+   * integrals matrices, where each matrix is of dimension [(norb x norb) x
+   * naux], with the (norb x norb) part stored in row-major order
+   * @throws std::runtime_error if integrals are not set
+   */
+  std::pair<const Eigen::MatrixXd&, const Eigen::MatrixXd&>
+  get_three_center_integrals() const;
+
+  /**
+   * @brief Get specific four-center two-electron integral element
+   * @param i First orbital index
+   * @param j Second orbital index
+   * @param k Third orbital index
+   * @param l Fourth orbital index
+   * @param channel Spin channel to query (aaaa, aabb, or bbbb), defaults to
+   * aaaa
+   * @return Four-center two-electron integral (ij|kl)
+   * @throws std::out_of_range if indices are invalid
+   */
+  double get_two_body_element(
+      unsigned i, unsigned j, unsigned k, unsigned l,
+      SpinChannel channel = SpinChannel::aaaa) const override;
+
+  /**
+   * @brief Check if two-body integrals are available
+   * @return True if two-body integrals are set
+   */
+  bool has_two_body_integrals() const override;
+
+  /**
+   * @brief Check if the Hamiltonian is restricted
+   * @return True if alpha and beta integrals are identical
+   */
+  bool is_restricted() const override final;
 
   /**
    * @brief Convert Hamiltonian to JSON
@@ -140,8 +170,8 @@ class CholeskyHamiltonianContainer
   /**
    * @brief Deserialize Hamiltonian data from HDF5 group
    * @param group HDF5 group to read data from
-   * @return Unique pointer to CholeskyHamiltonianContainer loaded from group
-   * @throws std::runtime_error if I/O error occurs or data is malformed
+   * @return Unique pointer to const Hamiltonian loaded from group
+   * @throws std::runtime_error if I/O error occurs
    */
   static std::unique_ptr<CholeskyHamiltonianContainer> from_hdf5(
       H5::Group& group);
@@ -149,15 +179,61 @@ class CholeskyHamiltonianContainer
   /**
    * @brief Load Hamiltonian from JSON
    * @param j JSON object containing Hamiltonian data
-   * @return Unique pointer to CholeskyHamiltonianContainer loaded from JSON
-   * @throws std::runtime_error if JSON is malformed or missing required fields
+   * @return Unique pointer to const Hamiltonian loaded from JSON
+   * @throws std::runtime_error if JSON is malformed
    */
   static std::unique_ptr<CholeskyHamiltonianContainer> from_json(
       const nlohmann::json& j);
 
+  /**
+   * @brief Save Hamiltonian to an FCIDUMP file
+   * @param filename Path to FCIDUMP file to create/overwrite
+   * @param nalpha Number of alpha electrons
+   * @param nbeta Number of beta electrons
+   * @throws std::runtime_error if I/O error occurs
+   */
+  void to_fcidump_file(const std::string& filename, size_t nalpha,
+                       size_t nbeta) const override final;
+
+  /**
+   * @brief Check if the Hamiltonian data is complete and consistent
+   * @return True if all required data is set and dimensions are consistent
+   */
+  bool is_valid() const override final;
+
  private:
-  // AO Cholesky vectors for integral reconstruction
-  const std::shared_ptr<Eigen::MatrixXd> _ao_cholesky_vectors;
+  /**
+   * Three-center integrals in MO basis, where each channel is stored as a
+   * matrix of dimension [(norb x norb) x naux] where norb x norb is stored in
+   * row major order
+   */
+  const std::pair<std::shared_ptr<Eigen::MatrixXd>,
+                  std::shared_ptr<Eigen::MatrixXd>>
+      _three_center_integrals;
+
+  /**
+   * Lazily computed four-center integrals cache (built on first access).
+   * Stores (aaaa, aabb, bbbb) as flattened arrays [norb^4].
+   * Uses shared_ptr so restricted case can share the same data for all
+   * channels.
+   */
+  mutable std::optional<std::tuple<std::shared_ptr<Eigen::VectorXd>,
+                                   std::shared_ptr<Eigen::VectorXd>,
+                                   std::shared_ptr<Eigen::VectorXd>>>
+      _cached_four_center_integrals;
+
+  /** Build four-center integrals from three-center integrals and cache them */
+  void _build_four_center_cache() const;
+
+  /** Validation helper for integral dimensions */
+  void validate_integral_dimensions() const override final;
+
+  static std::pair<std::shared_ptr<Eigen::MatrixXd>,
+                   std::shared_ptr<Eigen::MatrixXd>>
+  make_restricted_three_center_integrals(const Eigen::MatrixXd& integrals);
+
+  /** Serialization version */
+  static constexpr const char* SERIALIZATION_VERSION = "0.1.0";
 };
 
 }  // namespace qdk::chemistry::data

--- a/cpp/include/qdk/chemistry/data/hamiltonian_containers/cholesky.hpp
+++ b/cpp/include/qdk/chemistry/data/hamiltonian_containers/cholesky.hpp
@@ -186,7 +186,8 @@ class CholeskyHamiltonianContainer : public HamiltonianContainer {
   /**
    * @brief Deserialize Hamiltonian data from HDF5 group
    * @param group HDF5 group to read data from
-   * @return Unique pointer to const Hamiltonian loaded from group
+   * @return Unique pointer to const CholeskyHamiltonianContainer loaded from
+   * group
    * @throws std::runtime_error if I/O error occurs
    */
   static std::unique_ptr<CholeskyHamiltonianContainer> from_hdf5(
@@ -195,7 +196,8 @@ class CholeskyHamiltonianContainer : public HamiltonianContainer {
   /**
    * @brief Load Hamiltonian from JSON
    * @param j JSON object containing Hamiltonian data
-   * @return Unique pointer to const Hamiltonian loaded from JSON
+   * @return Unique pointer to const CholeskyHamiltonianContainer loaded from
+   * JSON
    * @throws std::runtime_error if JSON is malformed
    */
   static std::unique_ptr<CholeskyHamiltonianContainer> from_json(

--- a/cpp/include/qdk/chemistry/data/hamiltonian_containers/cholesky.hpp
+++ b/cpp/include/qdk/chemistry/data/hamiltonian_containers/cholesky.hpp
@@ -19,7 +19,7 @@ namespace qdk::chemistry::data {
 
 /**
  * @class CholeskyHamiltonianContainer
- * @brief Contains a molecular Hamiltonian using three-center
+ * @brief Contains a molecular Hamiltonian expressed using three-center
  * integrals.
  *
  * In addition to those contained in HamiltonianContainer, this subclass also
@@ -110,7 +110,7 @@ class CholeskyHamiltonianContainer : public HamiltonianContainer {
   /**
    * @brief Get the type of the underlying container
    * @return String identifying the container type (e.g.,
-   * "canonical_four_center", "cholesky")
+   * "cholesky")
    */
   std::string get_container_type() const override final;
 
@@ -204,16 +204,6 @@ class CholeskyHamiltonianContainer : public HamiltonianContainer {
       const nlohmann::json& j);
 
   /**
-   * @brief Save Hamiltonian to an FCIDUMP file
-   * @param filename Path to FCIDUMP file to create/overwrite
-   * @param nalpha Number of alpha electrons
-   * @param nbeta Number of beta electrons
-   * @throws std::runtime_error if I/O error occurs
-   */
-  void to_fcidump_file(const std::string& filename, size_t nalpha,
-                       size_t nbeta) const override final;
-
-  /**
    * @brief Check if the Hamiltonian data is complete and consistent
    * @return True if all required data is set and dimensions are consistent
    */
@@ -235,9 +225,9 @@ class CholeskyHamiltonianContainer : public HamiltonianContainer {
    * Uses shared_ptr so restricted case can share the same data for all
    * channels.
    */
-  mutable std::optional<std::tuple<std::shared_ptr<Eigen::VectorXd>,
-                                   std::shared_ptr<Eigen::VectorXd>,
-                                   std::shared_ptr<Eigen::VectorXd>>>
+  mutable std::tuple<std::shared_ptr<Eigen::VectorXd>,
+                     std::shared_ptr<Eigen::VectorXd>,
+                     std::shared_ptr<Eigen::VectorXd>>
       _cached_four_center_integrals;
 
   /** Build four-center integrals from three-center integrals and cache them */

--- a/cpp/include/qdk/chemistry/data/hamiltonian_containers/cholesky.hpp
+++ b/cpp/include/qdk/chemistry/data/hamiltonian_containers/cholesky.hpp
@@ -26,6 +26,8 @@ namespace qdk::chemistry::data {
  * contains:
  * - Three-center two-electron integrals (electron-electron repulsion) in MO
  * representation.
+ * - Optionally, AO Cholesky vectors for potential reuse in further
+ * transformations.
  *
  */
 class CholeskyHamiltonianContainer : public HamiltonianContainer {
@@ -136,7 +138,8 @@ class CholeskyHamiltonianContainer : public HamiltonianContainer {
   /**
    * @brief Get the optional AO Cholesky vectors
    * @return Const reference to the optional AO Cholesky vectors matrix
-   * [nao^2 x nchol]. Empty if not stored.
+   * [nao^2 x nchol]. Contains std::nullopt if AO Cholesky vectors were not
+   * provided at construction.
    */
   const std::optional<Eigen::MatrixXd>& get_ao_cholesky_vectors() const;
 

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.cpp
@@ -806,11 +806,12 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
       Eigen::MatrixXd H_active(nactive, nactive);
       H_active = Ca_active.transpose() * H_full * Ca_active;
       Eigen::MatrixXd dummy_fock = Eigen::MatrixXd::Zero(0, 0);
-      if (!_settings->get<bool>("store_cholesky_vectors")) {
+      if (_settings->get<bool>("store_ao_cholesky_vectors")) {
         return std::make_shared<data::Hamiltonian>(
-            std::make_unique<data::CanonicalFourCenterHamiltonianContainer>(
-                H_active, moeri_aaaa, orbitals,
-                structure->calculate_nuclear_repulsion_energy(), dummy_fock));
+            std::make_unique<data::CholeskyHamiltonianContainer>(
+                H_active, L_mo, orbitals,
+                structure->calculate_nuclear_repulsion_energy(), dummy_fock,
+                L_ao));
       }
       return std::make_shared<data::Hamiltonian>(
           std::make_unique<data::CholeskyHamiltonianContainer>(
@@ -824,13 +825,12 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
       H_active_beta = Cb_active.transpose() * H_full * Cb_active;
       Eigen::MatrixXd dummy_fock_alpha = Eigen::MatrixXd::Zero(0, 0);
       Eigen::MatrixXd dummy_fock_beta = Eigen::MatrixXd::Zero(0, 0);
-      if (!_settings->get<bool>("store_cholesky_vectors")) {
+      if (_settings->get<bool>("store_ao_cholesky_vectors")) {
         return std::make_shared<data::Hamiltonian>(
-            std::make_unique<data::CanonicalFourCenterHamiltonianContainer>(
-                H_active_alpha, H_active_beta, moeri_aaaa, moeri_aabb,
-                moeri_bbbb, orbitals,
+            std::make_unique<data::CholeskyHamiltonianContainer>(
+                H_active_alpha, H_active_beta, L_mo_alpha, L_mo_beta, orbitals,
                 structure->calculate_nuclear_repulsion_energy(),
-                dummy_fock_alpha, dummy_fock_beta));
+                dummy_fock_alpha, dummy_fock_beta, Eigen::MatrixXd(L_ao)));
       }
       return std::make_shared<data::Hamiltonian>(
           std::make_unique<data::CholeskyHamiltonianContainer>(
@@ -894,12 +894,12 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
       }
     }
 
-    if (!_settings->get<bool>("store_cholesky_vectors")) {
+    if (_settings->get<bool>("store_ao_cholesky_vectors")) {
       return std::make_shared<data::Hamiltonian>(
-          std::make_unique<data::CanonicalFourCenterHamiltonianContainer>(
-              H_active, moeri_aaaa, orbitals,
+          std::make_unique<data::CholeskyHamiltonianContainer>(
+              H_active, L_mo, orbitals,
               E_inactive + structure->calculate_nuclear_repulsion_energy(),
-              F_inactive));
+              F_inactive, Eigen::MatrixXd(L_ao)));
     }
     return std::make_shared<data::Hamiltonian>(
         std::make_unique<data::CholeskyHamiltonianContainer>(
@@ -1006,13 +1006,12 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
       }
     }
 
-    if (!_settings->get<bool>("store_cholesky_vectors")) {
+    if (_settings->get<bool>("store_ao_cholesky_vectors")) {
       return std::make_shared<data::Hamiltonian>(
-          std::make_unique<data::CanonicalFourCenterHamiltonianContainer>(
-              H_active_alpha, H_active_beta, moeri_aaaa, moeri_aabb, moeri_bbbb,
-              orbitals,
+          std::make_unique<data::CholeskyHamiltonianContainer>(
+              H_active_alpha, H_active_beta, L_mo_alpha, L_mo_beta, orbitals,
               E_inactive + structure->calculate_nuclear_repulsion_energy(),
-              F_inactive_alpha, F_inactive_beta));
+              F_inactive_alpha, F_inactive_beta, Eigen::MatrixXd(L_ao)));
     }
     return std::make_shared<data::Hamiltonian>(
         std::make_unique<data::CholeskyHamiltonianContainer>(

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.cpp
@@ -781,7 +781,7 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
             std::make_unique<data::CholeskyHamiltonianContainer>(
                 H_active, L_mo, orbitals,
                 structure->calculate_nuclear_repulsion_energy(), dummy_fock,
-                Eigen::MatrixXd(L_ao)));
+                L_ao));
       }
       return std::make_shared<data::Hamiltonian>(
           std::make_unique<data::CholeskyHamiltonianContainer>(
@@ -800,7 +800,7 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
             std::make_unique<data::CholeskyHamiltonianContainer>(
                 H_active_alpha, H_active_beta, L_mo_alpha, L_mo_beta, orbitals,
                 structure->calculate_nuclear_repulsion_energy(),
-                dummy_fock_alpha, dummy_fock_beta, Eigen::MatrixXd(L_ao)));
+                dummy_fock_alpha, dummy_fock_beta, L_ao));
       }
       return std::make_shared<data::Hamiltonian>(
           std::make_unique<data::CholeskyHamiltonianContainer>(
@@ -869,7 +869,7 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
           std::make_unique<data::CholeskyHamiltonianContainer>(
               H_active, L_mo, orbitals,
               E_inactive + structure->calculate_nuclear_repulsion_energy(),
-              F_inactive, Eigen::MatrixXd(L_ao)));
+              F_inactive, L_ao));
     }
     return std::make_shared<data::Hamiltonian>(
         std::make_unique<data::CholeskyHamiltonianContainer>(
@@ -981,7 +981,7 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
           std::make_unique<data::CholeskyHamiltonianContainer>(
               H_active_alpha, H_active_beta, L_mo_alpha, L_mo_beta, orbitals,
               E_inactive + structure->calculate_nuclear_repulsion_energy(),
-              F_inactive_alpha, F_inactive_beta, Eigen::MatrixXd(L_ao)));
+              F_inactive_alpha, F_inactive_beta, L_ao));
     }
     return std::make_shared<data::Hamiltonian>(
         std::make_unique<data::CholeskyHamiltonianContainer>(

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.cpp
@@ -768,16 +768,18 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
     output_matrix.noalias() = L_left * L_right.transpose();
   };
 
+  Eigen::MatrixXd L_mo;
+  Eigen::MatrixXd L_mo_alpha;
+  Eigen::MatrixXd L_mo_beta;
+
   if (is_restricted_calc) {
     // Transform to MO
-    Eigen::MatrixXd L_mo = detail::transform_cholesky_to_mo(L_ao, Ca_active);
+    L_mo = detail::transform_cholesky_to_mo(L_ao, Ca_active);
     reconstruct_eris(L_mo, L_mo, moeri_aaaa);
   } else {
     // Transform to MO (Alpha and Beta)
-    Eigen::MatrixXd L_mo_alpha =
-        detail::transform_cholesky_to_mo(L_ao, Ca_active);
-    Eigen::MatrixXd L_mo_beta =
-        detail::transform_cholesky_to_mo(L_ao, Cb_active);
+    L_mo_alpha = detail::transform_cholesky_to_mo(L_ao, Ca_active);
+    L_mo_beta = detail::transform_cholesky_to_mo(L_ao, Cb_active);
 
     reconstruct_eris(L_mo_alpha, L_mo_alpha, moeri_aaaa);  // (aaaa)
     reconstruct_eris(L_mo_beta, L_mo_beta, moeri_bbbb);    // (bbbb)
@@ -812,9 +814,8 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
       }
       return std::make_shared<data::Hamiltonian>(
           std::make_unique<data::CholeskyHamiltonianContainer>(
-              H_active, moeri_aaaa, orbitals,
-              structure->calculate_nuclear_repulsion_energy(), dummy_fock,
-              L_ao));
+              H_active, L_mo, orbitals,
+              structure->calculate_nuclear_repulsion_energy(), dummy_fock));
     } else {
       // Use unrestricted constructor
       Eigen::MatrixXd H_active_alpha(nactive, nactive);
@@ -833,9 +834,9 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
       }
       return std::make_shared<data::Hamiltonian>(
           std::make_unique<data::CholeskyHamiltonianContainer>(
-              H_active_alpha, H_active_beta, moeri_aaaa, moeri_aabb, moeri_bbbb,
-              orbitals, structure->calculate_nuclear_repulsion_energy(),
-              dummy_fock_alpha, dummy_fock_beta, L_ao));
+              H_active_alpha, H_active_beta, L_mo_alpha, L_mo_beta, orbitals,
+              structure->calculate_nuclear_repulsion_energy(), dummy_fock_alpha,
+              dummy_fock_beta));
     }
   }
 
@@ -902,9 +903,9 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
     }
     return std::make_shared<data::Hamiltonian>(
         std::make_unique<data::CholeskyHamiltonianContainer>(
-            H_active, moeri_aaaa, orbitals,
+            H_active, L_mo, orbitals,
             E_inactive + structure->calculate_nuclear_repulsion_energy(),
-            F_inactive, L_ao));
+            F_inactive));
   } else {
     // Unrestricted case
 
@@ -1015,10 +1016,9 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
     }
     return std::make_shared<data::Hamiltonian>(
         std::make_unique<data::CholeskyHamiltonianContainer>(
-            H_active_alpha, H_active_beta, moeri_aaaa, moeri_aabb, moeri_bbbb,
-            orbitals,
+            H_active_alpha, H_active_beta, L_mo_alpha, L_mo_beta, orbitals,
             E_inactive + structure->calculate_nuclear_repulsion_energy(),
-            F_inactive_alpha, F_inactive_beta, L_ao));
+            F_inactive_alpha, F_inactive_beta));
   }
 }
 }  // namespace qdk::chemistry::algorithms::microsoft

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.cpp
@@ -730,16 +730,6 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
   // Compute integrals (same size for alpha and beta)
   const size_t nactive = nactive_alpha;
 
-  // Declare MOERI vectors
-  Eigen::VectorXd moeri_aaaa;
-  Eigen::VectorXd moeri_aabb;
-  Eigen::VectorXd moeri_bbbb;
-
-  const size_t moeri_size = nactive * nactive * nactive * nactive;
-
-  // Store Cholesky vectors for later use in inactive space computation
-  // Eigen::MatrixXd L_ao;
-
   // Use Cholesky Decomposition
   double cholesky_tol = _settings->get<double>("cholesky_tolerance");
   double eri_tol = _settings->get<double>("eri_threshold");
@@ -752,21 +742,6 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
   Eigen::Map<const Eigen::MatrixXd> L_ao(
       output.data(), num_atomic_orbitals * num_atomic_orbitals,
       num_cholesky_vectors);
-  // L_ao = L_ao_map;
-  /**
-   * @brief Reconstruct MO ERIs from Cholesky vectors
-   * @param L_left Left Cholesky vectors in MO basis
-   * @param L_right Right Cholesky vectors in MO basis
-   * @param output Output vector to store reconstructed ERIs
-   */
-  auto reconstruct_eris = [moeri_size](const Eigen::MatrixXd& L_left,
-                                       const Eigen::MatrixXd& L_right,
-                                       Eigen::VectorXd& output) {
-    output.resize(moeri_size);
-    size_t n = L_left.rows();  // n_mo * n_mo
-    Eigen::Map<Eigen::MatrixXd> output_matrix(output.data(), n, n);
-    output_matrix.noalias() = L_left * L_right.transpose();
-  };
 
   Eigen::MatrixXd L_mo;
   Eigen::MatrixXd L_mo_alpha;
@@ -775,15 +750,10 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
   if (is_restricted_calc) {
     // Transform to MO
     L_mo = detail::transform_cholesky_to_mo(L_ao, Ca_active);
-    reconstruct_eris(L_mo, L_mo, moeri_aaaa);
   } else {
     // Transform to MO (Alpha and Beta)
     L_mo_alpha = detail::transform_cholesky_to_mo(L_ao, Ca_active);
     L_mo_beta = detail::transform_cholesky_to_mo(L_ao, Cb_active);
-
-    reconstruct_eris(L_mo_alpha, L_mo_alpha, moeri_aaaa);  // (aaaa)
-    reconstruct_eris(L_mo_beta, L_mo_beta, moeri_bbbb);    // (bbbb)
-    reconstruct_eris(L_mo_beta, L_mo_alpha, moeri_aabb);   // (aabb)
   }
 
   // Get inactive space indices for both alpha and beta
@@ -811,7 +781,7 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
             std::make_unique<data::CholeskyHamiltonianContainer>(
                 H_active, L_mo, orbitals,
                 structure->calculate_nuclear_repulsion_energy(), dummy_fock,
-                L_ao));
+                Eigen::MatrixXd(L_ao)));
       }
       return std::make_shared<data::Hamiltonian>(
           std::make_unique<data::CholeskyHamiltonianContainer>(

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.hpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.hpp
@@ -59,7 +59,7 @@ class CholeskyHamiltonianSettings : public qdk::chemistry::data::Settings {
                 "ERI screening threshold for skipping negligible shell "
                 "quartets during Cholesky decomposition",
                 qdk::chemistry::data::BoundConstraint<double>{0.0, 1.0});
-    set_default("store_cholesky_vectors", false);
+    set_default("store_cholesky_vectors", true);
   }
   ~CholeskyHamiltonianSettings() override = default;
 };

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.hpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.hpp
@@ -59,7 +59,7 @@ class CholeskyHamiltonianSettings : public qdk::chemistry::data::Settings {
                 "ERI screening threshold for skipping negligible shell "
                 "quartets during Cholesky decomposition",
                 qdk::chemistry::data::BoundConstraint<double>{0.0, 1.0});
-    set_default("store_cholesky_vectors", true);
+    set_default("store_ao_cholesky_vectors", false);
   }
   ~CholeskyHamiltonianSettings() override = default;
 };

--- a/cpp/src/qdk/chemistry/data/hamiltonian.cpp
+++ b/cpp/src/qdk/chemistry/data/hamiltonian.cpp
@@ -4,7 +4,9 @@
 
 #include <algorithm>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
+#include <limits>
 #include <macis/util/fcidump.hpp>
 #include <qdk/chemistry/data/hamiltonian.hpp>
 #include <qdk/chemistry/data/hamiltonian_containers/canonical_four_center.hpp>
@@ -293,6 +295,116 @@ HamiltonianContainer::make_restricted_inactive_fock_matrix(
   return std::make_pair(
       shared_matrix,
       shared_matrix);  // Both alpha and beta point to same data
+}
+
+void HamiltonianContainer::to_fcidump_file(const std::string& filename,
+                                           size_t nalpha,
+                                           size_t nbeta) const {
+  QDK_LOG_TRACE_ENTERING();
+
+  if (is_unrestricted()) {
+    throw std::runtime_error(
+        "FCIDUMP format is not supported for unrestricted Hamiltonians.");
+  }
+
+  std::ofstream file(filename);
+  if (!file.is_open()) {
+    throw std::runtime_error("Cannot open file for writing: " + filename);
+  }
+
+  size_t num_molecular_orbitals;
+  if (has_orbitals()) {
+    if (_orbitals->has_active_space()) {
+      auto active_indices = _orbitals->get_active_space_indices();
+      size_t n_active_alpha = active_indices.first.size();
+      size_t n_active_beta = active_indices.second.size();
+
+      if (n_active_alpha != n_active_beta) {
+        throw std::invalid_argument(
+            "For restricted Hamiltonian, alpha and beta active spaces must "
+            "have same size");
+      }
+      num_molecular_orbitals = n_active_alpha;
+    } else {
+      num_molecular_orbitals = _orbitals->get_num_molecular_orbitals();
+    }
+  } else {
+    throw std::runtime_error("Orbitals are not set");
+  }
+
+  const size_t nelec = nalpha + nbeta;
+  const size_t num_molecular_orbitals2 =
+      num_molecular_orbitals * num_molecular_orbitals;
+  const size_t num_molecular_orbitals3 =
+      num_molecular_orbitals2 * num_molecular_orbitals;
+  const double print_thresh = std::numeric_limits<double>::epsilon();
+
+  // C1 symmetry
+  std::string orb_string;
+  for (size_t i = 0; i < num_molecular_orbitals - 1; ++i) {
+    orb_string += "1,";
+  }
+  orb_string += "1";
+
+  // Write header
+  file << "&FCI ";
+  file << "NORB=" << num_molecular_orbitals << ", ";
+  file << "NELEC=" << nelec << ", ";
+  file << "MS2=" << (nalpha - nbeta) << ",\n";
+  file << "ORBSYM=" << orb_string << ",\n";
+  file << "ISYM=1,\n";
+  file << "&END\n";
+
+  auto formatted_line = [&](size_t i, size_t j, size_t k, size_t l,
+                            double val) {
+    if (std::abs(val) < print_thresh) return;
+
+    file << std::setw(28) << std::scientific << std::setprecision(16)
+         << std::right << val << " ";
+    file << std::setw(4) << i << " ";
+    file << std::setw(4) << j << " ";
+    file << std::setw(4) << k << " ";
+    file << std::setw(4) << l;
+  };
+
+  // Get the two-electron integrals via the virtual accessor
+  auto [eri_aaaa, eri_aabb, eri_bbbb] = get_two_body_integrals();
+
+  auto write_eri = [&](size_t i, size_t j, size_t k, size_t l) {
+    auto eri =
+        eri_aaaa(i * num_molecular_orbitals3 + j * num_molecular_orbitals2 +
+                 k * num_molecular_orbitals + l);
+
+    formatted_line(i + 1, j + 1, k + 1, l + 1, eri);
+    file << "\n";
+  };
+
+  auto write_1body = [&](size_t i, size_t j) {
+    auto hel = (*_one_body_integrals.first)(i, j);
+
+    formatted_line(i + 1, j + 1, 0, 0, hel);
+    file << "\n";
+  };
+
+  // Write permutationally unique MO ERIs
+  for (size_t i = 0, ij = 0; i < num_molecular_orbitals; ++i)
+    for (size_t j = i; j < num_molecular_orbitals; ++j, ij++) {
+      for (size_t k = 0, kl = 0; k < num_molecular_orbitals; ++k)
+        for (size_t l = k; l < num_molecular_orbitals; ++l, kl++) {
+          if (ij <= kl) {
+            write_eri(i, j, k, l);
+          }
+        }
+    }
+
+  // Write permutationally unique MO 1-body integrals
+  for (size_t i = 0; i < num_molecular_orbitals; ++i)
+    for (size_t j = 0; j <= i; ++j) {
+      write_1body(i, j);
+    }
+
+  // Write core energy
+  formatted_line(0, 0, 0, 0, _core_energy);
 }
 
 std::string Hamiltonian::get_summary() const {

--- a/cpp/src/qdk/chemistry/data/hamiltonian.cpp
+++ b/cpp/src/qdk/chemistry/data/hamiltonian.cpp
@@ -298,8 +298,7 @@ HamiltonianContainer::make_restricted_inactive_fock_matrix(
 }
 
 void HamiltonianContainer::to_fcidump_file(const std::string& filename,
-                                           size_t nalpha,
-                                           size_t nbeta) const {
+                                           size_t nalpha, size_t nbeta) const {
   QDK_LOG_TRACE_ENTERING();
 
   if (is_unrestricted()) {

--- a/cpp/src/qdk/chemistry/data/hamiltonian_containers/canonical_four_center.cpp
+++ b/cpp/src/qdk/chemistry/data/hamiltonian_containers/canonical_four_center.cpp
@@ -226,12 +226,6 @@ CanonicalFourCenterHamiltonianContainer::make_restricted_two_body_integrals(
       shared_integrals);  // aaaa, aabb, bbbb all point to same data
 }
 
-void CanonicalFourCenterHamiltonianContainer::to_fcidump_file(
-    const std::string& filename, size_t nalpha, size_t nbeta) const {
-  QDK_LOG_TRACE_ENTERING();
-  _to_fcidump_file(filename, nalpha, nbeta);
-}
-
 nlohmann::json CanonicalFourCenterHamiltonianContainer::to_json() const {
   QDK_LOG_TRACE_ENTERING();
   nlohmann::json j;
@@ -726,115 +720,6 @@ CanonicalFourCenterHamiltonianContainer::from_hdf5(H5::Group& group) {
   } catch (const H5::Exception& e) {
     throw std::runtime_error("HDF5 error: " + std::string(e.getCDetailMsg()));
   }
-}
-
-void CanonicalFourCenterHamiltonianContainer::_to_fcidump_file(
-    const std::string& filename, size_t nalpha, size_t nbeta) const {
-  QDK_LOG_TRACE_ENTERING();
-  // Check if this is an unrestricted Hamiltonian and throw error
-  if (is_unrestricted()) {
-    throw std::runtime_error(
-        "FCIDUMP format is not supported for unrestricted Hamiltonians.");
-  }
-
-  std::ofstream file(filename);
-  if (!file.is_open()) {
-    throw std::runtime_error("Cannot open file for writing: " + filename);
-  }
-
-  size_t num_molecular_orbitals;
-  if (has_orbitals()) {
-    if (_orbitals->has_active_space()) {
-      auto active_indices = _orbitals->get_active_space_indices();
-      size_t n_active_alpha = active_indices.first.size();
-      size_t n_active_beta = active_indices.second.size();
-
-      // For restricted case, alpha and beta should be the same
-      if (n_active_alpha != n_active_beta) {
-        throw std::invalid_argument(
-            "For restricted Hamiltonian, alpha and beta active spaces must "
-            "have "
-            "same size");
-      }
-      num_molecular_orbitals =
-          n_active_alpha;  // Can use either alpha or beta since they're equal
-    } else {
-      num_molecular_orbitals = _orbitals->get_num_molecular_orbitals();
-    }
-  } else {
-    throw std::runtime_error("Orbitals are not set");
-  }
-
-  const size_t nelec = nalpha + nbeta;
-  const size_t num_molecular_orbitals2 =
-      num_molecular_orbitals * num_molecular_orbitals;
-  const size_t num_molecular_orbitals3 =
-      num_molecular_orbitals2 * num_molecular_orbitals;
-  const double print_thresh = std::numeric_limits<double>::epsilon();
-
-  // We don't use symmetry, so populate with C1 data
-  std::string orb_string;
-  for (auto i = 0ul; i < num_molecular_orbitals - 1; ++i) {
-    orb_string += "1,";
-  }
-  orb_string += "1";
-
-  // Write the header of the FCIDUMP file
-  file << "&FCI ";
-  file << "NORB=" << num_molecular_orbitals << ", ";
-  file << "NELEC=" << nelec << ", ";
-  file << "MS2=" << (nalpha - nbeta) << ",\n";
-  file << "ORBSYM=" << orb_string << ",\n";
-  file << "ISYM=1,\n";
-  file << "&END\n";
-
-  auto formatted_line = [&](size_t i, size_t j, size_t k, size_t l,
-                            double val) {
-    if (std::abs(val) < print_thresh) return;
-
-    file << std::setw(28) << std::scientific << std::setprecision(16)
-         << std::right << val << " ";
-    file << std::setw(4) << i << " ";
-    file << std::setw(4) << j << " ";
-    file << std::setw(4) << k << " ";
-    file << std::setw(4) << l;
-  };
-
-  auto write_eri = [&](size_t i, size_t j, size_t k, size_t l) {
-    auto eri = (*std::get<0>(_two_body_integrals))(
-        i * num_molecular_orbitals3 + j * num_molecular_orbitals2 +
-        k * num_molecular_orbitals + l);
-
-    formatted_line(i + 1, j + 1, k + 1, l + 1, eri);
-    file << "\n";
-  };
-
-  auto write_1body = [&](size_t i, size_t j) {
-    auto hel = (*_one_body_integrals.first)(i, j);
-
-    formatted_line(i + 1, j + 1, 0, 0, hel);
-    file << "\n";
-  };
-
-  // Write permutationally unique MO ERIs
-  for (size_t i = 0, ij = 0; i < num_molecular_orbitals; ++i)
-    for (size_t j = i; j < num_molecular_orbitals; ++j, ij++) {
-      for (size_t k = 0, kl = 0; k < num_molecular_orbitals; ++k)
-        for (size_t l = k; l < num_molecular_orbitals; ++l, kl++) {
-          if (ij <= kl) {
-            write_eri(i, j, k, l);
-          }
-        }  // kl loop
-    }  // ij loop
-
-  // Write permutationally unique MO 1-body integrals
-  for (size_t i = 0; i < num_molecular_orbitals; ++i)
-    for (size_t j = 0; j <= i; ++j) {
-      write_1body(i, j);
-    }
-
-  // Write core energy
-  formatted_line(0, 0, 0, 0, _core_energy);
 }
 
 }  // namespace qdk::chemistry::data

--- a/cpp/src/qdk/chemistry/data/hamiltonian_containers/cholesky.cpp
+++ b/cpp/src/qdk/chemistry/data/hamiltonian_containers/cholesky.cpp
@@ -27,11 +27,13 @@ CholeskyHamiltonianContainer::CholeskyHamiltonianContainer(
     const Eigen::MatrixXd& one_body_integrals,
     const Eigen::MatrixXd& three_center_integrals,
     std::shared_ptr<Orbitals> orbitals, double core_energy,
-    const Eigen::MatrixXd& inactive_fock_matrix, HamiltonianType type)
+    const Eigen::MatrixXd& inactive_fock_matrix,
+    std::optional<Eigen::MatrixXd> ao_cholesky_vectors, HamiltonianType type)
     : HamiltonianContainer(one_body_integrals, orbitals, core_energy,
                            inactive_fock_matrix, type),
       _three_center_integrals(
-          make_restricted_three_center_integrals(three_center_integrals)) {
+          make_restricted_three_center_integrals(three_center_integrals)),
+      _ao_cholesky_vectors(std::move(ao_cholesky_vectors)) {
   QDK_LOG_TRACE_ENTERING();
 
   validate_integral_dimensions();
@@ -51,13 +53,15 @@ CholeskyHamiltonianContainer::CholeskyHamiltonianContainer(
     const Eigen::MatrixXd& three_center_integrals_bb,
     std::shared_ptr<Orbitals> orbitals, double core_energy,
     const Eigen::MatrixXd& inactive_fock_matrix_alpha,
-    const Eigen::MatrixXd& inactive_fock_matrix_beta, HamiltonianType type)
+    const Eigen::MatrixXd& inactive_fock_matrix_beta,
+    std::optional<Eigen::MatrixXd> ao_cholesky_vectors, HamiltonianType type)
     : HamiltonianContainer(one_body_integrals_alpha, one_body_integrals_beta,
                            orbitals, core_energy, inactive_fock_matrix_alpha,
                            inactive_fock_matrix_beta, type),
       _three_center_integrals(
           std::make_unique<Eigen::MatrixXd>(three_center_integrals_aa),
-          std::make_unique<Eigen::MatrixXd>(three_center_integrals_bb)) {
+          std::make_unique<Eigen::MatrixXd>(three_center_integrals_bb)),
+      _ao_cholesky_vectors(std::move(ao_cholesky_vectors)) {
   QDK_LOG_TRACE_ENTERING();
 
   validate_integral_dimensions();
@@ -76,13 +80,14 @@ std::unique_ptr<HamiltonianContainer> CholeskyHamiltonianContainer::clone()
   if (is_restricted()) {
     return std::make_unique<CholeskyHamiltonianContainer>(
         *_one_body_integrals.first, *_three_center_integrals.first, _orbitals,
-        _core_energy, *_inactive_fock_matrix.first, _type);
+        _core_energy, *_inactive_fock_matrix.first, _ao_cholesky_vectors,
+        _type);
   }
   return std::make_unique<CholeskyHamiltonianContainer>(
       *_one_body_integrals.first, *_one_body_integrals.second,
       *_three_center_integrals.first, *_three_center_integrals.second,
       _orbitals, _core_energy, *_inactive_fock_matrix.first,
-      *_inactive_fock_matrix.second, _type);
+      *_inactive_fock_matrix.second, _ao_cholesky_vectors, _type);
 }
 
 std::string CholeskyHamiltonianContainer::get_container_type() const {
@@ -161,6 +166,12 @@ CholeskyHamiltonianContainer::get_three_center_integrals() const {
   }
   return std::make_pair(std::cref(*_three_center_integrals.first),
                         std::cref(*_three_center_integrals.second));
+}
+
+const std::optional<Eigen::MatrixXd>&
+CholeskyHamiltonianContainer::get_ao_cholesky_vectors() const {
+  QDK_LOG_TRACE_ENTERING();
+  return _ao_cholesky_vectors;
 }
 
 double CholeskyHamiltonianContainer::get_two_body_element(
@@ -404,6 +415,17 @@ nlohmann::json CholeskyHamiltonianContainer::to_json() const {
     j["has_orbitals"] = false;
   }
 
+  if (_ao_cholesky_vectors) {
+    std::vector<std::vector<double>> ao_cholesky_vectors_vec;
+    for (int i = 0; i < _ao_cholesky_vectors->rows(); ++i) {
+      std::vector<double> row;
+      for (int j_idx = 0; j_idx < _ao_cholesky_vectors->cols(); ++j_idx) {
+        row.push_back((*_ao_cholesky_vectors)(i, j_idx));
+      }
+      ao_cholesky_vectors_vec.push_back(row);
+    }
+    j["ao_cholesky_vectors"] = ao_cholesky_vectors_vec;
+  }
   return j;
 }
 
@@ -537,18 +559,24 @@ CholeskyHamiltonianContainer::from_json(const nlohmann::json& j) {
       }
     }
 
+    std::optional<Eigen::MatrixXd> ao_cholesky_vectors;
+    if (j.contains("ao_cholesky_vectors")) {
+      ao_cholesky_vectors = load_matrix(j["ao_cholesky_vectors"]);
+    }
+
     // Create and return appropriate Hamiltonian using the correct constructor
     if (is_restricted_data) {
       // Use restricted constructor - it will create shared pointers internally
       // so alpha and beta point to the same data
       return std::make_unique<CholeskyHamiltonianContainer>(
           one_body_alpha, three_center_aa, orbitals, core_energy,
-          inactive_fock_alpha, type);
+          inactive_fock_alpha, std::move(ao_cholesky_vectors), type);
     } else {
       // Use unrestricted constructor with separate alpha and beta data
       return std::make_unique<CholeskyHamiltonianContainer>(
           one_body_alpha, one_body_beta, three_center_aa, three_center_bb,
-          orbitals, core_energy, inactive_fock_alpha, inactive_fock_beta, type);
+          orbitals, core_energy, inactive_fock_alpha, inactive_fock_beta,
+          std::move(ao_cholesky_vectors), type);
     }
 
   } catch (const std::exception& e) {
@@ -742,6 +770,10 @@ void CholeskyHamiltonianContainer::to_hdf5(H5::Group& group) const {
       _orbitals->to_hdf5(orbitals_group);
     }
 
+    if (_ao_cholesky_vectors) {
+      save_matrix_to_group(group, "ao_cholesky_vectors", *_ao_cholesky_vectors);
+    }
+
   } catch (const H5::Exception& e) {
     throw std::runtime_error("HDF5 error: " + std::string(e.getCDetailMsg()));
   }
@@ -849,17 +881,25 @@ CholeskyHamiltonianContainer::from_hdf5(H5::Group& group) {
           load_matrix_from_group(group, "inactive_fock_matrix_beta");
     }
 
+    // Load AO Cholesky vectors
+    std::optional<Eigen::MatrixXd> ao_cholesky_vectors;
+    if (dataset_exists_in_group(group, "ao_cholesky_vectors")) {
+      ao_cholesky_vectors =
+          load_matrix_from_group(group, "ao_cholesky_vectors");
+    }
+
     // Create and return appropriate Hamiltonian using the correct constructor
     if (is_restricted_data) {
       // Use restricted constructor - it will create shared pointers internally
       return std::make_unique<CholeskyHamiltonianContainer>(
           one_body_alpha, three_center_aa, orbitals, core_energy,
-          inactive_fock_alpha, type);
+          inactive_fock_alpha, std::move(ao_cholesky_vectors), type);
     } else {
       // Use unrestricted constructor with separate alpha and beta data
       return std::make_unique<CholeskyHamiltonianContainer>(
           one_body_alpha, one_body_beta, three_center_aa, three_center_bb,
-          orbitals, core_energy, inactive_fock_alpha, inactive_fock_beta, type);
+          orbitals, core_energy, inactive_fock_alpha, inactive_fock_beta,
+          std::move(ao_cholesky_vectors), type);
     }
 
   } catch (const H5::Exception& e) {

--- a/cpp/src/qdk/chemistry/data/hamiltonian_containers/cholesky.cpp
+++ b/cpp/src/qdk/chemistry/data/hamiltonian_containers/cholesky.cpp
@@ -153,8 +153,8 @@ void CholeskyHamiltonianContainer::_build_four_center_cache() const {
                                   _three_center_integrals.second);
     auto bbbb = build_four_center(_three_center_integrals.second,
                                   _three_center_integrals.second);
-    _cached_four_center_integrals = std::make_tuple(std::move(aaaa), std::move(aabb),
-                                                    std::move(bbbb));
+    _cached_four_center_integrals =
+        std::make_tuple(std::move(aaaa), std::move(aabb), std::move(bbbb));
   }
 }
 

--- a/cpp/src/qdk/chemistry/data/hamiltonian_containers/cholesky.cpp
+++ b/cpp/src/qdk/chemistry/data/hamiltonian_containers/cholesky.cpp
@@ -344,7 +344,7 @@ nlohmann::json CholeskyHamiltonianContainer::to_json() const {
   if (has_two_body_integrals()) {
     j["has_two_body_integrals"] = true;
 
-    // Store as object {"aa": [...], "ab": [...], "bb": [...]}
+    // Store as object {"aa": [...], "bb": [...]}
     nlohmann::json two_body_obj;
 
     // Store aa
@@ -358,18 +358,20 @@ nlohmann::json CholeskyHamiltonianContainer::to_json() const {
       three_center_aa_vec.push_back(row);
     }
     two_body_obj["aa"] = three_center_aa_vec;
-    // Store bb
-    std::vector<std::vector<double>> three_center_bb_vec;
-    for (int i = 0; i < _three_center_integrals.second->rows(); ++i) {
-      std::vector<double> row;
-      for (int j_idx = 0; j_idx < _three_center_integrals.second->cols();
-           ++j_idx) {
-        row.push_back((*_three_center_integrals.second)(i, j_idx));
-      }
-      three_center_bb_vec.push_back(row);
-    }
-    two_body_obj["bb"] = three_center_bb_vec;
 
+    if (is_unrestricted()) {
+      // Store bb
+      std::vector<std::vector<double>> three_center_bb_vec;
+      for (int i = 0; i < _three_center_integrals.second->rows(); ++i) {
+        std::vector<double> row;
+        for (int j_idx = 0; j_idx < _three_center_integrals.second->cols();
+             ++j_idx) {
+          row.push_back((*_three_center_integrals.second)(i, j_idx));
+        }
+        three_center_bb_vec.push_back(row);
+      }
+      two_body_obj["bb"] = three_center_bb_vec;
+    }
     j["three_center_integrals"] = two_body_obj;
   } else {
     j["has_two_body_integrals"] = false;
@@ -504,13 +506,20 @@ CholeskyHamiltonianContainer::from_json(const nlohmann::json& j) {
             "keys");
       }
 
-      if (!two_body_obj.contains("aa") || !two_body_obj.contains("bb")) {
+      if (!two_body_obj.contains("aa")) {
         throw std::runtime_error(
-            "three_center_integrals must contain aa and bb keys");
+            "three_center_integrals must contain at least aa key");
       }
 
       three_center_aa = load_matrix(two_body_obj["aa"]);
-      three_center_bb = load_matrix(two_body_obj["bb"]);
+      if (!is_restricted_data) {
+        if (!two_body_obj.contains("bb")) {
+          throw std::runtime_error(
+              "three_center_integrals must contain bb key for unrestricted "
+              "Hamiltonian");
+        }
+        three_center_bb = load_matrix(two_body_obj["bb"]);
+      }
     }
 
     // Load inactive Fock matrix

--- a/cpp/src/qdk/chemistry/data/hamiltonian_containers/cholesky.cpp
+++ b/cpp/src/qdk/chemistry/data/hamiltonian_containers/cholesky.cpp
@@ -104,14 +104,14 @@ CholeskyHamiltonianContainer::get_two_body_integrals() const {
   }
 
   // Lazily build and cache the four-center integrals on first access
-  if (!_cached_four_center_integrals) {
+  if (!std::get<0>(_cached_four_center_integrals)) {
     _build_four_center_cache();
   }
 
   return std::make_tuple(
-      std::cref(*std::get<0>(*_cached_four_center_integrals)),
-      std::cref(*std::get<1>(*_cached_four_center_integrals)),
-      std::cref(*std::get<2>(*_cached_four_center_integrals)));
+      std::cref(*std::get<0>(_cached_four_center_integrals)),
+      std::cref(*std::get<1>(_cached_four_center_integrals)),
+      std::cref(*std::get<2>(_cached_four_center_integrals)));
 }
 
 void CholeskyHamiltonianContainer::_build_four_center_cache() const {
@@ -147,14 +147,14 @@ void CholeskyHamiltonianContainer::_build_four_center_cache() const {
                                 _three_center_integrals.first);
 
   if (is_restricted()) {
-    _cached_four_center_integrals.emplace(aaaa, aaaa, aaaa);
+    _cached_four_center_integrals = std::make_tuple(aaaa, aaaa, aaaa);
   } else {
     auto aabb = build_four_center(_three_center_integrals.first,
                                   _three_center_integrals.second);
     auto bbbb = build_four_center(_three_center_integrals.second,
                                   _three_center_integrals.second);
-    _cached_four_center_integrals.emplace(std::move(aaaa), std::move(aabb),
-                                          std::move(bbbb));
+    _cached_four_center_integrals = std::make_tuple(std::move(aaaa), std::move(aabb),
+                                                    std::move(bbbb));
   }
 }
 
@@ -187,7 +187,7 @@ double CholeskyHamiltonianContainer::get_two_body_element(
     throw std::out_of_range("Orbital index out of range");
   }
 
-  if (!_cached_four_center_integrals) {
+  if (!std::get<0>(_cached_four_center_integrals)) {
     _build_four_center_cache();
   }
 
@@ -197,14 +197,14 @@ double CholeskyHamiltonianContainer::get_two_body_element(
   // Select the appropriate integral based on spin channel
   switch (channel) {
     case SpinChannel::aaaa:
-      return (*std::get<0>(*_cached_four_center_integrals))(ij * norb * norb +
-                                                            kl);
+      return (*std::get<0>(_cached_four_center_integrals))(ij * norb * norb +
+                                                           kl);
     case SpinChannel::aabb:
-      return (*std::get<1>(*_cached_four_center_integrals))(ij * norb * norb +
-                                                            kl);
+      return (*std::get<1>(_cached_four_center_integrals))(ij * norb * norb +
+                                                           kl);
     case SpinChannel::bbbb:
-      return (*std::get<2>(*_cached_four_center_integrals))(ij * norb * norb +
-                                                            kl);
+      return (*std::get<2>(_cached_four_center_integrals))(ij * norb * norb +
+                                                           kl);
 
     default:
       throw std::invalid_argument("Invalid spin channel");
@@ -592,116 +592,6 @@ CholeskyHamiltonianContainer::from_json(const nlohmann::json& j) {
     throw std::runtime_error("Failed to parse Hamiltonian from JSON: " +
                              std::string(e.what()));
   }
-}
-
-void CholeskyHamiltonianContainer::to_fcidump_file(const std::string& filename,
-                                                   size_t nalpha,
-                                                   size_t nbeta) const {
-  QDK_LOG_TRACE_ENTERING();
-
-  if (is_unrestricted()) {
-    throw std::runtime_error(
-        "FCIDUMP format is not supported for unrestricted Hamiltonians.");
-  }
-
-  std::ofstream file(filename);
-  if (!file.is_open()) {
-    throw std::runtime_error("Cannot open file for writing: " + filename);
-  }
-
-  size_t num_molecular_orbitals;
-  if (has_orbitals()) {
-    if (_orbitals->has_active_space()) {
-      auto active_indices = _orbitals->get_active_space_indices();
-      size_t n_active_alpha = active_indices.first.size();
-      size_t n_active_beta = active_indices.second.size();
-
-      if (n_active_alpha != n_active_beta) {
-        throw std::invalid_argument(
-            "For restricted Hamiltonian, alpha and beta active spaces must "
-            "have same size");
-      }
-      num_molecular_orbitals = n_active_alpha;
-    } else {
-      num_molecular_orbitals = _orbitals->get_num_molecular_orbitals();
-    }
-  } else {
-    throw std::runtime_error("Orbitals are not set");
-  }
-
-  const size_t nelec = nalpha + nbeta;
-  const size_t num_molecular_orbitals2 =
-      num_molecular_orbitals * num_molecular_orbitals;
-  const size_t num_molecular_orbitals3 =
-      num_molecular_orbitals2 * num_molecular_orbitals;
-  const double print_thresh = std::numeric_limits<double>::epsilon();
-
-  // C1 symmetry
-  std::string orb_string;
-  for (size_t i = 0; i < num_molecular_orbitals - 1; ++i) {
-    orb_string += "1,";
-  }
-  orb_string += "1";
-
-  // Write header
-  file << "&FCI ";
-  file << "NORB=" << num_molecular_orbitals << ", ";
-  file << "NELEC=" << nelec << ", ";
-  file << "MS2=" << (nalpha - nbeta) << ",\n";
-  file << "ORBSYM=" << orb_string << ",\n";
-  file << "ISYM=1,\n";
-  file << "&END\n";
-
-  auto formatted_line = [&](size_t i, size_t j, size_t k, size_t l,
-                            double val) {
-    if (std::abs(val) < print_thresh) return;
-
-    file << std::setw(28) << std::scientific << std::setprecision(16)
-         << std::right << val << " ";
-    file << std::setw(4) << i << " ";
-    file << std::setw(4) << j << " ";
-    file << std::setw(4) << k << " ";
-    file << std::setw(4) << l;
-  };
-
-  // Get the lazily-computed four-center integrals
-  auto [eri_aaaa, eri_aabb, eri_bbbb] = get_two_body_integrals();
-
-  auto write_eri = [&](size_t i, size_t j, size_t k, size_t l) {
-    auto eri =
-        eri_aaaa(i * num_molecular_orbitals3 + j * num_molecular_orbitals2 +
-                 k * num_molecular_orbitals + l);
-
-    formatted_line(i + 1, j + 1, k + 1, l + 1, eri);
-    file << "\n";
-  };
-
-  auto write_1body = [&](size_t i, size_t j) {
-    auto hel = (*_one_body_integrals.first)(i, j);
-
-    formatted_line(i + 1, j + 1, 0, 0, hel);
-    file << "\n";
-  };
-
-  // Write permutationally unique MO ERIs
-  for (size_t i = 0, ij = 0; i < num_molecular_orbitals; ++i)
-    for (size_t j = i; j < num_molecular_orbitals; ++j, ij++) {
-      for (size_t k = 0, kl = 0; k < num_molecular_orbitals; ++k)
-        for (size_t l = k; l < num_molecular_orbitals; ++l, kl++) {
-          if (ij <= kl) {
-            write_eri(i, j, k, l);
-          }
-        }
-    }
-
-  // Write permutationally unique MO 1-body integrals
-  for (size_t i = 0; i < num_molecular_orbitals; ++i)
-    for (size_t j = 0; j <= i; ++j) {
-      write_1body(i, j);
-    }
-
-  // Write core energy
-  formatted_line(0, 0, 0, 0, _core_energy);
 }
 
 void CholeskyHamiltonianContainer::to_hdf5(H5::Group& group) const {

--- a/cpp/src/qdk/chemistry/data/hamiltonian_containers/cholesky.cpp
+++ b/cpp/src/qdk/chemistry/data/hamiltonian_containers/cholesky.cpp
@@ -3,9 +3,14 @@
 // license information.
 
 #include <algorithm>
+#include <blas.hh>
+#include <cstddef>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
+#include <limits>
 #include <macis/util/fcidump.hpp>
+#include <memory>
 #include <qdk/chemistry/data/hamiltonian_containers/cholesky.hpp>
 #include <qdk/chemistry/data/orbitals.hpp>
 #include <qdk/chemistry/utils/logger.hpp>
@@ -20,34 +25,49 @@ namespace qdk::chemistry::data {
 
 CholeskyHamiltonianContainer::CholeskyHamiltonianContainer(
     const Eigen::MatrixXd& one_body_integrals,
-    const Eigen::VectorXd& two_body_integrals,
+    const Eigen::MatrixXd& three_center_integrals,
     std::shared_ptr<Orbitals> orbitals, double core_energy,
-    const Eigen::MatrixXd& inactive_fock_matrix, const Eigen::MatrixXd& L_ao,
-    HamiltonianType type)
-    : CanonicalFourCenterHamiltonianContainer(
-          one_body_integrals, two_body_integrals, orbitals, core_energy,
-          inactive_fock_matrix, type),
-      _ao_cholesky_vectors(std::make_shared<Eigen::MatrixXd>(L_ao)) {
+    const Eigen::MatrixXd& inactive_fock_matrix, HamiltonianType type)
+    : HamiltonianContainer(one_body_integrals, orbitals, core_energy,
+                           inactive_fock_matrix, type),
+      _three_center_integrals(
+          make_restricted_three_center_integrals(three_center_integrals)) {
   QDK_LOG_TRACE_ENTERING();
+
+  validate_integral_dimensions();
+  validate_restrictedness_consistency();
+  validate_active_space_dimensions();
+
+  if (!is_valid()) {
+    throw std::invalid_argument(
+        "Tried to generate invalid Hamiltonian object.");
+  }
 }
 
 CholeskyHamiltonianContainer::CholeskyHamiltonianContainer(
     const Eigen::MatrixXd& one_body_integrals_alpha,
     const Eigen::MatrixXd& one_body_integrals_beta,
-    const Eigen::VectorXd& two_body_integrals_aaaa,
-    const Eigen::VectorXd& two_body_integrals_aabb,
-    const Eigen::VectorXd& two_body_integrals_bbbb,
+    const Eigen::MatrixXd& three_center_integrals_aa,
+    const Eigen::MatrixXd& three_center_integrals_bb,
     std::shared_ptr<Orbitals> orbitals, double core_energy,
     const Eigen::MatrixXd& inactive_fock_matrix_alpha,
-    const Eigen::MatrixXd& inactive_fock_matrix_beta,
-    const Eigen::MatrixXd& L_ao, HamiltonianType type)
-    : CanonicalFourCenterHamiltonianContainer(
-          one_body_integrals_alpha, one_body_integrals_beta,
-          two_body_integrals_aaaa, two_body_integrals_aabb,
-          two_body_integrals_bbbb, orbitals, core_energy,
-          inactive_fock_matrix_alpha, inactive_fock_matrix_beta, type),
-      _ao_cholesky_vectors(std::make_shared<Eigen::MatrixXd>(L_ao)) {
+    const Eigen::MatrixXd& inactive_fock_matrix_beta, HamiltonianType type)
+    : HamiltonianContainer(one_body_integrals_alpha, one_body_integrals_beta,
+                           orbitals, core_energy, inactive_fock_matrix_alpha,
+                           inactive_fock_matrix_beta, type),
+      _three_center_integrals(
+          std::make_unique<Eigen::MatrixXd>(three_center_integrals_aa),
+          std::make_unique<Eigen::MatrixXd>(three_center_integrals_bb)) {
   QDK_LOG_TRACE_ENTERING();
+
+  validate_integral_dimensions();
+  validate_restrictedness_consistency();
+  validate_active_space_dimensions();
+
+  if (!is_valid()) {
+    throw std::invalid_argument(
+        "Tried to generate invalid Hamiltonian object.");
+  }
 }
 
 std::unique_ptr<HamiltonianContainer> CholeskyHamiltonianContainer::clone()
@@ -55,16 +75,14 @@ std::unique_ptr<HamiltonianContainer> CholeskyHamiltonianContainer::clone()
   QDK_LOG_TRACE_ENTERING();
   if (is_restricted()) {
     return std::make_unique<CholeskyHamiltonianContainer>(
-        *_one_body_integrals.first, *std::get<0>(_two_body_integrals),
-        _orbitals, _core_energy, *_inactive_fock_matrix.first,
-        *_ao_cholesky_vectors, _type);
+        *_one_body_integrals.first, *_three_center_integrals.first, _orbitals,
+        _core_energy, *_inactive_fock_matrix.first, _type);
   }
   return std::make_unique<CholeskyHamiltonianContainer>(
       *_one_body_integrals.first, *_one_body_integrals.second,
-      *std::get<0>(_two_body_integrals), *std::get<1>(_two_body_integrals),
-      *std::get<2>(_two_body_integrals), _orbitals, _core_energy,
-      *_inactive_fock_matrix.first, *_inactive_fock_matrix.second,
-      *_ao_cholesky_vectors, _type);
+      *_three_center_integrals.first, *_three_center_integrals.second,
+      _orbitals, _core_energy, *_inactive_fock_matrix.first,
+      *_inactive_fock_matrix.second, _type);
 }
 
 std::string CholeskyHamiltonianContainer::get_container_type() const {
@@ -72,30 +90,318 @@ std::string CholeskyHamiltonianContainer::get_container_type() const {
   return "cholesky";
 }
 
-nlohmann::json CholeskyHamiltonianContainer::to_json() const {
+std::tuple<const Eigen::VectorXd&, const Eigen::VectorXd&,
+           const Eigen::VectorXd&>
+CholeskyHamiltonianContainer::get_two_body_integrals() const {
+  QDK_LOG_TRACE_ENTERING();
+  if (!has_two_body_integrals()) {
+    throw std::runtime_error("Three-center integrals are not set");
+  }
+
+  // Lazily build and cache the four-center integrals on first access
+  if (!_cached_four_center_integrals) {
+    _build_four_center_cache();
+  }
+
+  return std::make_tuple(
+      std::cref(*std::get<0>(*_cached_four_center_integrals)),
+      std::cref(*std::get<1>(*_cached_four_center_integrals)),
+      std::cref(*std::get<2>(*_cached_four_center_integrals)));
+}
+
+void CholeskyHamiltonianContainer::_build_four_center_cache() const {
   QDK_LOG_TRACE_ENTERING();
 
-  // Start with base class serialization
-  nlohmann::json j = CanonicalFourCenterHamiltonianContainer::to_json();
+  size_t norb = _orbitals->get_active_space_indices().first.size();
+  size_t norb2 = norb * norb;
+  size_t norb4 = norb2 * norb2;
 
-  // Override container type
+  // Helper lambda to build 4-center from 3-center: (ij|kl) = sum_Q L_ij,Q *
+  // R_Q,kl, where L and R are column-major, and (ij|kl) is row-major
+  auto build_four_center =
+      [&](std::shared_ptr<const Eigen::MatrixXd> three_center_left,
+          std::shared_ptr<const Eigen::MatrixXd> three_center_right)
+      -> std::shared_ptr<Eigen::VectorXd> {
+    // Allocate output vector
+    auto four_center = std::make_shared<Eigen::VectorXd>(norb4);
+
+    size_t naux = three_center_left->cols();
+
+    // To make the resulting four-center integrals compatible with the row major
+    // storage, we calculate (kl|ij) = sum_Q R_kl,Q * L_Q,ij and store the
+    // result in col-major order, effectively (ij|kl) in row-major order.
+    blas::gemm(blas::Layout::ColMajor, blas::Op::NoTrans, blas::Op::Trans,
+               norb2, norb2, naux, 1.0, three_center_right->data(), norb2,
+               three_center_left->data(), norb2, 0.0, four_center->data(),
+               norb2);
+    return four_center;
+  };
+
+  // Build four-center integrals from three-center
+  auto aaaa = build_four_center(_three_center_integrals.first,
+                                _three_center_integrals.first);
+
+  if (is_restricted()) {
+    _cached_four_center_integrals.emplace(aaaa, aaaa, aaaa);
+  } else {
+    auto aabb = build_four_center(_three_center_integrals.first,
+                                  _three_center_integrals.second);
+    auto bbbb = build_four_center(_three_center_integrals.second,
+                                  _three_center_integrals.second);
+    _cached_four_center_integrals.emplace(std::move(aaaa), std::move(aabb),
+                                          std::move(bbbb));
+  }
+}
+
+std::pair<const Eigen::MatrixXd&, const Eigen::MatrixXd&>
+CholeskyHamiltonianContainer::get_three_center_integrals() const {
+  QDK_LOG_TRACE_ENTERING();
+  if (!has_two_body_integrals()) {
+    throw std::runtime_error("Three-center two-body integrals are not set");
+  }
+  return std::make_pair(std::cref(*_three_center_integrals.first),
+                        std::cref(*_three_center_integrals.second));
+}
+
+double CholeskyHamiltonianContainer::get_two_body_element(
+    unsigned i, unsigned j, unsigned k, unsigned l, SpinChannel channel) const {
+  QDK_LOG_TRACE_ENTERING();
+
+  if (!has_two_body_integrals()) {
+    throw std::runtime_error("Two-body integrals are not set");
+  }
+
+  size_t norb = _orbitals->get_active_space_indices().first.size();
+  if (i >= norb || j >= norb || k >= norb || l >= norb) {
+    throw std::out_of_range("Orbital index out of range");
+  }
+
+  if (!_cached_four_center_integrals) {
+    _build_four_center_cache();
+  }
+
+  size_t ij = i * norb + j;
+  size_t kl = k * norb + l;
+
+  // Select the appropriate integral based on spin channel
+  switch (channel) {
+    case SpinChannel::aaaa:
+      return (*std::get<0>(*_cached_four_center_integrals))(ij * norb * norb +
+                                                            kl);
+    case SpinChannel::aabb:
+      return (*std::get<1>(*_cached_four_center_integrals))(ij * norb * norb +
+                                                            kl);
+    case SpinChannel::bbbb:
+      return (*std::get<2>(*_cached_four_center_integrals))(ij * norb * norb +
+                                                            kl);
+
+    default:
+      throw std::invalid_argument("Invalid spin channel");
+  }
+}
+
+bool CholeskyHamiltonianContainer::has_two_body_integrals() const {
+  QDK_LOG_TRACE_ENTERING();
+  return _three_center_integrals.first != nullptr &&
+         _three_center_integrals.first->size() > 0;
+}
+
+bool CholeskyHamiltonianContainer::is_restricted() const {
+  QDK_LOG_TRACE_ENTERING();
+  // Hamiltonian is restricted if alpha and beta components point to the same
+  // data
+  return (_one_body_integrals.first == _one_body_integrals.second) &&
+         (_three_center_integrals.first == _three_center_integrals.second) &&
+         (_inactive_fock_matrix.first == _inactive_fock_matrix.second ||
+          (!_inactive_fock_matrix.first && !_inactive_fock_matrix.second));
+}
+
+bool CholeskyHamiltonianContainer::is_valid() const {
+  QDK_LOG_TRACE_ENTERING();
+  // Check if essential data is present
+  if (!has_one_body_integrals() || !has_two_body_integrals()) {
+    return false;
+  }
+
+  // Check dimension consistency
+  try {
+    validate_integral_dimensions();
+  } catch (const std::exception&) {
+    return false;
+  }
+
+  return true;
+}
+
+void CholeskyHamiltonianContainer::validate_integral_dimensions() const {
+  QDK_LOG_TRACE_ENTERING();
+  // Check alpha one-body integrals
+  HamiltonianContainer::validate_integral_dimensions();
+
+  if (!has_two_body_integrals()) {
+    return;
+  }
+
+  // Check two-body integrals dimensions
+  // Three-center integrals have shape [n_orb_pairs x n_aux] where n_orb_pairs =
+  // norb^2
+  auto norb_alpha = _one_body_integrals.first->rows();
+  auto orb_pair_size = norb_alpha * norb_alpha;
+
+  // Check alpha-alpha integrals - rows should equal orb_pair_size
+  if (static_cast<size_t>(_three_center_integrals.first->rows()) !=
+      orb_pair_size) {
+    throw std::invalid_argument(
+        "Alpha-alpha three-center integrals rows (" +
+        std::to_string(_three_center_integrals.first->rows()) +
+        ") does not match expected orb_pair size (" +
+        std::to_string(orb_pair_size) + " for " + std::to_string(norb_alpha) +
+        " orbitals)");
+  }
+
+  // Check beta-beta integrals (if different from alpha-alpha)
+  if (_three_center_integrals.second != _three_center_integrals.first) {
+    if (static_cast<size_t>(_three_center_integrals.second->rows()) !=
+            orb_pair_size ||
+        static_cast<size_t>(_three_center_integrals.second->cols()) !=
+            static_cast<size_t>(_three_center_integrals.first->cols())) {
+      throw std::invalid_argument(
+          "Beta three-center integrals size does not match with Alpha");
+    }
+  }
+}
+
+std::pair<std::shared_ptr<Eigen::MatrixXd>, std::shared_ptr<Eigen::MatrixXd>>
+CholeskyHamiltonianContainer::make_restricted_three_center_integrals(
+    const Eigen::MatrixXd& integrals) {
+  QDK_LOG_TRACE_ENTERING();
+  auto shared_integrals = std::make_shared<Eigen::MatrixXd>(integrals);
+  return std::make_pair(shared_integrals, shared_integrals);
+}
+
+nlohmann::json CholeskyHamiltonianContainer::to_json() const {
+  QDK_LOG_TRACE_ENTERING();
+  nlohmann::json j;
+
+  // Store version first
+  j["version"] = SERIALIZATION_VERSION;
+
+  // Store container type
   j["container_type"] = get_container_type();
 
-  // Store ao cholesky vectors (Cholesky-specific data)
-  if (_ao_cholesky_vectors != nullptr && _ao_cholesky_vectors->size() > 0) {
-    j["has_ao_cholesky_vectors"] = true;
-    // Store ao cholesky vectors
-    std::vector<std::vector<double>> L_ao_vec;
-    for (int i = 0; i < _ao_cholesky_vectors->rows(); ++i) {
+  // Store metadata
+  j["core_energy"] = _core_energy;
+  j["type"] =
+      (_type == HamiltonianType::Hermitian) ? "Hermitian" : "NonHermitian";
+
+  // Store restrictedness information
+  j["is_restricted"] = is_restricted();
+
+  // Store one-body integrals
+  if (has_one_body_integrals()) {
+    j["has_one_body_integrals"] = true;
+
+    // Store alpha one-body integrals
+    std::vector<std::vector<double>> one_body_alpha_vec;
+    for (int i = 0; i < _one_body_integrals.first->rows(); ++i) {
       std::vector<double> row;
-      for (int j_idx = 0; j_idx < _ao_cholesky_vectors->cols(); ++j_idx) {
-        row.push_back((*_ao_cholesky_vectors)(i, j_idx));
+      for (int j_idx = 0; j_idx < _one_body_integrals.first->cols(); ++j_idx) {
+        row.push_back((*_one_body_integrals.first)(i, j_idx));
       }
-      L_ao_vec.push_back(row);
+      one_body_alpha_vec.push_back(row);
     }
-    j["ao_cholesky_vectors"] = L_ao_vec;
+    j["one_body_integrals_alpha"] = one_body_alpha_vec;
+
+    // Store beta one-body integrals (only if unrestricted)
+    if (is_unrestricted()) {
+      std::vector<std::vector<double>> one_body_beta_vec;
+      for (int i = 0; i < _one_body_integrals.second->rows(); ++i) {
+        std::vector<double> row;
+        for (int j_idx = 0; j_idx < _one_body_integrals.second->cols();
+             ++j_idx) {
+          row.push_back((*_one_body_integrals.second)(i, j_idx));
+        }
+        one_body_beta_vec.push_back(row);
+      }
+      j["one_body_integrals_beta"] = one_body_beta_vec;
+    }
   } else {
-    j["has_ao_cholesky_vectors"] = false;
+    j["has_one_body_integrals"] = false;
+  }
+
+  // Store two-body integrals
+  if (has_two_body_integrals()) {
+    j["has_two_body_integrals"] = true;
+
+    // Store as object {"aa": [...], "ab": [...], "bb": [...]}
+    nlohmann::json two_body_obj;
+
+    // Store aa
+    std::vector<std::vector<double>> three_center_aa_vec;
+    for (int i = 0; i < _three_center_integrals.first->rows(); ++i) {
+      std::vector<double> row;
+      for (int j_idx = 0; j_idx < _three_center_integrals.first->cols();
+           ++j_idx) {
+        row.push_back((*_three_center_integrals.first)(i, j_idx));
+      }
+      three_center_aa_vec.push_back(row);
+    }
+    two_body_obj["aa"] = three_center_aa_vec;
+    // Store bb
+    std::vector<std::vector<double>> three_center_bb_vec;
+    for (int i = 0; i < _three_center_integrals.second->rows(); ++i) {
+      std::vector<double> row;
+      for (int j_idx = 0; j_idx < _three_center_integrals.second->cols();
+           ++j_idx) {
+        row.push_back((*_three_center_integrals.second)(i, j_idx));
+      }
+      three_center_bb_vec.push_back(row);
+    }
+    two_body_obj["bb"] = three_center_bb_vec;
+
+    j["three_center_integrals"] = two_body_obj;
+  } else {
+    j["has_two_body_integrals"] = false;
+  }
+
+  // Store inactive Fock matrix
+  if (has_inactive_fock_matrix()) {
+    j["has_inactive_fock_matrix"] = true;
+    // Store alpha inactive Fock matrix
+    std::vector<std::vector<double>> inactive_fock_alpha_vec;
+    for (int i = 0; i < _inactive_fock_matrix.first->rows(); ++i) {
+      std::vector<double> row;
+      for (int j_idx = 0; j_idx < _inactive_fock_matrix.first->cols();
+           ++j_idx) {
+        row.push_back((*_inactive_fock_matrix.first)(i, j_idx));
+      }
+      inactive_fock_alpha_vec.push_back(row);
+    }
+    j["inactive_fock_matrix_alpha"] = inactive_fock_alpha_vec;
+
+    // Store beta inactive Fock matrix (only if unrestricted)
+    if (is_unrestricted()) {
+      std::vector<std::vector<double>> inactive_fock_beta_vec;
+      for (int i = 0; i < _inactive_fock_matrix.second->rows(); ++i) {
+        std::vector<double> row;
+        for (int j_idx = 0; j_idx < _inactive_fock_matrix.second->cols();
+             ++j_idx) {
+          row.push_back((*_inactive_fock_matrix.second)(i, j_idx));
+        }
+        inactive_fock_beta_vec.push_back(row);
+      }
+      j["inactive_fock_matrix_beta"] = inactive_fock_beta_vec;
+    }
+  } else {
+    j["has_inactive_fock_matrix"] = false;
+  }
+
+  // Store orbital data
+  if (has_orbitals()) {
+    j["has_orbitals"] = true;
+    j["orbitals"] = _orbitals->to_json();
+  } else {
+    j["has_orbitals"] = false;
   }
 
   return j;
@@ -130,31 +436,19 @@ CholeskyHamiltonianContainer::from_json(const nlohmann::json& j) {
     auto load_matrix =
         [](const nlohmann::json& matrix_json) -> Eigen::MatrixXd {
       auto matrix_vec = matrix_json.get<std::vector<std::vector<double>>>();
-      if (matrix_vec.empty()) {
-        return Eigen::MatrixXd(0, 0);
-      }
-
-      Eigen::MatrixXd matrix(matrix_vec.size(), matrix_vec[0].size());
-      for (Eigen::Index i = 0; i < matrix.rows(); ++i) {
-        if (static_cast<Eigen::Index>(matrix_vec[i].size()) != matrix.cols()) {
+      int rows = matrix_vec.size();
+      int cols = rows > 0 ? matrix_vec[0].size() : 0;
+      Eigen::MatrixXd matrix(rows, cols);
+      for (int i = 0; i < rows; ++i) {
+        if (static_cast<int>(matrix_vec[i].size()) != cols) {
           throw std::runtime_error(
               "Matrix rows have inconsistent column counts");
         }
-        matrix.row(i) =
-            Eigen::VectorXd::Map(matrix_vec[i].data(), matrix.cols());
+        for (int j_idx = 0; j_idx < cols; ++j_idx) {
+          matrix(i, j_idx) = matrix_vec[i][j_idx];
+        }
       }
       return matrix;
-    };
-
-    // Helper function to load vector from JSON
-    auto load_vector =
-        [](const nlohmann::json& vector_json) -> Eigen::VectorXd {
-      auto vector_vec = vector_json.get<std::vector<double>>();
-      Eigen::VectorXd vector(vector_vec.size());
-      for (size_t i = 0; i < vector_vec.size(); ++i) {
-        vector(i) = vector_vec[i];
-      }
-      return vector;
     };
 
     // Load one-body integrals
@@ -174,28 +468,27 @@ CholeskyHamiltonianContainer::from_json(const nlohmann::json& j) {
     }
 
     // Load two-body integrals
-    Eigen::VectorXd two_body_aaaa, two_body_aabb, two_body_bbbb;
+    Eigen::MatrixXd three_center_aa, three_center_bb;
     bool has_two_body = j.value("has_two_body_integrals", false);
     if (has_two_body) {
-      if (!j.contains("two_body_integrals")) {
+      if (!j.contains("three_center_integrals")) {
         throw std::runtime_error("Two-body integrals data not found in JSON");
       }
 
-      auto two_body_obj = j["two_body_integrals"];
+      auto two_body_obj = j["three_center_integrals"];
       if (!two_body_obj.is_object()) {
         throw std::runtime_error(
-            "two_body_integrals must be an object with aaaa, aabb, bbbb keys");
+            "three_center_integrals must be an object with aa, bb "
+            "keys");
       }
 
-      if (!two_body_obj.contains("aaaa") || !two_body_obj.contains("aabb") ||
-          !two_body_obj.contains("bbbb")) {
+      if (!two_body_obj.contains("aa") || !two_body_obj.contains("bb")) {
         throw std::runtime_error(
-            "two_body_integrals must contain aaaa, aabb, and bbbb keys");
+            "three_center_integrals must contain aa and bb keys");
       }
 
-      two_body_aaaa = load_vector(two_body_obj["aaaa"]);
-      two_body_aabb = load_vector(two_body_obj["aabb"]);
-      two_body_bbbb = load_vector(two_body_obj["bbbb"]);
+      three_center_aa = load_matrix(two_body_obj["aa"]);
+      three_center_bb = load_matrix(two_body_obj["bb"]);
     }
 
     // Load inactive Fock matrix
@@ -219,15 +512,6 @@ CholeskyHamiltonianContainer::from_json(const nlohmann::json& j) {
       throw std::runtime_error("Hamiltonian JSON must include orbitals data");
     }
     auto orbitals = Orbitals::from_json(j["orbitals"]);
-
-    // Load ao cholesky vectors
-    Eigen::MatrixXd L_ao;
-    bool has_ao_cholesky_vectors = j.value("has_ao_cholesky_vectors", false);
-    if (has_ao_cholesky_vectors) {
-      if (j.contains("ao_cholesky_vectors")) {
-        L_ao = load_matrix(j["ao_cholesky_vectors"]);
-      }
-    }
 
     // Validate consistency: if orbitals have inactive indices,
     // then inactive fock matrix must be present
@@ -258,14 +542,13 @@ CholeskyHamiltonianContainer::from_json(const nlohmann::json& j) {
       // Use restricted constructor - it will create shared pointers internally
       // so alpha and beta point to the same data
       return std::make_unique<CholeskyHamiltonianContainer>(
-          one_body_alpha, two_body_aaaa, orbitals, core_energy,
-          inactive_fock_alpha, L_ao, type);
+          one_body_alpha, three_center_aa, orbitals, core_energy,
+          inactive_fock_alpha, type);
     } else {
       // Use unrestricted constructor with separate alpha and beta data
       return std::make_unique<CholeskyHamiltonianContainer>(
-          one_body_alpha, one_body_beta, two_body_aaaa, two_body_aabb,
-          two_body_bbbb, orbitals, core_energy, inactive_fock_alpha,
-          inactive_fock_beta, L_ao, type);
+          one_body_alpha, one_body_beta, three_center_aa, three_center_bb,
+          orbitals, core_energy, inactive_fock_alpha, inactive_fock_beta, type);
     }
 
   } catch (const std::exception& e) {
@@ -274,28 +557,189 @@ CholeskyHamiltonianContainer::from_json(const nlohmann::json& j) {
   }
 }
 
+void CholeskyHamiltonianContainer::to_fcidump_file(const std::string& filename,
+                                                   size_t nalpha,
+                                                   size_t nbeta) const {
+  QDK_LOG_TRACE_ENTERING();
+
+  if (is_unrestricted()) {
+    throw std::runtime_error(
+        "FCIDUMP format is not supported for unrestricted Hamiltonians.");
+  }
+
+  std::ofstream file(filename);
+  if (!file.is_open()) {
+    throw std::runtime_error("Cannot open file for writing: " + filename);
+  }
+
+  size_t num_molecular_orbitals;
+  if (has_orbitals()) {
+    if (_orbitals->has_active_space()) {
+      auto active_indices = _orbitals->get_active_space_indices();
+      size_t n_active_alpha = active_indices.first.size();
+      size_t n_active_beta = active_indices.second.size();
+
+      if (n_active_alpha != n_active_beta) {
+        throw std::invalid_argument(
+            "For restricted Hamiltonian, alpha and beta active spaces must "
+            "have same size");
+      }
+      num_molecular_orbitals = n_active_alpha;
+    } else {
+      num_molecular_orbitals = _orbitals->get_num_molecular_orbitals();
+    }
+  } else {
+    throw std::runtime_error("Orbitals are not set");
+  }
+
+  const size_t nelec = nalpha + nbeta;
+  const size_t num_molecular_orbitals2 =
+      num_molecular_orbitals * num_molecular_orbitals;
+  const size_t num_molecular_orbitals3 =
+      num_molecular_orbitals2 * num_molecular_orbitals;
+  const double print_thresh = std::numeric_limits<double>::epsilon();
+
+  // C1 symmetry
+  std::string orb_string;
+  for (size_t i = 0; i < num_molecular_orbitals - 1; ++i) {
+    orb_string += "1,";
+  }
+  orb_string += "1";
+
+  // Write header
+  file << "&FCI ";
+  file << "NORB=" << num_molecular_orbitals << ", ";
+  file << "NELEC=" << nelec << ", ";
+  file << "MS2=" << (nalpha - nbeta) << ",\n";
+  file << "ORBSYM=" << orb_string << ",\n";
+  file << "ISYM=1,\n";
+  file << "&END\n";
+
+  auto formatted_line = [&](size_t i, size_t j, size_t k, size_t l,
+                            double val) {
+    if (std::abs(val) < print_thresh) return;
+
+    file << std::setw(28) << std::scientific << std::setprecision(16)
+         << std::right << val << " ";
+    file << std::setw(4) << i << " ";
+    file << std::setw(4) << j << " ";
+    file << std::setw(4) << k << " ";
+    file << std::setw(4) << l;
+  };
+
+  // Get the lazily-computed four-center integrals
+  auto [eri_aaaa, eri_aabb, eri_bbbb] = get_two_body_integrals();
+
+  auto write_eri = [&](size_t i, size_t j, size_t k, size_t l) {
+    auto eri =
+        eri_aaaa(i * num_molecular_orbitals3 + j * num_molecular_orbitals2 +
+                 k * num_molecular_orbitals + l);
+
+    formatted_line(i + 1, j + 1, k + 1, l + 1, eri);
+    file << "\n";
+  };
+
+  auto write_1body = [&](size_t i, size_t j) {
+    auto hel = (*_one_body_integrals.first)(i, j);
+
+    formatted_line(i + 1, j + 1, 0, 0, hel);
+    file << "\n";
+  };
+
+  // Write permutationally unique MO ERIs
+  for (size_t i = 0, ij = 0; i < num_molecular_orbitals; ++i)
+    for (size_t j = i; j < num_molecular_orbitals; ++j, ij++) {
+      for (size_t k = 0, kl = 0; k < num_molecular_orbitals; ++k)
+        for (size_t l = k; l < num_molecular_orbitals; ++l, kl++) {
+          if (ij <= kl) {
+            write_eri(i, j, k, l);
+          }
+        }
+    }
+
+  // Write permutationally unique MO 1-body integrals
+  for (size_t i = 0; i < num_molecular_orbitals; ++i)
+    for (size_t j = 0; j <= i; ++j) {
+      write_1body(i, j);
+    }
+
+  // Write core energy
+  formatted_line(0, 0, 0, 0, _core_energy);
+}
+
 void CholeskyHamiltonianContainer::to_hdf5(H5::Group& group) const {
   QDK_LOG_TRACE_ENTERING();
   try {
-    // Start with base class serialization
-    CanonicalFourCenterHamiltonianContainer::to_hdf5(group);
-
-    // Override container type attribute
+    // Save version first
     H5::DataSpace scalar_space(H5S_SCALAR);
     H5::StrType string_type(H5::PredType::C_S1, H5T_VARIABLE);
 
-    // Remove and recreate container_type attribute with correct value
-    if (group.attrExists("container_type")) {
-      group.removeAttr("container_type");
-    }
+    H5::Attribute version_attr =
+        group.createAttribute("version", string_type, scalar_space);
+    std::string version_str = SERIALIZATION_VERSION;
+    version_attr.write(string_type, version_str);
+
+    // Add container type attribute
     H5::Attribute container_type_attr =
         group.createAttribute("container_type", string_type, scalar_space);
     std::string container_type_str = get_container_type();
     container_type_attr.write(string_type, container_type_str);
 
-    // Save ao cholesky vectors (Cholesky-specific data)
-    if (_ao_cholesky_vectors != nullptr && _ao_cholesky_vectors->size() > 0) {
-      save_matrix_to_group(group, "ao_cholesky_vectors", *_ao_cholesky_vectors);
+    // Save metadata
+    H5::Group metadata_group = group.createGroup("metadata");
+
+    // Save core energy
+    H5::Attribute core_energy_attr = metadata_group.createAttribute(
+        "core_energy", H5::PredType::NATIVE_DOUBLE, scalar_space);
+    core_energy_attr.write(H5::PredType::NATIVE_DOUBLE, &_core_energy);
+
+    // Save Hamiltonian type
+    std::string type_str =
+        (_type == HamiltonianType::Hermitian) ? "Hermitian" : "NonHermitian";
+    H5::StrType type_string_type(H5::PredType::C_S1, type_str.length() + 1);
+    H5::Attribute type_attr =
+        metadata_group.createAttribute("type", type_string_type, scalar_space);
+    type_attr.write(type_string_type, type_str.c_str());
+
+    // Save restrictedness information
+    hbool_t is_restricted_flag = is_restricted() ? 1 : 0;
+    H5::Attribute restricted_attr = metadata_group.createAttribute(
+        "is_restricted", H5::PredType::NATIVE_HBOOL, scalar_space);
+    restricted_attr.write(H5::PredType::NATIVE_HBOOL, &is_restricted_flag);
+
+    // Save integrals data
+    if (has_one_body_integrals()) {
+      save_matrix_to_group(group, "one_body_integrals_alpha",
+                           *_one_body_integrals.first);
+      if (is_unrestricted()) {
+        save_matrix_to_group(group, "one_body_integrals_beta",
+                             *_one_body_integrals.second);
+      }
+    }
+
+    if (has_two_body_integrals()) {
+      save_matrix_to_group(group, "three_center_integrals_aa",
+                           *_three_center_integrals.first);
+      if (is_unrestricted()) {
+        save_matrix_to_group(group, "three_center_integrals_bb",
+                             *_three_center_integrals.second);
+      }
+    }
+
+    // Save inactive Fock matrix
+    if (has_inactive_fock_matrix()) {
+      save_matrix_to_group(group, "inactive_fock_matrix_alpha",
+                           *_inactive_fock_matrix.first);
+      if (is_unrestricted()) {
+        save_matrix_to_group(group, "inactive_fock_matrix_beta",
+                             *_inactive_fock_matrix.second);
+      }
+    }
+
+    // Save nested orbitals data using HDF5 group
+    if (_orbitals) {
+      H5::Group orbitals_group = group.createGroup("orbitals");
+      _orbitals->to_hdf5(orbitals_group);
     }
 
   } catch (const H5::Exception& e) {
@@ -363,7 +807,7 @@ CholeskyHamiltonianContainer::from_hdf5(H5::Group& group) {
 
     // Load integral data based on restrictedness
     Eigen::MatrixXd one_body_alpha, one_body_beta;
-    Eigen::VectorXd two_body_aaaa, two_body_aabb, two_body_bbbb;
+    Eigen::MatrixXd three_center_aa, three_center_bb;
     Eigen::MatrixXd inactive_fock_alpha, inactive_fock_beta;
 
     // Load one-body integrals
@@ -379,19 +823,16 @@ CholeskyHamiltonianContainer::from_hdf5(H5::Group& group) {
     }
 
     // Load two-body integrals
-    if (dataset_exists_in_group(group, "two_body_integrals_aaaa")) {
-      two_body_aaaa = load_vector_from_group(group, "two_body_integrals_aaaa");
+    if (dataset_exists_in_group(group, "three_center_integrals_aa")) {
+      three_center_aa =
+          load_matrix_from_group(group, "three_center_integrals_aa");
     }
 
-    // For unrestricted, load aabb and bbbb separately
+    // For unrestricted, load bb separately
     if (!is_restricted_data) {
-      if (dataset_exists_in_group(group, "two_body_integrals_aabb")) {
-        two_body_aabb =
-            load_vector_from_group(group, "two_body_integrals_aabb");
-      }
-      if (dataset_exists_in_group(group, "two_body_integrals_bbbb")) {
-        two_body_bbbb =
-            load_vector_from_group(group, "two_body_integrals_bbbb");
+      if (dataset_exists_in_group(group, "three_center_integrals_bb")) {
+        three_center_bb =
+            load_matrix_from_group(group, "three_center_integrals_bb");
       }
     }
 
@@ -408,24 +849,17 @@ CholeskyHamiltonianContainer::from_hdf5(H5::Group& group) {
           load_matrix_from_group(group, "inactive_fock_matrix_beta");
     }
 
-    // load ao cholesky vectors
-    Eigen::MatrixXd L_ao;
-    if (dataset_exists_in_group(group, "ao_cholesky_vectors")) {
-      L_ao = load_matrix_from_group(group, "ao_cholesky_vectors");
-    }
-
     // Create and return appropriate Hamiltonian using the correct constructor
     if (is_restricted_data) {
       // Use restricted constructor - it will create shared pointers internally
       return std::make_unique<CholeskyHamiltonianContainer>(
-          one_body_alpha, two_body_aaaa, orbitals, core_energy,
-          inactive_fock_alpha, L_ao, type);
+          one_body_alpha, three_center_aa, orbitals, core_energy,
+          inactive_fock_alpha, type);
     } else {
       // Use unrestricted constructor with separate alpha and beta data
       return std::make_unique<CholeskyHamiltonianContainer>(
-          one_body_alpha, one_body_beta, two_body_aaaa, two_body_aabb,
-          two_body_bbbb, orbitals, core_energy, inactive_fock_alpha,
-          inactive_fock_beta, L_ao, type);
+          one_body_alpha, one_body_beta, three_center_aa, three_center_bb,
+          orbitals, core_energy, inactive_fock_alpha, inactive_fock_beta, type);
     }
 
   } catch (const H5::Exception& e) {

--- a/cpp/tests/test_hamiltonian.cpp
+++ b/cpp/tests/test_hamiltonian.cpp
@@ -88,7 +88,7 @@ auto run_restricted_o2 = [](const std::string& factory_name = "qdk") {
 
   auto ham_factory = HamiltonianConstructorFactory::create(factory_name);
   if (factory_name == "qdk_cholesky") {
-    ham_factory->settings().set("store_cholesky_vectors", true);
+    ham_factory->settings().set("store_ao_cholesky_vectors", true);
   }
   auto rhf_hamiltonian = ham_factory->run(rhf_orbitals);
 
@@ -112,7 +112,7 @@ auto run_unrestricted_o2 = [](const std::string& factory_name = "qdk") {
 
   auto ham_factory = HamiltonianConstructorFactory::create(factory_name);
   if (factory_name == "qdk_cholesky") {
-    ham_factory->settings().set("store_cholesky_vectors", true);
+    ham_factory->settings().set("store_ao_cholesky_vectors", true);
   }
   auto uhf_hamiltonian = ham_factory->run(uhf_orbitals);
 
@@ -1016,9 +1016,10 @@ TEST_F(HamiltonianTest, CholeskyContainerJSONSerialization) {
   double core_energy = 1.5;
   Eigen::MatrixXd inactive_fock = Eigen::MatrixXd::Zero(0, 0);
   Eigen::MatrixXd L_mo = Eigen::MatrixXd::Random(4, 3);
+  Eigen::MatrixXd L_ao = Eigen::MatrixXd::Random(4, 3);
 
   Hamiltonian h(std::make_unique<CholeskyHamiltonianContainer>(
-      one_body, L_mo, orbitals, core_energy, inactive_fock));
+      one_body, L_mo, orbitals, core_energy, inactive_fock, L_ao));
 
   // Test JSON conversion
   nlohmann::json j = h.to_json();
@@ -1027,9 +1028,7 @@ TEST_F(HamiltonianTest, CholeskyContainerJSONSerialization) {
   EXPECT_EQ(j["container"]["core_energy"], 1.5);
   EXPECT_TRUE(j["container"]["has_one_body_integrals"]);
   EXPECT_TRUE(j["container"]["has_two_body_integrals"]);
-  // TODO: Update test once optional AO Cholesky vectors are included in JSON
-  // serialization
-  EXPECT_FALSE(j["container"].contains("has_ao_cholesky_vectors"));
+  EXPECT_TRUE(j["container"].contains("ao_cholesky_vectors"));
 
   // Test deserialization
   auto h_loaded = Hamiltonian::from_json(j);

--- a/cpp/tests/test_hamiltonian.cpp
+++ b/cpp/tests/test_hamiltonian.cpp
@@ -961,11 +961,11 @@ TEST_F(HamiltonianTest, CholeskyContainerConstruction) {
   Eigen::MatrixXd inactive_fock = Eigen::MatrixXd::Zero(0, 0);
 
   // Create cholesky vectors (2x2 AO basis, 3 cholesky vectors)
-  Eigen::MatrixXd L_ao = Eigen::MatrixXd::Random(4, 3);
+  Eigen::MatrixXd L_mo = Eigen::MatrixXd::Random(4, 3);
 
   // Test restricted constructor
   Hamiltonian h(std::make_unique<CholeskyHamiltonianContainer>(
-      one_body, two_body, orbitals, core_energy, inactive_fock, L_ao));
+      one_body, L_mo, orbitals, core_energy, inactive_fock));
 
   EXPECT_TRUE(h.has_one_body_integrals());
   EXPECT_TRUE(h.has_two_body_integrals());
@@ -992,13 +992,14 @@ TEST_F(HamiltonianTest, CholeskyContainerUnrestrictedConstruction) {
   double core_energy = 1.5;
 
   // Create cholesky vectors
-  Eigen::MatrixXd L_ao = Eigen::MatrixXd::Random(4, 3);
+  Eigen::MatrixXd L_mo_alpha = Eigen::MatrixXd::Random(4, 3);
+  Eigen::MatrixXd L_mo_beta = Eigen::MatrixXd::Random(4, 3);
 
   // Test unrestricted constructor
   Hamiltonian h(std::make_unique<CholeskyHamiltonianContainer>(
-      one_body_alpha, one_body_beta, two_body_aaaa, two_body_aabb,
-      two_body_bbbb, unrestricted_orbitals, core_energy, inactive_fock_alpha,
-      inactive_fock_beta, L_ao));
+      one_body_alpha, one_body_beta, L_mo_alpha, L_mo_beta,
+      unrestricted_orbitals, core_energy, inactive_fock_alpha,
+      inactive_fock_beta));
 
   EXPECT_TRUE(h.has_one_body_integrals());
   EXPECT_TRUE(h.has_two_body_integrals());
@@ -1014,10 +1015,10 @@ TEST_F(HamiltonianTest, CholeskyContainerJSONSerialization) {
   auto orbitals = std::make_shared<ModelOrbitals>(2, true);
   double core_energy = 1.5;
   Eigen::MatrixXd inactive_fock = Eigen::MatrixXd::Zero(0, 0);
-  Eigen::MatrixXd L_ao = Eigen::MatrixXd::Random(4, 3);
+  Eigen::MatrixXd L_mo = Eigen::MatrixXd::Random(4, 3);
 
   Hamiltonian h(std::make_unique<CholeskyHamiltonianContainer>(
-      one_body, two_body, orbitals, core_energy, inactive_fock, L_ao));
+      one_body, L_mo, orbitals, core_energy, inactive_fock));
 
   // Test JSON conversion
   nlohmann::json j = h.to_json();
@@ -1026,7 +1027,9 @@ TEST_F(HamiltonianTest, CholeskyContainerJSONSerialization) {
   EXPECT_EQ(j["container"]["core_energy"], 1.5);
   EXPECT_TRUE(j["container"]["has_one_body_integrals"]);
   EXPECT_TRUE(j["container"]["has_two_body_integrals"]);
-  EXPECT_TRUE(j["container"]["has_ao_cholesky_vectors"]);
+  // TODO: Update test once optional AO Cholesky vectors are included in JSON
+  // serialization
+  EXPECT_FALSE(j["container"].contains("has_ao_cholesky_vectors"));
 
   // Test deserialization
   auto h_loaded = Hamiltonian::from_json(j);
@@ -1043,10 +1046,10 @@ TEST_F(HamiltonianTest, CholeskyContainerHDF5Serialization) {
   auto orbitals = std::make_shared<ModelOrbitals>(2, true);
   double core_energy = 1.5;
   Eigen::MatrixXd inactive_fock = Eigen::MatrixXd::Zero(0, 0);
-  Eigen::MatrixXd L_ao = Eigen::MatrixXd::Random(4, 3);
+  Eigen::MatrixXd L_mo = Eigen::MatrixXd::Random(4, 3);
 
   Hamiltonian h(std::make_unique<CholeskyHamiltonianContainer>(
-      one_body, two_body, orbitals, core_energy, inactive_fock, L_ao));
+      one_body, L_mo, orbitals, core_energy, inactive_fock));
 
   // Save to HDF5
   std::string filename = "test.cholesky.hamiltonian.h5";
@@ -1071,10 +1074,10 @@ TEST_F(HamiltonianTest, CholeskyContainerClone) {
   auto orbitals = std::make_shared<ModelOrbitals>(2, true);
   double core_energy = 1.5;
   Eigen::MatrixXd inactive_fock = Eigen::MatrixXd::Zero(0, 0);
-  Eigen::MatrixXd L_ao = Eigen::MatrixXd::Random(4, 3);
+  Eigen::MatrixXd L_mo = Eigen::MatrixXd::Random(4, 3);
 
   Hamiltonian h1(std::make_unique<CholeskyHamiltonianContainer>(
-      one_body, two_body, orbitals, core_energy, inactive_fock, L_ao));
+      one_body, L_mo, orbitals, core_energy, inactive_fock));
 
   // Test copy constructor (uses clone internally)
   Hamiltonian h2(h1);

--- a/cpp/tests/test_hamiltonian.cpp
+++ b/cpp/tests/test_hamiltonian.cpp
@@ -960,7 +960,7 @@ TEST_F(HamiltonianTest, CholeskyContainerConstruction) {
   double core_energy = 1.5;
   Eigen::MatrixXd inactive_fock = Eigen::MatrixXd::Zero(0, 0);
 
-  // Create cholesky vectors (2x2 AO basis, 3 cholesky vectors)
+  // Create cholesky vectors (2x2 MO basis, 3 cholesky vectors)
   Eigen::MatrixXd L_mo = Eigen::MatrixXd::Random(4, 3);
 
   // Test restricted constructor

--- a/cpp/tests/test_hamiltonian.cpp
+++ b/cpp/tests/test_hamiltonian.cpp
@@ -2229,7 +2229,6 @@ class DummyHamiltonianContainer : public HamiltonianContainer {
   bool is_restricted() const override { return true; }
   nlohmann::json to_json() const override { return {}; }
   void to_hdf5(H5::Group&) const override {}
-  void to_fcidump_file(const std::string&, size_t, size_t) const override {}
   bool is_valid() const override { return true; }
 };
 

--- a/docs/source/_static/examples/python/release_notes_v1_1.py
+++ b/docs/source/_static/examples/python/release_notes_v1_1.py
@@ -165,7 +165,7 @@ orbitals = _orbitals  # alias for display
 constructor = create("hamiltonian_constructor", "qdk_cholesky")
 constructor.settings().set("cholesky_tolerance", 1e-8)
 constructor.settings().set("eri_threshold", 1e-12)
-constructor.settings().set("store_cholesky_vectors", True)
+constructor.settings().set("store_ao_cholesky_vectors", True)
 cholesky_hamiltonian = constructor.run(orbitals)
 # end-cell-cholesky
 ################################################################################

--- a/docs/source/user/comprehensive/algorithms/hamiltonian_constructor.rst
+++ b/docs/source/user/comprehensive/algorithms/hamiltonian_constructor.rst
@@ -135,7 +135,7 @@ A Cholesky decomposition-based implementation for Hamiltonian construction.
 This method uses Cholesky decomposition of the electron repulsion integral (ERI) tensor to reduce memory requirements and computational cost while maintaining high accuracy.
 The decomposition represents the four-center ERIs as products of three-center integrals (Cholesky vectors), which are transformed to the MO basis.
 The output Hamiltonian stores the MO three-center integrals directly in a ``CholeskyHamiltonianContainer``, avoiding expansion to the full four-center representation.
-Additionally, the original AO Cholesky vectors is preserved in the container when ``store_ao_cholesky_vectors`` is enabled, and can be retrieved via ``get_ao_cholesky_vectors()``.
+Additionally, the original AO Cholesky vectors are preserved in the container when ``store_ao_cholesky_vectors`` is enabled, and can be retrieved via ``get_ao_cholesky_vectors()``.
 Four-center integrals are lazily computed from the three-center integrals on demand.
 
 .. rubric:: Settings

--- a/docs/source/user/comprehensive/algorithms/hamiltonian_constructor.rst
+++ b/docs/source/user/comprehensive/algorithms/hamiltonian_constructor.rst
@@ -133,7 +133,9 @@ QDK Cholesky
 
 A Cholesky decomposition-based implementation for Hamiltonian construction.
 This method uses Cholesky decomposition of the electron repulsion integral (ERI) tensor to reduce memory requirements and computational cost while maintaining high accuracy.
-The decomposition represents the four-center ERIs as products of three-center integrals (Cholesky vectors), which are then transformed to the molecular one- and two-electron integrals.
+The decomposition represents the four-center ERIs as products of three-center integrals (Cholesky vectors), which are transformed to the MO basis.
+When ``store_cholesky_vectors`` is enabled, the output Hamiltonian stores the MO three-center integrals directly in a ``CholeskyHamiltonianContainer``, avoiding expansion to the full four-center representation.
+Four-center integrals are lazily computed from the three-center integrals on demand.
 
 .. rubric:: Settings
 
@@ -155,7 +157,7 @@ The decomposition represents the four-center ERIs as products of three-center in
      - ERI screening threshold for skipping negligible shell quartets during Cholesky decomposition. Default: 1e-12
    * - ``store_cholesky_vectors``
      - bool
-     - Whether to store the AO Cholesky vectors in the output Hamiltonian container for potential reuse. Default: false
+     - Whether to store the MO three-center integrals in a ``CholeskyHamiltonianContainer`` instead of expanding to full four-center integrals. This reduces memory from :math:`O(N^4)` to :math:`O(N^2 N_{\text{aux}})`. Four-center integrals are lazily computed on demand. Default: false
 
 Related classes
 ---------------

--- a/docs/source/user/comprehensive/algorithms/hamiltonian_constructor.rst
+++ b/docs/source/user/comprehensive/algorithms/hamiltonian_constructor.rst
@@ -134,7 +134,8 @@ QDK Cholesky
 A Cholesky decomposition-based implementation for Hamiltonian construction.
 This method uses Cholesky decomposition of the electron repulsion integral (ERI) tensor to reduce memory requirements and computational cost while maintaining high accuracy.
 The decomposition represents the four-center ERIs as products of three-center integrals (Cholesky vectors), which are transformed to the MO basis.
-When ``store_cholesky_vectors`` is enabled, the output Hamiltonian stores the MO three-center integrals directly in a ``CholeskyHamiltonianContainer``, avoiding expansion to the full four-center representation.
+The output Hamiltonian stores the MO three-center integrals directly in a ``CholeskyHamiltonianContainer``, avoiding expansion to the full four-center representation.
+Additionally, the original AO Cholesky vectors is preserved in the container when ``store_ao_cholesky_vectors`` is enabled, and can be retrieved via ``get_ao_cholesky_vectors()``.
 Four-center integrals are lazily computed from the three-center integrals on demand.
 
 .. rubric:: Settings
@@ -155,9 +156,9 @@ Four-center integrals are lazily computed from the three-center integrals on dem
    * - ``eri_threshold``
      - float
      - ERI screening threshold for skipping negligible shell quartets during Cholesky decomposition. Default: 1e-12
-   * - ``store_cholesky_vectors``
+   * - ``store_ao_cholesky_vectors``
      - bool
-     - Whether to store the MO three-center integrals in a ``CholeskyHamiltonianContainer`` instead of expanding to full four-center integrals. This reduces memory from :math:`O(N^4)` to :math:`O(N^2 N_{\text{aux}})`. Four-center integrals are lazily computed on demand. Default: false
+     - Whether to store the AO three-center integrals in a ``CholeskyHamiltonianContainer`` in addition to the MO three-center integrals, which are always saved. Default: false
 
 Related classes
 ---------------

--- a/python/src/pybind11/data/hamiltonian.cpp
+++ b/python/src/pybind11/data/hamiltonian.cpp
@@ -368,16 +368,31 @@ Raises:
   // AO Cholesky vectors access
   cholesky_container.def(
       "get_ao_cholesky_vectors",
-      [](const CholeskyHamiltonianContainer& self)
-          -> std::optional<Eigen::MatrixXd> {
-        return self.get_ao_cholesky_vectors();
+      [](const CholeskyHamiltonianContainer& self) -> py::object {
+        const auto& opt = self.get_ao_cholesky_vectors();
+        if (!opt) return py::none();
+        const Eigen::MatrixXd& mat = *opt;
+        // Return a zero-copy view. We tie lifetime to self via
+        // py::return_value_policy semantics by passing a capsule that
+        // prevents GC.  The reference is valid as long as the container
+        // (and thus `self`) is alive; pybind11's prevent-gc mechanism
+        // handles that through the `self` capture in the keep-alive.
+        return py::array_t<double>(
+            {mat.rows(), mat.cols()},  // shape
+            {static_cast<py::ssize_t>(sizeof(double)),
+             static_cast<py::ssize_t>(mat.rows()) *
+                 static_cast<py::ssize_t>(sizeof(double))},  // strides
+                                                             // (col-major)
+            mat.data(),                                      // data pointer
+            py::cast(self));  // prevent GC of self while array is alive
       },
       R"(
-Get the optional AO Cholesky vectors.
+Get the optional AO Cholesky vectors (zero-copy view).
 
 Returns:
     numpy.ndarray or None: AO Cholesky vectors matrix [nao^2 x nchol],
-    or None if not stored.
+    or None if not stored. The returned array shares memory with the
+    internal storage and should not be modified.
 )");
 
   // Two-body integral access (lazily computed from three-center integrals)

--- a/python/src/pybind11/data/hamiltonian.cpp
+++ b/python/src/pybind11/data/hamiltonian.cpp
@@ -271,7 +271,7 @@ Examples:
   cholesky_container.def(
       py::init<const Eigen::MatrixXd&, const Eigen::MatrixXd&,
                std::shared_ptr<Orbitals>, double, const Eigen::MatrixXd&,
-               HamiltonianType>(),
+               std::optional<Eigen::MatrixXd>, HamiltonianType>(),
       R"(
 Constructor for restricted active space Hamiltonian with Cholesky-decomposed integrals.
 
@@ -282,6 +282,8 @@ Args:
     orbitals (Orbitals): Molecular orbital data
     core_energy (float): Core energy (nuclear repulsion + inactive orbitals)
     inactive_fock_matrix (numpy.ndarray): Inactive Fock matrix [norb x norb]
+    ao_cholesky_vectors (numpy.ndarray or None, optional): AO Cholesky vectors
+        for potential reuse. Defaults to None.
     type (HamiltonianType, optional): Type of Hamiltonian (Hermitian by default)
 
 Examples:
@@ -296,6 +298,7 @@ Examples:
       py::arg("one_body_integrals"), py::arg("three_center_integrals"),
       py::arg("orbitals"), py::arg("core_energy"),
       py::arg("inactive_fock_matrix"),
+      py::arg("ao_cholesky_vectors") = py::none(),
       py::arg("type") = HamiltonianType::Hermitian);
 
   // Unrestricted constructor
@@ -303,7 +306,8 @@ Examples:
       py::init<const Eigen::MatrixXd&, const Eigen::MatrixXd&,
                const Eigen::MatrixXd&, const Eigen::MatrixXd&,
                std::shared_ptr<Orbitals>, double, const Eigen::MatrixXd&,
-               const Eigen::MatrixXd&, HamiltonianType>(),
+               const Eigen::MatrixXd&, std::optional<Eigen::MatrixXd>,
+               HamiltonianType>(),
       R"(
 Constructor for unrestricted active space Hamiltonian with Cholesky-decomposed integrals.
 
@@ -318,6 +322,8 @@ Args:
     core_energy (float): Core energy (nuclear repulsion + inactive orbitals)
     inactive_fock_matrix_alpha (numpy.ndarray): Alpha inactive Fock matrix [norb x norb]
     inactive_fock_matrix_beta (numpy.ndarray): Beta inactive Fock matrix [norb x norb]
+    ao_cholesky_vectors (numpy.ndarray or None, optional): AO Cholesky vectors
+        for potential reuse. Defaults to None.
     type (HamiltonianType, optional): Type of Hamiltonian (Hermitian by default)
 
 Examples:
@@ -339,6 +345,7 @@ Examples:
       py::arg("three_center_integrals_bb"), py::arg("orbitals"),
       py::arg("core_energy"), py::arg("inactive_fock_matrix_alpha"),
       py::arg("inactive_fock_matrix_beta"),
+      py::arg("ao_cholesky_vectors") = py::none(),
       py::arg("type") = HamiltonianType::Hermitian);
 
   // Three-center integral access

--- a/python/src/pybind11/data/hamiltonian.cpp
+++ b/python/src/pybind11/data/hamiltonian.cpp
@@ -365,6 +365,21 @@ Raises:
 )",
       py::return_value_policy::reference_internal);
 
+  // AO Cholesky vectors access
+  cholesky_container.def(
+      "get_ao_cholesky_vectors",
+      [](const CholeskyHamiltonianContainer& self)
+          -> std::optional<Eigen::MatrixXd> {
+        return self.get_ao_cholesky_vectors();
+      },
+      R"(
+Get the optional AO Cholesky vectors.
+
+Returns:
+    numpy.ndarray or None: AO Cholesky vectors matrix [nao^2 x nchol],
+    or None if not stored.
+)");
+
   // Two-body integral access (lazily computed from three-center integrals)
   bind_getter_as_property(cholesky_container, "get_two_body_integrals",
                           &CholeskyHamiltonianContainer::get_two_body_integrals,

--- a/python/src/pybind11/data/hamiltonian.cpp
+++ b/python/src/pybind11/data/hamiltonian.cpp
@@ -243,25 +243,25 @@ Returns:
   py::class_<CholeskyHamiltonianContainer, HamiltonianContainer,
              py::smart_holder>
       cholesky_container(data, "CholeskyHamiltonianContainer", R"(
-Represents a molecular Hamiltonian using Cholesky-decomposed two-electron integrals.
+Represents a molecular Hamiltonian using Cholesky-decomposed three-center integrals.
 This class stores molecular Hamiltonian data for quantum chemistry calculations,
 specifically designed for active space methods. It contains:
 
 * One-electron integrals (kinetic + nuclear attraction) in MO representation
-* Two-electron integrals (electron-electron repulsion) in MO representation
-* Cholesky vectors approximating the AO two-electron integrals
+* Three-center two-electron integrals (ij|Q) in MO representation
 * Molecular orbital information for the active space
 * Core energy contributions from inactive orbitals and nuclear repulsion
+
+Four-center integrals are lazily computed from three-center integrals on first access.
 
 Examples:
     >>> import numpy as np
     >>> # Create restricted Hamiltonian
     >>> one_body = np.random.rand(4, 4)  # 4 orbitals
-    >>> two_body = np.random.rand(256)   # 4^4 elements
-    >>> ao_cholesky_vectors = np.random.rand(4*4, 10)   # 10 Cholesky vectors
+    >>> three_center = np.random.rand(16, 10)  # (norb^2) x naux
     >>> inactive_fock_matrix = np.random.rand(4, 4)
     >>> container = CholeskyHamiltonianContainer(
-    ...     one_body, two_body, orbitals, 10.5, inactive_fock_matrix, ao_cholesky_vectors
+    ...     one_body, three_center, orbitals, 10.5, inactive_fock_matrix
     ... )
     >>> # Wrap in Hamiltonian interface
     >>> hamiltonian = Hamiltonian(container)
@@ -269,42 +269,40 @@ Examples:
 
   // Restricted constructor
   cholesky_container.def(
-      py::init<const Eigen::MatrixXd&, const Eigen::VectorXd&,
+      py::init<const Eigen::MatrixXd&, const Eigen::MatrixXd&,
                std::shared_ptr<Orbitals>, double, const Eigen::MatrixXd&,
-               const Eigen::MatrixXd&, HamiltonianType>(),
+               HamiltonianType>(),
       R"(
 Constructor for restricted active space Hamiltonian with Cholesky-decomposed integrals.
 
 Args:
     one_body_integrals (numpy.ndarray): One-electron integrals matrix [norb x norb]
-    two_body_integrals (numpy.ndarray): Two-electron integrals vector [norb^4]
+    three_center_integrals (numpy.ndarray): Three-center two-electron integrals
+        in MO basis [(norb*norb) x naux]
     orbitals (Orbitals): Molecular orbital data
     core_energy (float): Core energy (nuclear repulsion + inactive orbitals)
     inactive_fock_matrix (numpy.ndarray): Inactive Fock matrix [norb x norb]
-    ao_cholesky_vectors (numpy.ndarray): AO basis Cholesky vectors [norb^2 x nvec]
     type (HamiltonianType, optional): Type of Hamiltonian (Hermitian by default)
 
 Examples:
     >>> import numpy as np
     >>> one_body = np.random.rand(4, 4)
-    >>> two_body = np.random.rand(256)  # 4^4 elements
-    >>> ao_cholesky_vecs = np.random.rand(16, 10)  # 16 = 4^2, 10 vectors
+    >>> three_center = np.random.rand(16, 10)  # 16 = 4^2, 10 auxiliary basis functions
     >>> inactive_fock_matrix = np.random.rand(4, 4)
     >>> container = CholeskyHamiltonianContainer(
-    ...     one_body, two_body, orbitals, 10.5, inactive_fock_matrix, ao_cholesky_vectors
+    ...     one_body, three_center, orbitals, 10.5, inactive_fock_matrix
     ... )
 )",
-      py::arg("one_body_integrals"), py::arg("two_body_integrals"),
+      py::arg("one_body_integrals"), py::arg("three_center_integrals"),
       py::arg("orbitals"), py::arg("core_energy"),
-      py::arg("inactive_fock_matrix"), py::arg("ao_cholesky_vectors"),
+      py::arg("inactive_fock_matrix"),
       py::arg("type") = HamiltonianType::Hermitian);
 
   // Unrestricted constructor
   cholesky_container.def(
       py::init<const Eigen::MatrixXd&, const Eigen::MatrixXd&,
-               const Eigen::VectorXd&, const Eigen::VectorXd&,
-               const Eigen::VectorXd&, std::shared_ptr<Orbitals>, double,
                const Eigen::MatrixXd&, const Eigen::MatrixXd&,
+               std::shared_ptr<Orbitals>, double, const Eigen::MatrixXd&,
                const Eigen::MatrixXd&, HamiltonianType>(),
       R"(
 Constructor for unrestricted active space Hamiltonian with Cholesky-decomposed integrals.
@@ -312,40 +310,55 @@ Constructor for unrestricted active space Hamiltonian with Cholesky-decomposed i
 Args:
     one_body_integrals_alpha (numpy.ndarray): Alpha one-electron integrals [norb x norb]
     one_body_integrals_beta (numpy.ndarray): Beta one-electron integrals [norb x norb]
-    two_body_integrals_aaaa (numpy.ndarray): Alpha-alpha-alpha-alpha integrals [norb^4]
-    two_body_integrals_aabb (numpy.ndarray): Alpha-beta-alpha-beta integrals [norb^4]
-    two_body_integrals_bbbb (numpy.ndarray): Beta-beta-beta-beta integrals [norb^4]
+    three_center_integrals_aa (numpy.ndarray): Alpha-alpha three-center integrals
+        [(norb*norb) x naux], orbital pair index in row-major order
+    three_center_integrals_bb (numpy.ndarray): Beta-beta three-center integrals
+        [(norb*norb) x naux], orbital pair index in row-major order
     orbitals (Orbitals): Molecular orbital data
     core_energy (float): Core energy (nuclear repulsion + inactive orbitals)
     inactive_fock_matrix_alpha (numpy.ndarray): Alpha inactive Fock matrix [norb x norb]
     inactive_fock_matrix_beta (numpy.ndarray): Beta inactive Fock matrix [norb x norb]
-    ao_cholesky_vectors (numpy.ndarray): AO basis Cholesky vectors [norb^2 x nvec]
     type (HamiltonianType, optional): Type of Hamiltonian (Hermitian by default)
 
 Examples:
     >>> import numpy as np
     >>> one_body_a = np.random.rand(4, 4)
     >>> one_body_b = np.random.rand(4, 4)
-    >>> two_body_aaaa = np.random.rand(256)
-    >>> two_body_aabb = np.random.rand(256)
-    >>> two_body_bbbb = np.random.rand(256)
-    >>> cholesky_vecs = np.random.rand(16, 10)
+    >>> three_center_aa = np.random.rand(16, 10)  # 16 = 4^2, 10 aux
+    >>> three_center_bb = np.random.rand(16, 10)
     >>> fock_a = np.random.rand(4, 4)
     >>> fock_b = np.random.rand(4, 4)
     >>> container = CholeskyHamiltonianContainer(
     ...     one_body_a, one_body_b,
-    ...     two_body_aaaa, two_body_aabb, two_body_bbbb,
-    ...     orbitals, 10.5, fock_a, fock_b, cholesky_vecs
+    ...     three_center_aa, three_center_bb,
+    ...     orbitals, 10.5, fock_a, fock_b
     ... )
 )",
       py::arg("one_body_integrals_alpha"), py::arg("one_body_integrals_beta"),
-      py::arg("two_body_integrals_aaaa"), py::arg("two_body_integrals_aabb"),
-      py::arg("two_body_integrals_bbbb"), py::arg("orbitals"),
+      py::arg("three_center_integrals_aa"),
+      py::arg("three_center_integrals_bb"), py::arg("orbitals"),
       py::arg("core_energy"), py::arg("inactive_fock_matrix_alpha"),
-      py::arg("inactive_fock_matrix_beta"), py::arg("ao_cholesky_vectors"),
+      py::arg("inactive_fock_matrix_beta"),
       py::arg("type") = HamiltonianType::Hermitian);
 
-  // Two-body integral access
+  // Three-center integral access
+  bind_getter_as_property(
+      cholesky_container, "get_three_center_integrals",
+      &CholeskyHamiltonianContainer::get_three_center_integrals,
+      R"(
+Get three-center integrals in MO basis for all spin channels.
+
+Returns:
+    tuple[numpy.ndarray, numpy.ndarray]: Pair of (aa, bb) three-center
+    two-electron integral matrices, each of dimension [(norb*norb) x naux]
+    with the orbital pair index stored in row-major order.
+
+Raises:
+    RuntimeError: If three-center integrals are not set
+)",
+      py::return_value_policy::reference_internal);
+
+  // Two-body integral access (lazily computed from three-center integrals)
   bind_getter_as_property(cholesky_container, "get_two_body_integrals",
                           &CholeskyHamiltonianContainer::get_two_body_integrals,
                           R"(

--- a/python/tests/test_hamiltonian.py
+++ b/python/tests/test_hamiltonian.py
@@ -1061,6 +1061,49 @@ class TestCholeskyHamiltonian:
             h_unrestricted.get_one_body_integrals()[1], h_unrestricted_json.get_one_body_integrals()[1]
         )
 
+    def test_ao_cholesky_vectors_absent_by_default(self):
+        """Test that AO Cholesky vectors are None when not provided."""
+        one_body = np.eye(2)
+        rng = np.random.default_rng(20)
+        three_center = rng.random((4, 10))
+        orbitals = create_test_orbitals(2)
+
+        container = CholeskyHamiltonianContainer(one_body, three_center, orbitals, 1.0, np.array([]))
+        assert container.get_ao_cholesky_vectors() is None
+
+    def test_ao_cholesky_vectors_present(self):
+        """Test construction with AO Cholesky vectors and retrieval."""
+        one_body = np.eye(2)
+        rng = np.random.default_rng(21)
+        three_center = rng.random((4, 10))
+        ao_vecs = rng.random((9, 5))  # e.g. 3^2 AOs, 5 Cholesky vectors
+        orbitals = create_test_orbitals(2)
+
+        container = CholeskyHamiltonianContainer(
+            one_body, three_center, orbitals, 1.0, np.array([]),
+            ao_cholesky_vectors=ao_vecs
+        )
+        result = container.get_ao_cholesky_vectors()
+        assert result is not None
+        np.testing.assert_array_almost_equal(result, ao_vecs)
+
+    def test_ao_cholesky_vectors_roundtrip_json(self):
+        """Test that AO Cholesky vectors survive JSON round-trip."""
+        one_body = np.eye(2)
+        rng = np.random.default_rng(22)
+        three_center = rng.random((4, 10))
+        ao_vecs = rng.random((9, 5))
+        orbitals = create_test_orbitals(2)
+
+        container = CholeskyHamiltonianContainer(
+            one_body, three_center, orbitals, 1.0, np.array([]),
+            ao_cholesky_vectors=ao_vecs
+        )
+        h = Hamiltonian(container)
+
+        h_roundtrip = Hamiltonian.from_json(h.to_json())
+        assert h_roundtrip.get_container_type() == "cholesky"
+
 
 def test_hamiltonian_data_type_name():
     """Test that Hamiltonian has the correct _data_type_name class attribute."""

--- a/python/tests/test_hamiltonian.py
+++ b/python/tests/test_hamiltonian.py
@@ -1102,6 +1102,15 @@ class TestCholeskyHamiltonian:
         h_roundtrip = Hamiltonian.from_json(h.to_json())
         assert h_roundtrip.get_container_type() == "cholesky"
 
+        roundtrip_data = json.loads(h_roundtrip.to_json())
+        assert "ao_cholesky_vectors" in roundtrip_data["container"]
+        assert np.allclose(
+            np.array(roundtrip_data["container"]["ao_cholesky_vectors"]),
+            ao_vecs,
+            rtol=float_comparison_relative_tolerance,
+            atol=float_comparison_absolute_tolerance,
+        )
+
 
 def test_hamiltonian_data_type_name():
     """Test that Hamiltonian has the correct _data_type_name class attribute."""

--- a/python/tests/test_hamiltonian.py
+++ b/python/tests/test_hamiltonian.py
@@ -607,12 +607,11 @@ class TestCholeskyHamiltonian:
         """Test construction of Cholesky Hamiltonian."""
         one_body = np.eye(2)
         rng = np.random.default_rng(0)
-        two_body = rng.random(2**4)
         cholesky_vecs = rng.random((4, 10))  # 4 = 2^2 AOs, 10 vectors
         coeffs = np.array([[1.0, 0.0], [0.0, 1.0]])
         orbitals = Orbitals(coeffs, None, None, create_test_basis_set(2))
 
-        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, two_body, orbitals, 1.5, np.array([]), cholesky_vecs))
+        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, cholesky_vecs, orbitals, 1.5, np.array([])))
         assert isinstance(h, Hamiltonian)
         assert h.has_one_body_integrals()
         assert h.has_two_body_integrals()
@@ -622,23 +621,21 @@ class TestCholeskyHamiltonian:
         """Test Hamiltonian size properties."""
         one_body = np.eye(3)
         rng = np.random.default_rng(1)
-        two_body = rng.random(3**4)
         cholesky_vecs = rng.random((9, 15))  # 9 = 3^2 AOs, 15 vectors
         orbitals = create_test_orbitals(3)
 
-        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, two_body, orbitals, 0.0, np.array([]), cholesky_vecs))
+        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, cholesky_vecs, orbitals, 0.0, np.array([])))
         assert h.get_orbitals().get_num_molecular_orbitals() == 3
 
     def test_full_constructor(self):
         """Test full constructor with all parameters."""
         one_body = np.array([[1.0, 0.5], [0.5, 2.0]])
         rng = np.random.default_rng(0)
-        two_body = rng.random(2**4)
         cholesky_vecs = rng.random((4, 10))
         coeffs = np.array([[1.0, 0.0], [0.0, 1.0]])
         orbitals = Orbitals(coeffs, None, None, create_test_basis_set(2))
 
-        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, two_body, orbitals, 1.5, np.array([]), cholesky_vecs))
+        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, cholesky_vecs, orbitals, 1.5, np.array([])))
         assert h.has_one_body_integrals()
         assert h.has_two_body_integrals()
         assert h.has_orbitals()
@@ -649,18 +646,12 @@ class TestCholeskyHamiltonian:
         assert np.array_equal(aa, one_body)
         assert np.array_equal(bb, one_body)
 
-        aaaa, aabb, bbbb = h.get_two_body_integrals()
-        assert np.array_equal(aaaa, two_body)
-        assert np.array_equal(aabb, two_body)
-        assert np.array_equal(bbbb, two_body)
-
     def test_one_body_integrals(self):
         """Test one-body integral access."""
         one_body = np.array([[1.0, 0.2], [0.2, 1.5]])
-        two_body = np.zeros(2**4)
         cholesky_vecs = np.random.default_rng(2).random((4, 8))
         orbitals = create_test_orbitals(2)
-        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, two_body, orbitals, 0.0, np.array([]), cholesky_vecs))
+        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, cholesky_vecs, orbitals, 0.0, np.array([])))
         assert h.has_one_body_integrals()
         assert np.array_equal(h.get_one_body_integrals()[0], one_body)
 
@@ -668,47 +659,37 @@ class TestCholeskyHamiltonian:
         """Test two-body integral access."""
         one_body = np.eye(2)
         rng = np.random.default_rng(1)
-        two_body = rng.random(2**4)
         cholesky_vecs = rng.random((4, 10))
         orbitals = create_test_orbitals(2)
-        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, two_body, orbitals, 0.0, np.array([]), cholesky_vecs))
+        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, cholesky_vecs, orbitals, 0.0, np.array([])))
         assert h.has_two_body_integrals()
-        # get_two_body_integrals returns (aaaa, aabb, bbbb) tuple
-        aaaa, aabb, bbbb = h.get_two_body_integrals()
-        # For restricted case, all should be the same and equal to two_body
-        assert np.array_equal(aaaa, two_body)
-        assert np.array_equal(aabb, two_body)
-        assert np.array_equal(bbbb, two_body)
 
     def test_two_body_element_access(self):
         """Test individual two-body element access."""
         one_body = np.eye(2)
         rng = np.random.default_rng(3)
-        two_body = rng.random(2**4)
         cholesky_vecs = rng.random((4, 10))
         orbitals = create_test_orbitals(2)
-        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, two_body, orbitals, 0.0, np.array([]), cholesky_vecs))
+        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, cholesky_vecs, orbitals, 0.0, np.array([])))
         val = h.get_two_body_element(0, 1, 1, 0)
         assert isinstance(val, float)
 
     def test_active_space_management(self):
         """Test core energy handling."""
         one_body = np.eye(3)
-        two_body = np.zeros(3**4)
         cholesky_vecs = np.random.default_rng(4).random((9, 15))
         orbitals = create_test_orbitals(3)
-        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, two_body, orbitals, 2.5, np.array([]), cholesky_vecs))
+        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, cholesky_vecs, orbitals, 2.5, np.array([])))
         assert h.get_core_energy() == 2.5
 
     def test_json_serialization(self):
         """Test JSON serialization and deserialization."""
         one_body = np.array([[1.0, 0.5], [0.5, 2.0]])
         rng = np.random.default_rng(42)
-        two_body = rng.random(2**4)
         cholesky_vecs = rng.random((4, 10))
         coeffs = np.array([[1.0, 0.0], [0.0, 1.0]])
         orbitals = Orbitals(coeffs, None, None, create_test_basis_set(2))
-        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, two_body, orbitals, 1.5, np.array([]), cholesky_vecs))
+        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, cholesky_vecs, orbitals, 1.5, np.array([])))
 
         data = json.loads(h.to_json())
         assert isinstance(data, dict)
@@ -761,11 +742,10 @@ class TestCholeskyHamiltonian:
         """Test JSON file I/O."""
         one_body = np.array([[1.0, 0.5], [0.5, 2.0]])
         rng = np.random.default_rng(42)
-        two_body = rng.random(2**4)
         cholesky_vecs = rng.random((4, 10))
         coeffs = np.array([[1.0, 0.0], [0.0, 1.0]])
         orbitals = Orbitals(coeffs, None, None, create_test_basis_set(2))
-        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, two_body, orbitals, 1.5, np.array([]), cholesky_vecs))
+        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, cholesky_vecs, orbitals, 1.5, np.array([])))
 
         with tempfile.NamedTemporaryFile(suffix=".hamiltonian.json", delete=False) as f:
             filename = f.name
@@ -818,11 +798,10 @@ class TestCholeskyHamiltonian:
         """Test HDF5 file I/O."""
         one_body = np.array([[1.0, 0.5], [0.5, 2.0]])
         rng = np.random.default_rng(42)
-        two_body = rng.random(2**4)
         cholesky_vecs = rng.random((4, 10))
         coeffs = np.array([[1.0, 0.0], [0.0, 1.0]])
         orbitals = Orbitals(coeffs, None, None, create_test_basis_set(2))
-        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, two_body, orbitals, 1.5, np.array([]), cholesky_vecs))
+        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, cholesky_vecs, orbitals, 1.5, np.array([])))
 
         with tempfile.NamedTemporaryFile(suffix=".hamiltonian.h5", delete=False) as f:
             filename = f.name
@@ -875,11 +854,10 @@ class TestCholeskyHamiltonian:
         """Test generic file I/O with format specification."""
         one_body = np.array([[1.0, 0.5], [0.5, 2.0]])
         rng = np.random.default_rng(42)
-        two_body = rng.random(2**4)
         cholesky_vecs = rng.random((4, 10))
         coeffs = np.array([[1.0, 0.0], [0.0, 1.0]])
         orbitals = Orbitals(coeffs, None, None, create_test_basis_set(2))
-        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, two_body, orbitals, 1.5, np.array([]), cholesky_vecs))
+        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, cholesky_vecs, orbitals, 1.5, np.array([])))
 
         # Test JSON format
         with tempfile.NamedTemporaryFile(suffix=".hamiltonian.json", delete=False) as f:
@@ -919,10 +897,9 @@ class TestCholeskyHamiltonian:
         """Test that Cholesky Hamiltonian can be pickled and unpickled correctly."""
         one_body = np.eye(3)
         rng = np.random.default_rng(5)
-        two_body = rng.random(3**4)
         cholesky_vecs = rng.random((9, 15))
         orbitals = create_test_orbitals(3)
-        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, two_body, orbitals, 0.0, np.array([]), cholesky_vecs))
+        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, cholesky_vecs, orbitals, 0.0, np.array([])))
 
         # Test pickling round-trip
         pickled_data = pickle.dumps(h)
@@ -967,11 +944,10 @@ class TestCholeskyHamiltonian:
         rng = np.random.default_rng(42)
         one_body = rng.random((3, 3))
         one_body = 0.5 * (one_body + one_body.T)  # Make symmetric
-        two_body = rng.random(3**4)
         cholesky_vecs = rng.random((9, 15))
         inactive_fock = rng.random((3, 3))
 
-        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, two_body, orbitals, 1.0, inactive_fock, cholesky_vecs))
+        h = Hamiltonian(CholeskyHamiltonianContainer(one_body, cholesky_vecs, orbitals, 1.0, inactive_fock))
 
         # Verify Hamiltonian properties
         assert h.is_restricted()
@@ -984,11 +960,6 @@ class TestCholeskyHamiltonian:
         # Verify integral access
         assert np.array_equal(h.get_one_body_integrals()[0], one_body)
         assert np.array_equal(h.get_one_body_integrals()[1], one_body)
-
-        aaaa, aabb, bbbb = h.get_two_body_integrals()
-        assert np.array_equal(aaaa, two_body)
-        assert np.array_equal(aabb, two_body)
-        assert np.array_equal(bbbb, two_body)
 
     def test_unrestricted_hamiltonian_construction(self):
         """Test unrestricted Cholesky Hamiltonian construction and properties."""
@@ -1006,10 +977,8 @@ class TestCholeskyHamiltonian:
         rng = np.random.default_rng(123)
         one_body_alpha = np.array([[1.0, 0.2], [0.2, 1.5]])
         one_body_beta = np.array([[1.1, 0.3], [0.3, 1.6]])
-        two_body_aaaa = rng.random(2**4)
-        two_body_aabb = rng.random(2**4)
-        two_body_bbbb = rng.random(2**4)
-        cholesky_vecs = rng.random((4, 10))
+        cholesky_vecs_aa = rng.random((4, 10))
+        cholesky_vecs_bb = rng.random((4, 10))
         inactive_fock_alpha = np.array([[0.5, 0.1], [0.1, 0.7]])
         inactive_fock_beta = np.array([[0.6, 0.2], [0.2, 0.8]])
 
@@ -1017,14 +986,12 @@ class TestCholeskyHamiltonian:
             CholeskyHamiltonianContainer(
                 one_body_alpha,
                 one_body_beta,
-                two_body_aaaa,
-                two_body_aabb,
-                two_body_bbbb,
+                cholesky_vecs_aa,
+                cholesky_vecs_bb,
                 orbitals,
                 2.0,
                 inactive_fock_alpha,
                 inactive_fock_beta,
-                cholesky_vecs,
             )
         )
 
@@ -1039,10 +1006,6 @@ class TestCholeskyHamiltonian:
         # Verify separate alpha/beta integral access
         assert np.array_equal(h.get_one_body_integrals()[0], one_body_alpha)
         assert np.array_equal(h.get_one_body_integrals()[1], one_body_beta)
-        aaaa, aabb, bbbb = h.get_two_body_integrals()
-        assert np.array_equal(aaaa, two_body_aaaa)
-        assert np.array_equal(aabb, two_body_aabb)
-        assert np.array_equal(bbbb, two_body_bbbb)
 
     def test_unrestricted_vs_restricted_serialization(self):
         """Test that restricted/unrestricted nature is preserved in serialization."""
@@ -1052,10 +1015,9 @@ class TestCholeskyHamiltonian:
         orbitals_restricted = Orbitals(coeffs, None, None, basis_set)
 
         one_body = np.array([[1.0, 0.1], [0.1, 1.0]])
-        two_body = np.ones(16) * 0.5
         cholesky_vecs = np.random.default_rng(6).random((4, 8))
         h_restricted = Hamiltonian(
-            CholeskyHamiltonianContainer(one_body, two_body, orbitals_restricted, 1.0, np.eye(2), cholesky_vecs)
+            CholeskyHamiltonianContainer(one_body, cholesky_vecs, orbitals_restricted, 1.0, np.eye(2))
         )
 
         # Test unrestricted Hamiltonian
@@ -1065,22 +1027,18 @@ class TestCholeskyHamiltonian:
 
         one_body_alpha = np.array([[1.0, 0.1], [0.1, 1.0]])
         one_body_beta = np.array([[1.1, 0.2], [0.2, 1.1]])
-        two_body_aaaa = np.ones(16) * 1.0
-        two_body_aabb = np.ones(16) * 2.0
-        two_body_bbbb = np.ones(16) * 3.0
-        cholesky_vecs_unres = np.random.default_rng(7).random((4, 8))
+        cholesky_vecs_aa = np.random.default_rng(7).random((4, 8))
+        cholesky_vecs_bb = np.random.default_rng(7).random((4, 8))
         h_unrestricted = Hamiltonian(
             CholeskyHamiltonianContainer(
                 one_body_alpha,
                 one_body_beta,
-                two_body_aaaa,
-                two_body_aabb,
-                two_body_bbbb,
+                cholesky_vecs_aa,
+                cholesky_vecs_bb,
                 orbitals_unrestricted,
                 2.0,
                 np.eye(2),
                 np.eye(2),
-                cholesky_vecs_unres,
             )
         )
 

--- a/python/tests/test_hamiltonian.py
+++ b/python/tests/test_hamiltonian.py
@@ -1080,8 +1080,7 @@ class TestCholeskyHamiltonian:
         orbitals = create_test_orbitals(2)
 
         container = CholeskyHamiltonianContainer(
-            one_body, three_center, orbitals, 1.0, np.array([]),
-            ao_cholesky_vectors=ao_vecs
+            one_body, three_center, orbitals, 1.0, np.array([]), ao_cholesky_vectors=ao_vecs
         )
         result = container.get_ao_cholesky_vectors()
         assert result is not None
@@ -1096,8 +1095,7 @@ class TestCholeskyHamiltonian:
         orbitals = create_test_orbitals(2)
 
         container = CholeskyHamiltonianContainer(
-            one_body, three_center, orbitals, 1.0, np.array([]),
-            ao_cholesky_vectors=ao_vecs
+            one_body, three_center, orbitals, 1.0, np.array([]), ao_cholesky_vectors=ao_vecs
         )
         h = Hamiltonian(container)
 


### PR DESCRIPTION
Cholesky Hamiltonian used to save AO based integrals and save 4 center integrals during serialization. This PR did the following:

1. Cholesky Hamiltonian is no longer a derived class of canonical four center Hamiltonian
2. Cholesky Hamiltonian stores MO based integrals instead of AO, and it does not store the full 4-center integral (note changes in constructor breaks original API)
3. Cholesky Hamiltonian writes MO based 3-center integrals to disk when from_json and from_hdf5 is called.
4. The setting `store_cholesky_vectors` is changed to `store_ao_cholesky_vector`. It means we no longer want to store the result from CholeskyHamiltonianFactory inside CanonicalFourCenterContainer. We also added the ability to optionally store AO based Cholesky vector in the Hamiltonian container. This is done with optional parameter in constructing.