### PR TITLE
Remove _to_fcidump_file method from Hamiltonian

### DIFF
--- a/cpp/include/qdk/chemistry/data/hamiltonian.hpp
+++ b/cpp/include/qdk/chemistry/data/hamiltonian.hpp
@@ -644,16 +644,6 @@ class Hamiltonian : public DataClass,
    */
   static std::shared_ptr<Hamiltonian> _from_hdf5_file(
       const std::string& filename);
-
-  /**
-   * @brief Save FCIDUMP file without filename validation (internal use)
-   * @param filename Path to FCIDUMP file to create/overwrite
-   * @param nalpha Number of alpha electrons
-   * @param nbeta Number of beta electrons
-   * @throws std::runtime_error if I/O error occurs
-   */
-  void _to_fcidump_file(const std::string& filename, size_t nalpha,
-                        size_t nbeta) const;
 };
 
 // Enforce inheritance from base class and presence of required methods.


### PR DESCRIPTION
Removed internal method declaration for saving FCIDUMP files.