### PR TITLE
Fix int32 overflow in Cholesky decomposition and container serialization

### DIFF
--- a/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.cpp
@@ -326,20 +326,26 @@ std::tuple<std::vector<double>, size_t> compute_cholesky_vectors(
 
     // correct for cholesky contributions by subtracting previous vectors
     if (current_col > 0) {
-      // Extract rows from L_data corresponding to shell pairs
-      std::vector<double> L_rows(n_cols * current_col);
+      // Use Eigen::Map with 64-bit (ptrdiff_t) indexing to avoid LP64 BLAS
+      // int32 overflow when num_aos2 * current_col > INT32_MAX.
+      // L_data is a column-major matrix of shape (num_aos2 x current_col).
+      // NOTE: L_map must be consumed before L_data grows (via insert() below),
+      // since reallocation would invalidate the mapped pointer.
+      Eigen::Map<const Eigen::MatrixXd> L_map(L_data.data(), num_aos2,
+                                              current_col);
+
+      // Extract rows from L_data corresponding to shell pairs.
+      // L_rows(col, k) = L_data(global_index[col], k) for each shell pair.
+      Eigen::MatrixXd L_rows(n_cols, current_col);
       for (size_t col = 0; col < n_cols; ++col) {
-        const size_t global_index = shell_pairs_to_lookup[col];
-        // Copy row from L_data: L_rows[col, :] = L_data[global_index, :]
-        blas::copy(current_col, L_data.data() + global_index, num_aos2,
-                   L_rows.data() + col, n_cols);
+        L_rows.row(col) = L_map.row(shell_pairs_to_lookup[col]);
       }
-      // Compute eri_col -= L_data * L_rows^T
-      // eri_col is num_aos2 x n_cols, L_data is num_aos2 x current_col,
+
+      // Compute eri_col -= L_map * L_rows^T
+      // eri_col is num_aos2 x n_cols, L_map is num_aos2 x current_col,
       // L_rows^T is current_col x n_cols
-      blas::gemm(blas::Layout::ColMajor, blas::Op::NoTrans, blas::Op::Trans,
-                 num_aos2, n_cols, current_col, -1.0, L_data.data(), num_aos2,
-                 L_rows.data(), n_cols, 1.0, eri_col.data(), num_aos2);
+      Eigen::Map<Eigen::MatrixXd> eri_col_map(eri_col.data(), num_aos2, n_cols);
+      eri_col_map.noalias() -= L_map * L_rows.transpose();
     }
 
     // form new cholesky vector for each index in shell pair avoid redundant

--- a/cpp/src/qdk/chemistry/data/hamiltonian_containers/cholesky.cpp
+++ b/cpp/src/qdk/chemistry/data/hamiltonian_containers/cholesky.cpp
@@ -314,9 +314,10 @@ nlohmann::json CholeskyHamiltonianContainer::to_json() const {
 
     // Store alpha one-body integrals
     std::vector<std::vector<double>> one_body_alpha_vec;
-    for (int i = 0; i < _one_body_integrals.first->rows(); ++i) {
+    for (Eigen::Index i = 0; i < _one_body_integrals.first->rows(); ++i) {
       std::vector<double> row;
-      for (int j_idx = 0; j_idx < _one_body_integrals.first->cols(); ++j_idx) {
+      for (Eigen::Index j_idx = 0; j_idx < _one_body_integrals.first->cols();
+           ++j_idx) {
         row.push_back((*_one_body_integrals.first)(i, j_idx));
       }
       one_body_alpha_vec.push_back(row);
@@ -326,9 +327,9 @@ nlohmann::json CholeskyHamiltonianContainer::to_json() const {
     // Store beta one-body integrals (only if unrestricted)
     if (is_unrestricted()) {
       std::vector<std::vector<double>> one_body_beta_vec;
-      for (int i = 0; i < _one_body_integrals.second->rows(); ++i) {
+      for (Eigen::Index i = 0; i < _one_body_integrals.second->rows(); ++i) {
         std::vector<double> row;
-        for (int j_idx = 0; j_idx < _one_body_integrals.second->cols();
+        for (Eigen::Index j_idx = 0; j_idx < _one_body_integrals.second->cols();
              ++j_idx) {
           row.push_back((*_one_body_integrals.second)(i, j_idx));
         }
@@ -349,10 +350,10 @@ nlohmann::json CholeskyHamiltonianContainer::to_json() const {
 
     // Store aa
     std::vector<std::vector<double>> three_center_aa_vec;
-    for (int i = 0; i < _three_center_integrals.first->rows(); ++i) {
+    for (Eigen::Index i = 0; i < _three_center_integrals.first->rows(); ++i) {
       std::vector<double> row;
-      for (int j_idx = 0; j_idx < _three_center_integrals.first->cols();
-           ++j_idx) {
+      for (Eigen::Index j_idx = 0;
+           j_idx < _three_center_integrals.first->cols(); ++j_idx) {
         row.push_back((*_three_center_integrals.first)(i, j_idx));
       }
       three_center_aa_vec.push_back(row);
@@ -362,10 +363,11 @@ nlohmann::json CholeskyHamiltonianContainer::to_json() const {
     if (is_unrestricted()) {
       // Store bb
       std::vector<std::vector<double>> three_center_bb_vec;
-      for (int i = 0; i < _three_center_integrals.second->rows(); ++i) {
+      for (Eigen::Index i = 0; i < _three_center_integrals.second->rows();
+           ++i) {
         std::vector<double> row;
-        for (int j_idx = 0; j_idx < _three_center_integrals.second->cols();
-             ++j_idx) {
+        for (Eigen::Index j_idx = 0;
+             j_idx < _three_center_integrals.second->cols(); ++j_idx) {
           row.push_back((*_three_center_integrals.second)(i, j_idx));
         }
         three_center_bb_vec.push_back(row);
@@ -382,9 +384,9 @@ nlohmann::json CholeskyHamiltonianContainer::to_json() const {
     j["has_inactive_fock_matrix"] = true;
     // Store alpha inactive Fock matrix
     std::vector<std::vector<double>> inactive_fock_alpha_vec;
-    for (int i = 0; i < _inactive_fock_matrix.first->rows(); ++i) {
+    for (Eigen::Index i = 0; i < _inactive_fock_matrix.first->rows(); ++i) {
       std::vector<double> row;
-      for (int j_idx = 0; j_idx < _inactive_fock_matrix.first->cols();
+      for (Eigen::Index j_idx = 0; j_idx < _inactive_fock_matrix.first->cols();
            ++j_idx) {
         row.push_back((*_inactive_fock_matrix.first)(i, j_idx));
       }
@@ -395,10 +397,10 @@ nlohmann::json CholeskyHamiltonianContainer::to_json() const {
     // Store beta inactive Fock matrix (only if unrestricted)
     if (is_unrestricted()) {
       std::vector<std::vector<double>> inactive_fock_beta_vec;
-      for (int i = 0; i < _inactive_fock_matrix.second->rows(); ++i) {
+      for (Eigen::Index i = 0; i < _inactive_fock_matrix.second->rows(); ++i) {
         std::vector<double> row;
-        for (int j_idx = 0; j_idx < _inactive_fock_matrix.second->cols();
-             ++j_idx) {
+        for (Eigen::Index j_idx = 0;
+             j_idx < _inactive_fock_matrix.second->cols(); ++j_idx) {
           row.push_back((*_inactive_fock_matrix.second)(i, j_idx));
         }
         inactive_fock_beta_vec.push_back(row);
@@ -419,9 +421,10 @@ nlohmann::json CholeskyHamiltonianContainer::to_json() const {
 
   if (_ao_cholesky_vectors) {
     std::vector<std::vector<double>> ao_cholesky_vectors_vec;
-    for (int i = 0; i < _ao_cholesky_vectors->rows(); ++i) {
+    for (Eigen::Index i = 0; i < _ao_cholesky_vectors->rows(); ++i) {
       std::vector<double> row;
-      for (int j_idx = 0; j_idx < _ao_cholesky_vectors->cols(); ++j_idx) {
+      for (Eigen::Index j_idx = 0; j_idx < _ao_cholesky_vectors->cols();
+           ++j_idx) {
         row.push_back((*_ao_cholesky_vectors)(i, j_idx));
       }
       ao_cholesky_vectors_vec.push_back(row);
@@ -460,15 +463,16 @@ CholeskyHamiltonianContainer::from_json(const nlohmann::json& j) {
     auto load_matrix =
         [](const nlohmann::json& matrix_json) -> Eigen::MatrixXd {
       auto matrix_vec = matrix_json.get<std::vector<std::vector<double>>>();
-      int rows = matrix_vec.size();
-      int cols = rows > 0 ? matrix_vec[0].size() : 0;
+      Eigen::Index rows = static_cast<Eigen::Index>(matrix_vec.size());
+      Eigen::Index cols =
+          rows > 0 ? static_cast<Eigen::Index>(matrix_vec[0].size()) : 0;
       Eigen::MatrixXd matrix(rows, cols);
-      for (int i = 0; i < rows; ++i) {
-        if (static_cast<int>(matrix_vec[i].size()) != cols) {
+      for (Eigen::Index i = 0; i < rows; ++i) {
+        if (static_cast<Eigen::Index>(matrix_vec[i].size()) != cols) {
           throw std::runtime_error(
               "Matrix rows have inconsistent column counts");
         }
-        for (int j_idx = 0; j_idx < cols; ++j_idx) {
+        for (Eigen::Index j_idx = 0; j_idx < cols; ++j_idx) {
           matrix(i, j_idx) = matrix_vec[i][j_idx];
         }
       }


### PR DESCRIPTION
**Fixes two int32 overflow bugs in the Cholesky Hamiltonian code that cause silent data corruption for systems with approximately 900 or more AOs.**

When `compute_cholesky_vectors()` exceeds approximately 2622 Cholesky vectors with 819,025 or more AO pairs (nao >= 905), the LP64 BLAS calls `blas::copy` and `blas::gemm` overflow their internal 32-bit Fortran integer index computations (`j * incx` and `j * lda` where `incx = lda = nao^2`). This silently corrupts the L vector subtraction step, producing incorrect Cholesky vectors from that rank onward.

Separately, the JSON serialization in `CholeskyHamiltonianContainer::to_json()` and `from_json()` uses `int` loop variables compared against `Eigen::Index` (int64_t) return values from `.rows()` and `.cols()`, which is a latent overflow for large matrices.

**Commit 1** (`cholesky.cpp`): Replace `int` loop variables with `Eigen::Index` in all JSON serialization loops (one-body, three-center, inactive Fock, AO Cholesky vectors, and the `load_matrix` lambda). Follows the same pattern as PR 439.

**Commit 2** (`cholesky_hamiltonian.cpp`): Replace the `blas::copy` (strided row gather) and `blas::gemm` (L * L_rows^T subtraction) with `Eigen::Map` operations that use 64-bit `ptrdiff_t` pointer arithmetic. Since `EIGEN_USE_BLAS` is not defined in the build, Eigen's internal gemm handles the full computation with 64-bit indexing, eliminating the LP64 overflow entirely.
