### PR TITLE
Batch GEMM orthogonalization in Cholesky decomposition

### DIFF
--- a/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.cpp
@@ -5,6 +5,7 @@
 #include "cholesky_hamiltonian.hpp"
 
 // STL Headers
+#include <algorithm>
 #include <cstring>
 #include <filesystem>
 #include <set>
@@ -218,6 +219,13 @@ std::tuple<std::vector<double>, size_t> compute_cholesky_vectors(
   }
 #endif
 
+  // Target number of GEMM columns per batched orthogonalization call.
+  // Amortizes memory-bandwidth cost of reading L_data by combining multiple
+  // shell pairs into one GEMM. Auto-adapts to basis set: small shells (s,p)
+  // batch many; large shells (d,f) batch few. Value of 20 saturates bandwidth
+  // on typical hardware.
+  constexpr size_t TARGET_GEMM_COLS = 20;
+
   QDK_LOGGER().info("Cholesky Rank | Max Diagonal Element");
   double D_max = 0.0;
   while (current_col < max_rank) {
@@ -226,40 +234,69 @@ std::tuple<std::vector<double>, size_t> compute_cholesky_vectors(
       break;
     }
 
-    // get max diagonal element
-    size_t q_shell_pair_max;
-    D_max = 0.0;
-    size_t s1_max, s2_max;
+    // === Step 1: Select top-B shell pairs by max diagonal ===
+    struct SPInfo {
+      size_t sp_index, s1, s2;
+      double max_diag;
+    };
+    std::vector<SPInfo> sp_list;
+    sp_list.reserve(active_shell_pairs.size());
     for (const auto sp_index : active_shell_pairs) {
       const auto [s1, s2] = sp_index_to_shells[sp_index];
-      // get block max
       const auto& diag = D_shell_pair[sp_index];
       const double block_max = *std::max_element(diag.begin(), diag.end());
-      if (block_max > D_max) {
-        D_max = block_max;
-        q_shell_pair_max = sp_index;
-        s1_max = s1;
-        s2_max = s2;
-      }
+      sp_list.push_back({sp_index, s1, s2, block_max});
     }
-    QDK_LOGGER().info("{:>13} | {}", current_col, D_max);
+    // Sort all active shell pairs by max diagonal (descending)
+    std::sort(sp_list.begin(), sp_list.end(),
+              [](const SPInfo& a, const SPInfo& b) {
+                return a.max_diag > b.max_diag;
+              });
 
-    // check convergence
+    D_max = sp_list[0].max_diag;
     if (D_max < threshold) {
+      QDK_LOGGER().info("{:>13} | {}", current_col, D_max);
       break;
     }
 
-    // get column for max shell pair (s1_max, s2_max)
-    const size_t n1_max = obs[s1_max].size();
-    const size_t n2_max = obs[s2_max].size();
-    const size_t n_cols = n1_max * n2_max;
-    const size_t eri_col_used = num_aos2 * n_cols;
-    std::fill_n(eri_col_max.begin(), eri_col_used, 0.0);
+    // Accumulate shell pairs until we reach the target column count
+    size_t n_batch = 0;
+    size_t total_n_cols = 0;
+    for (size_t b = 0; b < sp_list.size(); ++b) {
+      if (sp_list[b].max_diag < threshold) break;
+      const size_t n1 = obs[sp_list[b].s1].size();
+      const size_t n2 = obs[sp_list[b].s2].size();
+      total_n_cols += n1 * n2;
+      n_batch++;
+      if (total_n_cols >= TARGET_GEMM_COLS) break;
+    }
+    if (n_batch == 0) break;
 
-    // Accumulate ERI integrals directly into the shared buffer.
-    // Thread assignment by (s34++) % nthreads maps each (s3, s4) shell pair
-    // to exactly one thread, so each (bf3, bf4) index block is written by a
-    // single thread. No synchronization or per-thread buffers are needed.
+    // Build batch entries
+    struct BatchEntry {
+      size_t sp_index, s1, s2, n1, n2, n_cols, col_offset;
+      size_t bf1_st, bf2_st;
+    };
+    std::vector<BatchEntry> batch(n_batch);
+    total_n_cols = 0;  // recompute for accurate offsets
+    for (size_t b = 0; b < n_batch; ++b) {
+      const auto& sp = sp_list[b];
+      const size_t n1 = obs[sp.s1].size();
+      const size_t n2 = obs[sp.s2].size();
+      batch[b] = {
+          sp.sp_index,  sp.s1,           sp.s2,          n1, n2, n1 * n2,
+          total_n_cols, shell2bf[sp.s1], shell2bf[sp.s2]};
+      total_n_cols += n1 * n2;
+    }
+
+    QDK_LOGGER().info("{:>13} | {} | batch={}", current_col, D_max, n_batch);
+
+    // === Step 2: Compute ERI columns for ALL batch entries ===
+    // Each shell pair writes to its own section of eri_col_batch.
+    // No dependency between shell pairs — fully parallel.
+    const size_t eri_batch_size = num_aos2 * total_n_cols;
+    std::vector<double> eri_col_batch(eri_batch_size, 0.0);
+
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
@@ -271,147 +308,152 @@ std::tuple<std::vector<double>, size_t> compute_cholesky_vectors(
 #endif
       auto& engine = engines_coulomb[thread_id];
       const auto& buf = engine.results();
-      for (size_t s3 = 0, s34 = 0; s3 < num_shells; ++s3) {
-        const size_t n3 = obs[s3].size();
-        const size_t bf3_st = shell2bf[s3];
-        for (size_t s4 = 0; s4 < num_shells; ++s4) {
-          // Assign to threads
-          if ((s34++) % nthreads != thread_id) continue;
 
-          // screening via schwarz bounds
-          if (K_schwarz(s1_max, s2_max) * K_schwarz(s3, s4) < eri_threshold) {
-            continue;
+      for (size_t b = 0; b < n_batch; ++b) {
+        const auto& be = batch[b];
+        double* eri_out = eri_col_batch.data() + be.col_offset * num_aos2;
+
+        for (size_t s3 = 0, s34 = 0; s3 < num_shells; ++s3) {
+          const size_t n3 = obs[s3].size();
+          const size_t bf3_st = shell2bf[s3];
+          for (size_t s4 = 0; s4 < num_shells; ++s4) {
+            if ((s34++) % nthreads != thread_id) continue;
+
+            if (K_schwarz(be.s1, be.s2) * K_schwarz(s3, s4) < eri_threshold) {
+              continue;
+            }
+
+            const size_t n4 = obs[s4].size();
+            const size_t bf4_st = shell2bf[s4];
+
+            engine.compute2<::libint2::Operator::coulomb,
+                            ::libint2::BraKet::xx_xx, 0>(obs[be.s1], obs[be.s2],
+                                                         obs[s3], obs[s4]);
+            const auto& res = buf[0];
+            if (res == nullptr) continue;
+
+            for (size_t i = 0, ijkl = 0; i < be.n1; ++i) {
+              const size_t ind_i = i * be.n2;
+              for (size_t j = 0; j < be.n2; ++j) {
+                const size_t ind_ij = (ind_i + j) * num_aos2;
+                for (size_t k = 0; k < n3; ++k) {
+                  const size_t ind_ijk = ind_ij + (bf3_st + k) * num_aos;
+                  for (size_t l = 0; l < n4; ++l, ++ijkl) {
+                    eri_out[ind_ijk + (bf4_st + l)] += res[ijkl];
+                  }
+                }
+              }
+            }
+          }  // s4
+        }  // s3
+      }  // for each batch entry
+    }  // omp parallel
+    // === Step 3: ONE big GEMM for all columns at once ===
+    // Precompute lookup for all columns
+    std::vector<size_t> all_lookup(total_n_cols);
+    for (size_t b = 0; b < n_batch; ++b) {
+      const auto& be = batch[b];
+      for (size_t i = 0; i < be.n1; ++i) {
+        for (size_t j = 0; j < be.n2; ++j) {
+          const size_t local_idx = i * be.n2 + j;
+          all_lookup[be.col_offset + local_idx] =
+              (be.bf1_st + i) * num_aos + (be.bf2_st + j);
+        }
+      }
+    }
+
+    if (current_col > 0) {
+      // Gather rows: L_rows[col, :] = L_data[all_lookup[col], :]
+      std::vector<double> L_rows(total_n_cols * current_col);
+      for (size_t col = 0; col < total_n_cols; ++col) {
+        blas::copy(current_col, L_data.data() + all_lookup[col], num_aos2,
+                   L_rows.data() + col, total_n_cols);
+      }
+      // One big GEMM: eri_col_batch -= L_data * L_rows^T
+      blas::gemm(blas::Layout::ColMajor, blas::Op::NoTrans, blas::Op::Trans,
+                 num_aos2, total_n_cols, current_col, -1.0, L_data.data(),
+                 num_aos2, L_rows.data(), total_n_cols, 1.0,
+                 eri_col_batch.data(), num_aos2);
+    }
+    // === Step 4: Form vectors (sequentially within batch) ===
+    // Process each batch entry, forming vectors and doing in-batch
+    // Gram-Schmidt against vectors formed earlier in this batch.
+    for (size_t b = 0; b < n_batch; ++b) {
+      const auto& be = batch[b];
+      double* eri_col = eri_col_batch.data() + be.col_offset * num_aos2;
+
+      for (size_t local_i = 0; local_i < be.n1; ++local_i) {
+        const size_t j_max = (be.s1 == be.s2) ? (local_i + 1) : be.n2;
+        for (size_t local_j = 0; local_j < j_max; ++local_j) {
+          const size_t local_index = local_i * be.n2 + local_j;
+          const double D_val = D_shell_pair[be.sp_index][local_index];
+
+          if (D_val < threshold) continue;
+
+          double Q_max = std::sqrt(1.0 / D_val);
+          std::vector<double> L_col_vec(num_aos2);
+          blas::copy(num_aos2, eri_col + local_index * num_aos2, 1,
+                     L_col_vec.data(), 1);
+          blas::scal(num_aos2, Q_max, L_col_vec.data(), 1);
+
+          L_data.insert(L_data.end(), L_col_vec.data(),
+                        L_col_vec.data() + num_aos2);
+
+          const double* L_col = L_data.data() + current_col * num_aos2;
+
+          // In-batch Gram-Schmidt: update remaining ERI columns in this
+          // shell pair (same as before)
+          for (size_t col = local_index + 1; col < be.n1 * be.n2; ++col) {
+            const size_t global_col_idx =
+                (be.bf1_st + col / be.n2) * num_aos + (be.bf2_st + col % be.n2);
+            const double scale_factor = -L_col[global_col_idx];
+            blas::axpy(num_aos2, scale_factor, L_col, 1,
+                       eri_col + col * num_aos2, 1);
           }
 
-          const size_t n4 = obs[s4].size();
-          const size_t bf4_st = shell2bf[s4];
-
-          // compute integral shell quartet
-          engine.compute2<::libint2::Operator::coulomb,
-                          ::libint2::BraKet::xx_xx, 0>(obs[s1_max], obs[s2_max],
-                                                       obs[s3], obs[s4]);
-          const auto& res = buf[0];
-          if (res == nullptr) continue;
-
-          // fill in eri_col — direct write, no thread-local copy
-          for (size_t i = 0, ijkl = 0; i < n1_max; ++i) {
-            const size_t ind_i = i * n2_max;
-            for (size_t j = 0; j < n2_max; ++j) {
-              const size_t ind_ij = (ind_i + j) * num_aos2;
-              for (size_t k = 0; k < n3; ++k) {
-                const size_t ind_ijk = ind_ij + (bf3_st + k) * num_aos;
-                for (size_t l = 0; l < n4; ++l, ++ijkl) {
-                  const size_t ind_ijkl = ind_ijk + (bf4_st + l);
-                  eri_col_max[ind_ijkl] += res[ijkl];
-                }  // l
-              }  // k
-            }  // j
-          }  // i
-        }  // s4
-      }  // s3
-    }  // omp parallel
-    // No merge step — threads wrote directly to shared buffer.
-
-    // precompute lookup
-    const size_t bf1_max_st = shell2bf[s1_max];
-    const size_t bf2_max_st = shell2bf[s2_max];
-    std::vector<size_t> shell_pairs_to_lookup(n1_max * n2_max);
-    for (size_t i = 0; i < n1_max; ++i) {
-      for (size_t j = 0; j < n2_max; ++j) {
-        const size_t local_index = i * n2_max + j;
-        shell_pairs_to_lookup[local_index] =
-            (bf1_max_st + i) * num_aos + (bf2_max_st + j);
-      }
-    }
-
-    // correct for cholesky contributions by subtracting previous vectors
-    if (current_col > 0) {
-      // Extract rows from L_data corresponding to shell pairs
-      std::vector<double> L_rows(n_cols * current_col);
-      for (size_t col = 0; col < n_cols; ++col) {
-        const size_t global_index = shell_pairs_to_lookup[col];
-        // Copy row from L_data: L_rows[col, :] = L_data[global_index, :]
-        blas::copy(current_col, L_data.data() + global_index, num_aos2,
-                   L_rows.data() + col, n_cols);
-      }
-      // Compute eri_col -= L_data * L_rows^T
-      // eri_col is num_aos2 x n_cols, L_data is num_aos2 x current_col,
-      // L_rows^T is current_col x n_cols
-      blas::gemm(blas::Layout::ColMajor, blas::Op::NoTrans, blas::Op::Trans,
-                 num_aos2, n_cols, current_col, -1.0, L_data.data(), num_aos2,
-                 L_rows.data(), n_cols, 1.0, eri_col_max.data(), num_aos2);
-    }
-
-    // form new cholesky vector for each index in shell pair avoid redundant
-    // vectors for symmetric shell pairs
-    for (size_t local_i = 0; local_i < n1_max; ++local_i) {
-      const size_t j_max = (s1_max == s2_max) ? (local_i + 1) : n2_max;
-      for (size_t local_j = 0; local_j < j_max; ++local_j) {
-        const size_t local_index = local_i * n2_max + local_j;
-        const double D_val = D_shell_pair[q_shell_pair_max][local_index];
-
-        // skip if below threshold
-        if (D_val < threshold) {
-          continue;
-        }
-
-        // Form Cholesky vector
-        double Q_max = std::sqrt(1.0 / D_val);
-        std::vector<double> L_col_vec(num_aos2);
-        // Copy column from eri_col
-        blas::copy(num_aos2, eri_col_max.data() + local_index * num_aos2, 1,
-                   L_col_vec.data(), 1);
-        // Scale by Q_max
-        blas::scal(num_aos2, Q_max, L_col_vec.data(), 1);
-
-        // append to L_data
-        L_data.insert(L_data.end(), L_col_vec.data(),
-                      L_col_vec.data() + num_aos2);
-
-        // reference to current column
-        const double* L_col = L_data.data() + current_col * num_aos2;
-
-        // Update remaining columns in eri_col for vectors formed within this
-        // shell pair
-        for (size_t col = local_index + 1; col < n1_max * n2_max; ++col) {
-          const size_t global_col_idx = shell_pairs_to_lookup[col];
-          const double scale_factor = -L_col[global_col_idx];
-          double* eri_col_ptr = eri_col_max.data() + col * num_aos2;
-          blas::axpy(num_aos2, scale_factor, L_col, 1, eri_col_ptr, 1);
-        }
-
-        // Update diagonal elements
-        std::vector<size_t> shell_pairs_to_remove;
-        for (const auto sp_index : active_shell_pairs) {
-          const auto [s1, s2] = sp_index_to_shells[sp_index];
-          const auto n1 = obs[s1].size();
-          const auto n2 = obs[s2].size();
-          const auto bf1_st = shell2bf[s1];
-          const auto bf2_st = shell2bf[s2];
-          // update diagonal block
-          for (size_t i = 0; i < n1; ++i) {
-            const size_t bf1_st_i = (bf1_st + i) * num_aos;
-            for (size_t j = 0; j < n2; ++j) {
-              const size_t idx = i * n2 + j;
-              const size_t global_idx = bf1_st_i + (bf2_st + j);
-              D_shell_pair[sp_index][idx] -=
-                  L_col[global_idx] * L_col[global_idx];
+          // ALSO update ERI columns of LATER batch entries
+          // (cross-batch Gram-Schmidt)
+          for (size_t b2 = b + 1; b2 < n_batch; ++b2) {
+            const auto& be2 = batch[b2];
+            double* eri_col2 = eri_col_batch.data() + be2.col_offset * num_aos2;
+            for (size_t col2 = 0; col2 < be2.n1 * be2.n2; ++col2) {
+              const size_t g_idx = (be2.bf1_st + col2 / be2.n2) * num_aos +
+                                   (be2.bf2_st + col2 % be2.n2);
+              const double sf = -L_col[g_idx];
+              blas::axpy(num_aos2, sf, L_col, 1, eri_col2 + col2 * num_aos2, 1);
             }
           }
-          // remove if below threshold
-          const auto& diag = D_shell_pair[sp_index];
-          const double max_diag = *std::max_element(diag.begin(), diag.end());
-          if (max_diag < threshold) {
-            shell_pairs_to_remove.push_back(sp_index);
+
+          // Update diagonal elements
+          std::vector<size_t> shell_pairs_to_remove;
+          for (const auto sp_index : active_shell_pairs) {
+            const auto [s1, s2] = sp_index_to_shells[sp_index];
+            const auto n1 = obs[s1].size();
+            const auto n2 = obs[s2].size();
+            const auto bf1_st = shell2bf[s1];
+            const auto bf2_st = shell2bf[s2];
+            for (size_t i = 0; i < n1; ++i) {
+              const size_t bf1_st_i = (bf1_st + i) * num_aos;
+              for (size_t j = 0; j < n2; ++j) {
+                const size_t idx = i * n2 + j;
+                const size_t global_idx = bf1_st_i + (bf2_st + j);
+                D_shell_pair[sp_index][idx] -=
+                    L_col[global_idx] * L_col[global_idx];
+              }
+            }
+            const auto& diag = D_shell_pair[sp_index];
+            const double max_diag = *std::max_element(diag.begin(), diag.end());
+            if (max_diag < threshold) {
+              shell_pairs_to_remove.push_back(sp_index);
+            }
           }
+          for (const auto sp_index : shell_pairs_to_remove) {
+            active_shell_pairs.erase(sp_index);
+          }
+          current_col += 1;
         }
-        // remove inactive shell pairs
-        for (const auto sp_index : shell_pairs_to_remove) {
-          active_shell_pairs.erase(sp_index);
-        }
-        current_col += 1;
       }
-    }
+    }  // for each batch entry
   }
 
   QDK_LOGGER().info("Cholesky rank: {}", current_col);


### PR DESCRIPTION
Profiling shows the per-vector orthogonalization GEMM is 91% of wall time and memory-bandwidth-limited. Batch multiple shell pairs into one GEMM call (~20 columns), amortizing the L matrix read. Auto-adapts to basis set: small shells batch many, large shells batch few. ERI columns are computed independently; in-batch Gram-Schmidt handles mutual orthogonality.

Benchmark (Cu-oxo metalloprotein, cc-pVDZ, converged):
  431 AOs: 332->158s (2.1x, 32T), 355->205s (1.7x, 208T)
  965 AOs: 2161->1045s (2.1x, 32T), 2256->1143s (2.0x, 208T)