### PR TITLE
Fix for 1es ADO agent

### DIFF
--- a/.pipelines/python-wheels.yaml
+++ b/.pipelines/python-wheels.yaml
@@ -30,7 +30,7 @@ parameters:
     os: linux
     arch: x86_64
     march: x86-64-v3
-    imageName: ubuntu-22.04
+    imageName: Ubuntu24.04Nightly
   - name: linux_aarch64
     os: linux
     arch: aarch64


### PR DESCRIPTION
Fix for ##[error]Remote machine provider issue: Failed to request agent. Exception Image ubuntu-22.04 doesn't exist in pool aqe-1es-HB120-pool
,##[error]Remote machine provider issue: The remote provider was unable to process the request.

Error can be viewed here: https://dev.azure.com/ms-azurequantum/AzureQuantum/_build/results?buildId=156198&view=results