### PR TITLE
Fix conflict between Orbital instance and the custom basis

### DIFF
--- a/cpp/src/qdk/chemistry/algorithms/microsoft/scf.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/scf.cpp
@@ -47,6 +47,10 @@ std::pair<double, std::shared_ptr<data::Wavefunction>> ScfSolver::_run_impl(
   utils::microsoft::initialize_backend();
 
   // check basis_or_guess type
+  if (basis_or_guess.valueless_by_exception()) {
+    throw std::invalid_argument(
+        "basis_or_guess is valueless due to an exception.");
+  }
   enum class BasisSetType { Explicit, FromString, FromOrbitals };
   BasisSetType basis_set_type;
 
@@ -60,22 +64,29 @@ std::pair<double, std::shared_ptr<data::Wavefunction>> ScfSolver::_run_impl(
     }
     basis_set_type = BasisSetType::FromOrbitals;
     basis_set_name = orbitals->get_basis_set()->get_name();
-    std::transform(basis_set_name.begin(), basis_set_name.end(),
-                   basis_set_name.begin(), ::tolower);
+    std::transform(
+        basis_set_name.begin(), basis_set_name.end(), basis_set_name.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
     qdk_raw_basis_set = orbitals->get_basis_set();
   } else if (std::holds_alternative<std::shared_ptr<data::BasisSet>>(
                  basis_or_guess)) {
     auto basis = std::get<std::shared_ptr<data::BasisSet>>(basis_or_guess);
+    if (!basis) {
+      throw std::invalid_argument(
+          "Explicit BasisSet argument must not be null.");
+    }
     basis_set_type = BasisSetType::Explicit;
     basis_set_name = basis->get_name();
-    std::transform(basis_set_name.begin(), basis_set_name.end(),
-                   basis_set_name.begin(), ::tolower);
+    std::transform(
+        basis_set_name.begin(), basis_set_name.end(), basis_set_name.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
     qdk_raw_basis_set = basis;
   } else if (std::holds_alternative<std::string>(basis_or_guess)) {
     basis_set_type = BasisSetType::FromString;
     basis_set_name = std::get<std::string>(basis_or_guess);
-    std::transform(basis_set_name.begin(), basis_set_name.end(),
-                   basis_set_name.begin(), ::tolower);
+    std::transform(
+        basis_set_name.begin(), basis_set_name.end(), basis_set_name.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
     if (basis_set_name == data::BasisSet::custom_name) {
       throw std::invalid_argument(
           "Custom basis name requires an explicit BasisSet or Orbitals.");

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/scf.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/scf.cpp
@@ -51,29 +51,35 @@ std::pair<double, std::shared_ptr<data::Wavefunction>> ScfSolver::_run_impl(
   BasisSetType basis_set_type;
 
   std::string basis_set_name;
+  std::shared_ptr<data::BasisSet> qdk_raw_basis_set = nullptr;
   if (std::holds_alternative<std::shared_ptr<data::Orbitals>>(basis_or_guess)) {
-    basis_set_name = std::get<std::shared_ptr<data::Orbitals>>(basis_or_guess)
-                         ->get_basis_set()
-                         ->get_name();
+    auto orbitals = std::get<std::shared_ptr<data::Orbitals>>(basis_or_guess);
+    if (!orbitals || !orbitals->get_basis_set()) {
+      throw std::invalid_argument(
+          "Orbitals initial guess must include a basis set.");
+    }
     basis_set_type = BasisSetType::FromOrbitals;
+    basis_set_name = orbitals->get_basis_set()->get_name();
+    std::transform(basis_set_name.begin(), basis_set_name.end(),
+                   basis_set_name.begin(), ::tolower);
+    qdk_raw_basis_set = orbitals->get_basis_set();
   } else if (std::holds_alternative<std::shared_ptr<data::BasisSet>>(
                  basis_or_guess)) {
-    basis_set_name =
-        std::get<std::shared_ptr<data::BasisSet>>(basis_or_guess)->get_name();
+    auto basis = std::get<std::shared_ptr<data::BasisSet>>(basis_or_guess);
     basis_set_type = BasisSetType::Explicit;
+    basis_set_name = basis->get_name();
+    std::transform(basis_set_name.begin(), basis_set_name.end(),
+                   basis_set_name.begin(), ::tolower);
+    qdk_raw_basis_set = basis;
   } else if (std::holds_alternative<std::string>(basis_or_guess)) {
-    basis_set_name = std::get<std::string>(basis_or_guess);
     basis_set_type = BasisSetType::FromString;
-  }
-  std::transform(basis_set_name.begin(), basis_set_name.end(),
-                 basis_set_name.begin(), ::tolower);
-
-  std::shared_ptr<data::BasisSet> qdk_raw_basis_set = nullptr;
-  if (basis_set_name == data::BasisSet::custom_name ||
-      basis_set_type == BasisSetType::Explicit) {
-    qdk_raw_basis_set =
-        std::get<std::shared_ptr<data::BasisSet>>(basis_or_guess);
-  } else {
+    basis_set_name = std::get<std::string>(basis_or_guess);
+    std::transform(basis_set_name.begin(), basis_set_name.end(),
+                   basis_set_name.begin(), ::tolower);
+    if (basis_set_name == data::BasisSet::custom_name) {
+      throw std::invalid_argument(
+          "Custom basis name requires an explicit BasisSet or Orbitals.");
+    }
     qdk_raw_basis_set =
         data::BasisSet::from_basis_name(basis_set_name, structure);
   }

--- a/cpp/tests/test_scf.cpp
+++ b/cpp/tests/test_scf.cpp
@@ -8,6 +8,7 @@
 #include <qdk/chemistry/algorithms/scf.hpp>
 #include <qdk/chemistry/data/basis_set.hpp>
 #include <qdk/chemistry/data/wavefunction_containers/sd.hpp>
+#include <qdk/chemistry/utils/orbital_rotation.hpp>
 
 #include "../src/qdk/chemistry/algorithms/microsoft/utils.hpp"
 #include "ut_common.hpp"
@@ -525,6 +526,46 @@ TEST_F(ScfTest, InitialGuessRestart) {
 
   // Should get the same energy (within tight tolerance)
   EXPECT_NEAR(energy_first, energy_second, testing::scf_energy_tolerance);
+}
+
+TEST_F(ScfTest, CustomElementMapBasisRotatedOrbitalInitialGuessRuns) {
+  using namespace qdk::chemistry::utils;
+
+  auto water = testing::create_water_structure();
+
+  std::map<std::string, std::string> element_basis_map = {{"O", "sto-3g"},
+                                                          {"H", "sto-3g"}};
+  auto custom_basis = BasisSet::from_element_map(element_basis_map, water);
+
+  auto scf_solver = ScfSolverFactory::create();
+  scf_solver->settings().set("method", "hf");
+  scf_solver_restart->settings().set("max_iterations", 5);
+  auto [energy_first, wfn_first] = scf_solver->run(water, 0, 1, custom_basis);
+
+  auto orbitals_first = wfn_first->get_orbitals();
+  EXPECT_EQ(orbitals_first->get_basis_set()->get_name(), BasisSet::custom_name);
+
+  auto [n_alpha, n_beta] = wfn_first->get_total_num_electrons();
+  const size_t n_mo = orbitals_first->get_num_molecular_orbitals();
+  const size_t n_virtual = n_mo - n_alpha;
+  const size_t rotation_size = n_alpha * n_virtual;
+  Eigen::VectorXd rotation_vector =
+      Eigen::VectorXd::Constant(rotation_size, 0.01);
+
+  auto rotated_orbitals =
+      rotate_orbitals(orbitals_first, rotation_vector, n_alpha, n_beta);
+  EXPECT_EQ(rotated_orbitals->get_basis_set()->get_name(),
+            BasisSet::custom_name);
+
+  auto scf_solver_restart = ScfSolverFactory::create();
+  scf_solver_restart->settings().set("method", "hf");
+  scf_solver_restart->settings().set("max_iterations", 5);
+
+  std::pair<double, std::shared_ptr<Wavefunction>> restart_result;
+  EXPECT_NO_THROW({
+    restart_result = scf_solver_restart->run(water, 0, 1, rotated_orbitals);
+  });
+  EXPECT_NE(restart_result.second, nullptr);
 }
 
 TEST_F(ScfTest, OxygenTripletInitialGuessRestart) {

--- a/cpp/tests/test_scf.cpp
+++ b/cpp/tests/test_scf.cpp
@@ -539,7 +539,7 @@ TEST_F(ScfTest, CustomElementMapBasisRotatedOrbitalInitialGuessRuns) {
 
   auto scf_solver = ScfSolverFactory::create();
   scf_solver->settings().set("method", "hf");
-  scf_solver_restart->settings().set("max_iterations", 5);
+  scf_solver->settings().set("max_iterations", 5);
   auto [energy_first, wfn_first] = scf_solver->run(water, 0, 1, custom_basis);
 
   auto orbitals_first = wfn_first->get_orbitals();

--- a/cpp/tests/test_scf.cpp
+++ b/cpp/tests/test_scf.cpp
@@ -539,7 +539,7 @@ TEST_F(ScfTest, CustomElementMapBasisRotatedOrbitalInitialGuessRuns) {
 
   auto scf_solver = ScfSolverFactory::create();
   scf_solver->settings().set("method", "hf");
-  scf_solver->settings().set("max_iterations", 5);
+  scf_solver->settings().set("convergence_threshold", 1e-2);
   auto [energy_first, wfn_first] = scf_solver->run(water, 0, 1, custom_basis);
 
   auto orbitals_first = wfn_first->get_orbitals();
@@ -559,7 +559,7 @@ TEST_F(ScfTest, CustomElementMapBasisRotatedOrbitalInitialGuessRuns) {
 
   auto scf_solver_restart = ScfSolverFactory::create();
   scf_solver_restart->settings().set("method", "hf");
-  scf_solver_restart->settings().set("max_iterations", 5);
+  scf_solver_restart->settings().set("convergence_threshold", 1e-2);
 
   std::pair<double, std::shared_ptr<Wavefunction>> restart_result;
   EXPECT_NO_THROW({

--- a/cpp/tests/test_utils.cpp
+++ b/cpp/tests/test_utils.cpp
@@ -304,29 +304,6 @@ TEST_F(OrbitalRotationTest, UnitaryRotationTest) {
               testing::numerical_zero_tolerance);
 }
 
-// Regression test: SCF should accept rotated orbitals as an initial guess.
-TEST_F(OrbitalRotationTest, ScfRunWithRotatedOrbitalsInitialGuessTest) {
-  using namespace qdk::chemistry::utils;
-
-  size_t num_virtual_orbitals =
-      num_molecular_orbitals - num_alpha_occupied_orbitals;
-  size_t rotation_size = num_alpha_occupied_orbitals * num_virtual_orbitals;
-  Eigen::VectorXd rotation_vector =
-      Eigen::VectorXd::Constant(rotation_size, 0.01);
-
-  auto rotated_orbitals =
-      rotate_orbitals(test_orbitals_restricted, rotation_vector,
-                      num_alpha_occupied_orbitals, num_beta_occupied_orbitals);
-  ASSERT_NE(rotated_orbitals, nullptr);
-
-  auto water = testing::create_water_structure();
-  auto scf_solver = ScfSolverFactory::create();
-
-  std::pair<double, std::shared_ptr<Wavefunction>> result;
-  EXPECT_NO_THROW({ result = scf_solver->run(water, 0, 1, rotated_orbitals); });
-  EXPECT_NE(result.second, nullptr);
-}
-
 // Test fixture for mathematical utility functions
 class MathUtilsTest : public ::testing::Test {
  protected:

--- a/cpp/tests/test_utils.cpp
+++ b/cpp/tests/test_utils.cpp
@@ -304,6 +304,29 @@ TEST_F(OrbitalRotationTest, UnitaryRotationTest) {
               testing::numerical_zero_tolerance);
 }
 
+// Regression test: SCF should accept rotated orbitals as an initial guess.
+TEST_F(OrbitalRotationTest, ScfRunWithRotatedOrbitalsInitialGuessTest) {
+  using namespace qdk::chemistry::utils;
+
+  size_t num_virtual_orbitals =
+      num_molecular_orbitals - num_alpha_occupied_orbitals;
+  size_t rotation_size = num_alpha_occupied_orbitals * num_virtual_orbitals;
+  Eigen::VectorXd rotation_vector =
+      Eigen::VectorXd::Constant(rotation_size, 0.01);
+
+  auto rotated_orbitals =
+      rotate_orbitals(test_orbitals_restricted, rotation_vector,
+                      num_alpha_occupied_orbitals, num_beta_occupied_orbitals);
+  ASSERT_NE(rotated_orbitals, nullptr);
+
+  auto water = testing::create_water_structure();
+  auto scf_solver = ScfSolverFactory::create();
+
+  std::pair<double, std::shared_ptr<Wavefunction>> result;
+  EXPECT_NO_THROW({ result = scf_solver->run(water, 0, 1, rotated_orbitals); });
+  EXPECT_NE(result.second, nullptr);
+}
+
 // Test fixture for mathematical utility functions
 class MathUtilsTest : public ::testing::Test {
  protected:


### PR DESCRIPTION
When the user input an orbital with a custom basis, for example, from element map, then the conflict between the orbital and the basis can cause `RuntimeError: std::get: wrong index for variant`. This PR is to fix the bug.