### PR TITLE
Fix bug in stability checker

### DIFF
--- a/cpp/include/qdk/chemistry/data/orbitals.hpp
+++ b/cpp/include/qdk/chemistry/data/orbitals.hpp
@@ -229,13 +229,13 @@ class Orbitals : public DataClass,
 
   /**
    * @brief Check if calculation is restricted (RHF/RKS/ROHF/ROKS)
-   * @return True if alpha and beta coefficients share the same storage
+   * @return True if orbitals are restricted
    */
   virtual bool is_restricted() const;
 
   /**
    * @brief Check if calculation is unrestricted (UHF/UKS)
-   * @return True if alpha and beta coefficients use separate storage
+   * @return True if orbitals are unrestricted
    */
   virtual bool is_unrestricted() const;
 

--- a/cpp/include/qdk/chemistry/data/orbitals.hpp
+++ b/cpp/include/qdk/chemistry/data/orbitals.hpp
@@ -228,14 +228,14 @@ class Orbitals : public DataClass,
   virtual std::vector<size_t> get_all_mo_indices() const;
 
   /**
-   * @brief Check if calculation is restricted (RHF/RKS)
-   * @return True if alpha and beta coefficients are identical
+   * @brief Check if calculation is restricted (RHF/RKS/ROHF/ROKS)
+   * @return True if alpha and beta coefficients share the same storage
    */
   virtual bool is_restricted() const;
 
   /**
    * @brief Check if calculation is unrestricted (UHF/UKS)
-   * @return True if alpha and beta coefficients are different
+   * @return True if alpha and beta coefficients use separate storage
    */
   virtual bool is_unrestricted() const;
 

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/stability.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/stability.cpp
@@ -13,6 +13,7 @@
 #include <qdk/chemistry/data/stability_result.hpp>
 #include <qdk/chemistry/data/wavefunction.hpp>
 #include <qdk/chemistry/utils/logger.hpp>
+#include <random>
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -329,45 +330,29 @@ class StabilityOperator {
 };
 
 /**
- * @brief Construct an initial eigenvector for the Davidson heuristic. Uses the
- * inverse of the orbital energy differences as a preconditioned guess and
- * enforces single dominant components in each occupied block. Safeguards of
- * 1e4/1e-4 avoid division by zero when the energy differences are extremely
- * small.
+ * @brief Construct an initial eigenvector for the Davidson solver using a
+ * random Gaussian guess. Each element is drawn from N(0,1) with a fixed seed
+ * for reproducibility, and the resulting vector is normalized to unit length.
  *
- * The Davidson algorithm is highly sensitive to the choice of the initial
- * vector. Mixing the two initialization strategies reduces the risk of
- * Davidson failing to converge.
+ * A random guess avoids confinement to a symmetric subspace that can occur
+ * when alpha and beta orbitals are identical (e.g. an unrestricted calculation
+ * that converged to a closed-shell solution). In such cases a deterministic
+ * guess based on orbital energy differences would be symmetric between the
+ * spin channels and would miss antisymmetric instability modes.
  *
- * @param eigen_diff Flattened array of orbital energy differences.
- * @param n_alpha_electrons Number of occupied alpha orbitals.
- * @param n_beta_electrons Number of occupied beta orbitals.
- * @param num_virtual_alpha_orbitals Number of virtual alpha orbitals.
- * @param num_virtual_beta_orbitals Number of virtual beta orbitals.
- * @param unrestricted True when the reference wavefunction is UHF.
  * @param eigenvector [in, out] Output vector that stores the initialized guess.
  */
-void initialize_eigenvector(const Eigen::VectorXd& eigen_diff,
-                            size_t n_alpha_electrons, size_t n_beta_electrons,
-                            size_t num_virtual_alpha_orbitals,
-                            size_t num_virtual_beta_orbitals, bool unrestricted,
-                            Eigen::VectorXd& eigenvector) {
+void initialize_eigenvector(Eigen::VectorXd& eigenvector) {
   QDK_LOG_TRACE_ENTERING();
   int eigensize = eigenvector.size();
-  auto nova = num_virtual_alpha_orbitals * n_alpha_electrons;
-  double min_abs_eigen_diff = 1e-4;
-  eigenvector = Eigen::VectorXd::Constant(eigensize, 1.0 / min_abs_eigen_diff);
-  for (int i = 0; i < eigen_diff.size(); ++i) {
-    if (std::abs(eigen_diff(i)) > min_abs_eigen_diff) {
-      eigenvector(i) = 1.0 / eigen_diff(i);
-    }
+
+  // Use a random Gaussian initial guess to avoid being trapped in a symmetric
+  // subspace (e.g. when alpha and beta orbitals are identical).
+  std::mt19937 gen(42);
+  std::normal_distribution<double> dist(0.0, 1.0);
+  for (int i = 0; i < eigensize; ++i) {
+    eigenvector(i) = dist(gen);
   }
-  eigenvector.normalize();
-  if (n_alpha_electrons > 0)
-    eigenvector((n_alpha_electrons - 1) * num_virtual_alpha_orbitals) = 1.0;
-  if (unrestricted && n_beta_electrons > 0)
-    eigenvector((n_beta_electrons - 1) * num_virtual_beta_orbitals + nova) =
-        1.0;
   eigenvector.normalize();
 }
 
@@ -540,10 +525,7 @@ StabilityChecker::_run_impl(
   }
 
   Eigen::VectorXd eigenvector = Eigen::VectorXd::Zero(eigensize);
-  detail::initialize_eigenvector(eigen_diff, n_alpha_electrons,
-                                 n_beta_electrons, num_virtual_alpha_orbitals,
-                                 num_virtual_beta_orbitals, unrestricted,
-                                 eigenvector);
+  detail::initialize_eigenvector(eigenvector);
 
   const int64_t max_subspace =
       std::min(davidson_max_subspace, static_cast<int64_t>(eigensize));

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/stability.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/stability.cpp
@@ -330,15 +330,8 @@ class StabilityOperator {
 };
 
 /**
- * @brief Construct an initial eigenvector for the Davidson solver using a
- * random Gaussian guess. Each element is drawn from N(0,1) with a fixed seed
- * for reproducibility, and the resulting vector is normalized to unit length.
- *
- * A random guess avoids confinement to a symmetric subspace that can occur
- * when alpha and beta orbitals are identical (e.g. an unrestricted calculation
- * that converged to a closed-shell solution). In such cases a deterministic
- * guess based on orbital energy differences would be symmetric between the
- * spin channels and would miss antisymmetric instability modes.
+ * @brief Initialize eigenvector with a random Gaussian guess (N(0,1), seed 42,
+ * normalized). Avoids trapping in symmetric subspaces when alpha == beta.
  *
  * @param eigenvector [in, out] Output vector that stores the initialized guess.
  */

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/stability.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/stability.cpp
@@ -331,7 +331,7 @@ class StabilityOperator {
 
 /**
  * @brief Initialize eigenvector with a random Gaussian guess (N(0,1), seed 42,
- * normalized). Avoids trapping in symmetric subspaces.
+ * normalized) to avoid trapping in a subspace.
  *
  * @param eigenvector [in, out] Output vector that stores the initialized guess.
  */

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/stability.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/stability.cpp
@@ -331,7 +331,7 @@ class StabilityOperator {
 
 /**
  * @brief Initialize eigenvector with a random Gaussian guess (N(0,1), seed 42,
- * normalized). Avoids trapping in symmetric subspaces when alpha == beta.
+ * normalized). Avoids trapping in symmetric subspaces.
  *
  * @param eigenvector [in, out] Output vector that stores the initialized guess.
  */
@@ -340,7 +340,7 @@ void initialize_eigenvector(Eigen::VectorXd& eigenvector) {
   int eigensize = eigenvector.size();
 
   // Use a random Gaussian initial guess to avoid being trapped in a symmetric
-  // subspace (e.g. when alpha and beta orbitals are identical).
+  // subspace when the rotation space has limited degrees of freedom.
   std::mt19937 gen(42);
   std::normal_distribution<double> dist(0.0, 1.0);
   for (int i = 0; i < eigensize; ++i) {

--- a/cpp/src/qdk/chemistry/data/orbitals.cpp
+++ b/cpp/src/qdk/chemistry/data/orbitals.cpp
@@ -1127,17 +1127,30 @@ std::shared_ptr<Orbitals> Orbitals::from_hdf5(H5::Group& group) {
       return ModelOrbitals::from_hdf5(group);
     }
 
+    // Read is_restricted flag from metadata
+    bool restricted = false;
+    try {
+      H5::Group metadata_group = group.openGroup("metadata");
+      H5::DataSet ds = metadata_group.openDataSet("is_restricted");
+      ds.read(&restricted, H5::PredType::NATIVE_HBOOL);
+    } catch (const H5::Exception&) {
+      throw std::runtime_error(
+          "HDF5 file missing 'metadata' group or 'is_restricted' dataset");
+    }
+
     // Handle regular Orbitals case
     // Load coefficients (required)
     auto coeffs_alpha = load_matrix_from_group(group, "coefficients_alpha");
 
-    // Check if beta coefficients exist
+    // Only read beta coefficients if unrestricted
     std::optional<Eigen::MatrixXd> coeffs_beta_opt;
-    try {
-      auto coeffs_beta = load_matrix_from_group(group, "coefficients_beta");
-      coeffs_beta_opt = coeffs_beta;
-    } catch (const std::exception&) {
-      // Beta coefficients don't exist - this is a restricted calculation
+    if (!restricted) {
+      try {
+        auto coeffs_beta = load_matrix_from_group(group, "coefficients_beta");
+        coeffs_beta_opt = coeffs_beta;
+      } catch (const std::exception&) {
+        // Beta coefficients don't exist - this is a restricted calculation
+      }
     }
 
     // Load optional energies
@@ -1199,7 +1212,13 @@ std::shared_ptr<Orbitals> Orbitals::from_hdf5(H5::Group& group) {
     } catch (const std::exception&) { /* optional */
     }
 
-    if (coeffs_beta_opt) {
+    if (restricted || !coeffs_beta_opt) {
+      // Restricted case - use single-matrix constructor to share the pointer
+      return std::make_shared<Orbitals>(
+          coeffs_alpha, energies_alpha, ao_overlap, basis_set,
+          std::make_tuple(std::move(active_indices_alpha),
+                          std::move(inactive_indices_alpha)));
+    } else {
       // Unrestricted case
       return std::make_shared<Orbitals>(
           coeffs_alpha, *coeffs_beta_opt, energies_alpha, energies_beta,
@@ -1208,12 +1227,6 @@ std::shared_ptr<Orbitals> Orbitals::from_hdf5(H5::Group& group) {
                           std::move(active_indices_beta),
                           std::move(inactive_indices_alpha),
                           std::move(inactive_indices_beta)));
-    } else {
-      // Restricted case
-      return std::make_shared<Orbitals>(
-          coeffs_alpha, energies_alpha, ao_overlap, basis_set,
-          std::make_tuple(std::move(active_indices_alpha),
-                          std::move(inactive_indices_alpha)));
     }
 
   } catch (const H5::Exception& e) {

--- a/cpp/src/qdk/chemistry/data/orbitals.cpp
+++ b/cpp/src/qdk/chemistry/data/orbitals.cpp
@@ -1317,7 +1317,10 @@ std::shared_ptr<Orbitals> Orbitals::from_json(const nlohmann::json& j) {
       throw std::runtime_error("JSON missing required coefficient data");
     }
 
-    const auto is_restricted = j.value("is_restricted", false);
+    if (!j.contains("is_restricted")) {
+      throw std::runtime_error("JSON missing required 'is_restricted' field");
+    }
+    const auto is_restricted = j["is_restricted"].get<bool>();
     auto coeffs_alpha = json_to_matrix(j["coefficients"]["alpha"]);
 
     // Load optional energies

--- a/cpp/src/qdk/chemistry/data/orbitals.cpp
+++ b/cpp/src/qdk/chemistry/data/orbitals.cpp
@@ -666,6 +666,21 @@ bool Orbitals::is_restricted() const {
         "Cannot determine if orbitals are restricted: orbital coefficients "
         "not set");
   }
+  // Verify energy pointers are consistent with coefficients
+  if (_energies.first && _energies.second) {
+    if (_coefficients.first == _coefficients.second &&
+        _energies.first != _energies.second) {
+      throw std::runtime_error(
+          "Inconsistent orbital state: coefficients are shared but energies "
+          "are not");
+    }
+    if (_coefficients.first != _coefficients.second &&
+        _energies.first == _energies.second) {
+      throw std::runtime_error(
+          "Inconsistent orbital state: coefficients are separate but energies "
+          "are shared");
+    }
+  }
   return _coefficients.first == _coefficients.second;
 }
 
@@ -1159,7 +1174,7 @@ std::shared_ptr<Orbitals> Orbitals::from_hdf5(H5::Group& group) {
     if (dataset_exists_in_group(group, "energies_alpha")) {
       energies_alpha = load_vector_from_group(group, "energies_alpha");
     }
-    if (dataset_exists_in_group(group, "energies_beta")) {
+    if (!restricted && dataset_exists_in_group(group, "energies_beta")) {
       energies_beta = load_vector_from_group(group, "energies_beta");
     }
 

--- a/cpp/src/qdk/chemistry/data/orbitals.cpp
+++ b/cpp/src/qdk/chemistry/data/orbitals.cpp
@@ -1134,7 +1134,7 @@ std::shared_ptr<Orbitals> Orbitals::from_hdf5(H5::Group& group) {
       H5::DataSet ds = metadata_group.openDataSet("is_restricted");
       ds.read(&restricted, H5::PredType::NATIVE_HBOOL);
     } catch (const H5::Exception&) {
-      throw std::runtime_error(
+      throw std::invalid_argument(
           "HDF5 file missing 'metadata' group or 'is_restricted' dataset");
     }
 
@@ -1148,8 +1148,9 @@ std::shared_ptr<Orbitals> Orbitals::from_hdf5(H5::Group& group) {
       try {
         auto coeffs_beta = load_matrix_from_group(group, "coefficients_beta");
         coeffs_beta_opt = coeffs_beta;
-      } catch (const std::exception&) {
-        // Beta coefficients don't exist - this is a restricted calculation
+      } catch (const H5::Exception&) {
+        throw std::invalid_argument(
+            "HDF5 file missing 'coefficients_beta' for unrestricted orbitals");
       }
     }
 
@@ -1314,11 +1315,12 @@ std::shared_ptr<Orbitals> Orbitals::from_json(const nlohmann::json& j) {
     // Load coefficients (required for regular Orbitals)
     if (!j.contains("coefficients") || !j["coefficients"].contains("alpha") ||
         !j["coefficients"].contains("beta")) {
-      throw std::runtime_error("JSON missing required coefficient data");
+      throw std::invalid_argument("JSON missing required coefficient data");
     }
 
     if (!j.contains("is_restricted")) {
-      throw std::runtime_error("JSON missing required 'is_restricted' field");
+      throw std::invalid_argument(
+          "JSON missing required 'is_restricted' field");
     }
     const auto is_restricted = j["is_restricted"].get<bool>();
     auto coeffs_alpha = json_to_matrix(j["coefficients"]["alpha"]);

--- a/cpp/src/qdk/chemistry/data/orbitals.cpp
+++ b/cpp/src/qdk/chemistry/data/orbitals.cpp
@@ -680,7 +680,7 @@ bool Orbitals::is_restricted() const {
       if (!_energies.first->isApprox(*_energies.second)) {
         return false;
       } else {
-        QDK_LOG_WARNING(
+        QDK_LOGGER().warn(
             "Although there are two sets of coefficients, the coefficient "
             "matrices and energies are identical. This orbital will be treated "
             "as restricted! To obtain an unrestricted orbital, consider "

--- a/cpp/src/qdk/chemistry/data/orbitals.cpp
+++ b/cpp/src/qdk/chemistry/data/orbitals.cpp
@@ -664,31 +664,9 @@ bool Orbitals::is_restricted() const {
   if (!_coefficients.first || !_coefficients.second) {
     throw std::runtime_error(
         "Cannot determine if orbitals are restricted: orbital coefficients "
-        "not "
-        "set");
+        "not set");
   }
-  // Compare coefficient pointers first for efficiency
-  if (_coefficients.first == _coefficients.second) {
-    return true;
-  }
-  // If pointers are different, check if the data is the same
-  if (!_coefficients.first->isApprox(*_coefficients.second)) {
-    return false;
-  } else {
-    // Also check energies if both are set
-    if (_energies.first && _energies.second) {
-      if (!_energies.first->isApprox(*_energies.second)) {
-        return false;
-      } else {
-        QDK_LOGGER().warn(
-            "Although there are two sets of coefficients, the coefficient "
-            "matrices and energies are identical. This orbital will be treated "
-            "as restricted! To obtain an unrestricted orbital, consider "
-            "running SCF with a spin-broken initial guess.");
-      }
-    }
-  }
-  return true;
+  return _coefficients.first == _coefficients.second;
 }
 
 bool Orbitals::has_active_space() const {

--- a/cpp/src/qdk/chemistry/data/orbitals.cpp
+++ b/cpp/src/qdk/chemistry/data/orbitals.cpp
@@ -679,6 +679,12 @@ bool Orbitals::is_restricted() const {
     if (_energies.first && _energies.second) {
       if (!_energies.first->isApprox(*_energies.second)) {
         return false;
+      } else {
+        QDK_LOG_WARNING(
+            "Although there are two sets of coefficients, the coefficient "
+            "matrices and energies are identical. This orbital will be treated "
+            "as restricted! To obtain an unrestricted orbital, consider "
+            "running SCF with a spin-broken initial guess.");
       }
     }
   }

--- a/cpp/tests/test_orbitals_comprehensive.cpp
+++ b/cpp/tests/test_orbitals_comprehensive.cpp
@@ -193,8 +193,8 @@ TEST_F(OrbitalsTest, OpenShellAndRestrictedQueries) {
   Orbitals unrestricted_orb(coeffs, coeffs, energies, energies, std::nullopt,
                             basis_set);
 
-  // Should now be open shell
-  EXPECT_TRUE(unrestricted_orb.is_restricted());
+  // Should now be open shell (different pointers even though same data)
+  EXPECT_FALSE(unrestricted_orb.is_restricted());
 }
 
 TEST_F(OrbitalsTest, HasEnergies) {

--- a/cpp/tests/test_stability.cpp
+++ b/cpp/tests/test_stability.cpp
@@ -927,3 +927,47 @@ TEST_F(StabilityCheckerTest, QDK_RHF_H2_Stretched_STO3G_External_Instability) {
   EXPECT_NEAR(smallest_internal_eigenvalue, 0.6291346026640, davidson_tol);
   EXPECT_NEAR(smallest_external_eigenvalue, -0.4313775656554, davidson_tol);
 }
+
+TEST_F(StabilityCheckerTest, QDK_UHF_H2_Stretched_STO3G_Internal_Only) {
+  // Test stability analysis on stretched H2 molecule with unrestricted UHF.
+  // Only internal stability is valid for UHF.
+  std::vector<Eigen::Vector3d> coords = {
+      {0.0, 0.0, 0.0},
+      {4.0, 0.0, 0.0},
+  };
+  std::vector<Element> elements = {Element::H, Element::H};
+  auto h2 = std::make_shared<Structure>(coords, elements);
+
+  auto scf_solver = ScfSolverFactory::create();
+  scf_solver->settings().set("method", "hf");
+  scf_solver->settings().set("scf_type", "unrestricted");
+  auto [energy, wavefunction] = scf_solver->run(h2, 0, 1, "sto-3g");
+
+  EXPECT_NEAR(energy, -0.761082247527, testing::scf_energy_tolerance);
+  EXPECT_FALSE(wavefunction->get_orbitals()->is_restricted());
+
+  auto stability_checker = StabilityCheckerFactory::create("qdk");
+  stability_checker->settings().set("method", "hf");
+
+  auto [is_stable, result] = stability_checker->run(wavefunction);
+
+  EXPECT_TRUE(result != nullptr);
+  EXPECT_TRUE(result->has_internal_result());
+  EXPECT_TRUE(result->has_external_result());
+  EXPECT_GT(result->internal_size(), 0);
+  EXPECT_GT(result->external_size(), 0);
+
+  EXPECT_TRUE(result->is_internal_stable());
+  EXPECT_FALSE(result->is_external_stable());
+  EXPECT_FALSE(is_stable);
+
+  const double smallest_internal_eigenvalue =
+      result->get_smallest_internal_eigenvalue();
+  const double smallest_external_eigenvalue =
+      result->get_smallest_external_eigenvalue();
+  const double davidson_tol =
+      stability_checker->settings().get<double>("davidson_tolerance") * 1e2;
+
+  EXPECT_NEAR(smallest_internal_eigenvalue, 0.6291346026640, davidson_tol);
+  EXPECT_NEAR(smallest_external_eigenvalue, -0.4313775656554, davidson_tol);
+}

--- a/cpp/tests/test_stability.cpp
+++ b/cpp/tests/test_stability.cpp
@@ -882,3 +882,48 @@ TEST_F(StabilityCheckerTest, QDK_RHF_N2_Stretched_PBE_Instability) {
   EXPECT_NEAR(smallest_internal_eigenvalue, 0.1659455646937, davidson_tol);
   EXPECT_NEAR(smallest_external_eigenvalue, -0.01967330067025, davidson_tol);
 }
+
+TEST_F(StabilityCheckerTest, QDK_RHF_H2_Stretched_STO3G_External_Instability) {
+  // Test stability analysis on stretched H2 molecule with restricted RHF.
+  std::vector<Eigen::Vector3d> coords = {
+      {0.0, 0.0, 0.0},
+      {4.0, 0.0, 0.0},
+  };
+  std::vector<Element> elements = {Element::H, Element::H};
+  auto h2 = std::make_shared<Structure>(coords, elements);
+
+  auto scf_solver = ScfSolverFactory::create();
+  scf_solver->settings().set("method", "hf");
+  scf_solver->settings().set("scf_type", "restricted");
+  auto [energy, wavefunction] = scf_solver->run(h2, 0, 1, "sto-3g");
+
+  EXPECT_NEAR(energy, -0.761082247527, testing::scf_energy_tolerance);
+  EXPECT_TRUE(wavefunction->get_orbitals()->is_restricted());
+
+  auto stability_checker = StabilityCheckerFactory::create("qdk");
+  stability_checker->settings().set("internal", true);
+  stability_checker->settings().set("external", true);
+  stability_checker->settings().set("method", "hf");
+
+  auto [is_stable, result] = stability_checker->run(wavefunction);
+
+  EXPECT_TRUE(result != nullptr);
+  EXPECT_TRUE(result->has_internal_result());
+  EXPECT_TRUE(result->has_external_result());
+  EXPECT_GT(result->internal_size(), 0);
+  EXPECT_GT(result->external_size(), 0);
+
+  EXPECT_TRUE(result->is_internal_stable());
+  EXPECT_FALSE(result->is_external_stable());
+  EXPECT_FALSE(is_stable);
+
+  const double smallest_internal_eigenvalue =
+      result->get_smallest_internal_eigenvalue();
+  const double smallest_external_eigenvalue =
+      result->get_smallest_external_eigenvalue();
+  const double davidson_tol =
+      stability_checker->settings().get<double>("davidson_tolerance") * 1e2;
+
+  EXPECT_NEAR(smallest_internal_eigenvalue, 0.6291346026640, davidson_tol);
+  EXPECT_NEAR(smallest_external_eigenvalue, -0.4313775656554, davidson_tol);
+}

--- a/cpp/tests/test_stability.cpp
+++ b/cpp/tests/test_stability.cpp
@@ -928,7 +928,8 @@ TEST_F(StabilityCheckerTest, QDK_RHF_H2_Stretched_STO3G_External_Instability) {
   EXPECT_NEAR(smallest_external_eigenvalue, -0.4313775656554, davidson_tol);
 }
 
-TEST_F(StabilityCheckerTest, QDK_UHF_H2_Stretched_STO3G_Internal_Only) {
+TEST_F(StabilityCheckerTest,
+       QDK_UHF_H2_Stretched_STO3G_distinguished_restricted) {
   // Test stability analysis on stretched H2 molecule with unrestricted UHF.
   // Only internal stability is valid for UHF.
   std::vector<Eigen::Vector3d> coords = {
@@ -953,21 +954,17 @@ TEST_F(StabilityCheckerTest, QDK_UHF_H2_Stretched_STO3G_Internal_Only) {
 
   EXPECT_TRUE(result != nullptr);
   EXPECT_TRUE(result->has_internal_result());
-  EXPECT_TRUE(result->has_external_result());
+  EXPECT_FALSE(result->has_external_result());
   EXPECT_GT(result->internal_size(), 0);
-  EXPECT_GT(result->external_size(), 0);
+  EXPECT_EQ(result->external_size(), 0);
 
-  EXPECT_TRUE(result->is_internal_stable());
-  EXPECT_FALSE(result->is_external_stable());
+  EXPECT_FALSE(result->is_internal_stable());
   EXPECT_FALSE(is_stable);
 
   const double smallest_internal_eigenvalue =
       result->get_smallest_internal_eigenvalue();
-  const double smallest_external_eigenvalue =
-      result->get_smallest_external_eigenvalue();
   const double davidson_tol =
       stability_checker->settings().get<double>("davidson_tolerance") * 1e2;
 
-  EXPECT_NEAR(smallest_internal_eigenvalue, 0.6291346026640, davidson_tol);
-  EXPECT_NEAR(smallest_external_eigenvalue, -0.4313775656554, davidson_tol);
+  EXPECT_NEAR(smallest_internal_eigenvalue, -0.4313775656554, davidson_tol);
 }

--- a/external/macis/include/macis/solvers/davidson.hpp
+++ b/external/macis/include/macis/solvers/davidson.hpp
@@ -274,11 +274,18 @@ auto davidson(int64_t N, int64_t max_m, const Functor& op, const double* D,
   logger->info("  {} = {:6}, {} = {:4}, {} = {:10.5e}", "N", N, "MAX_M", max_m,
                "RES_TOL", tol);
 
-  // Handle trivial case of 1x1 matrix
+  // Handle trivial case of 1x1 matrix by evaluating the operator on the
+  // current trial vector (instead of using the preconditioner diagonal D[0]).
   if (N == 1) {
-    // For a 1x1 matrix, the eigenvalue is simply the diagonal element
-    double eigenvalue = D[0];
-    X[0] = 1.0;  // Normalized eigenvector
+    if (std::abs(X[0]) < min_abs_denominator) {
+      X[0] = 1.0;
+    }
+    double AX = 0.0;
+    op.operator_action(1, 1., X, N, 0., &AX, N);
+    const double eigenvalue = AX / X[0];
+    logger->warn(
+        "N==1 detected: using direct operator action on the trial vector and "
+        "returning the 1D Rayleigh quotient AX/X as the eigenvalue.");
     logger->info(
         "iter =    0, LAM(0) = {:20.12e}, RNORM =   0.000000000000e+00",
         eigenvalue);

--- a/external/macis/include/macis/solvers/davidson.hpp
+++ b/external/macis/include/macis/solvers/davidson.hpp
@@ -277,20 +277,15 @@ auto davidson(int64_t N, int64_t max_m, const Functor& op, const double* D,
   // Handle trivial case of 1x1 matrix by evaluating the operator on the
   // current trial vector (instead of using the preconditioner diagonal D[0]).
   if (N == 1) {
-    if (std::abs(X[0]) < min_abs_denominator) {
-      X[0] = 1.0;
-    }
+    X[0] = 1.0;
     double AX = 0.0;
     op.operator_action(1, 1., X, N, 0., &AX, N);
-    const double eigenvalue = AX / X[0];
     logger->warn(
         "N==1 detected: using direct operator action on the trial vector and "
-        "returning the 1D Rayleigh quotient AX/X as the eigenvalue.");
+        "returning AX as the eigenvalue.");
     logger->info(
-        "iter =    0, LAM(0) = {:20.12e}, RNORM =   0.000000000000e+00",
-        eigenvalue);
-    logger->info("Davidson Converged!");
-    return std::make_pair(size_t(0), eigenvalue);
+        "iter =    0, LAM(0) = {:20.12e}, RNORM =   0.000000000000e+00", AX);
+    return std::make_pair(size_t(0), AX);
   }
 
   std::vector<double> V(N * (max_m + 1)), AV(N * (max_m + 1)),

--- a/external/macis/include/macis/solvers/davidson.hpp
+++ b/external/macis/include/macis/solvers/davidson.hpp
@@ -280,9 +280,6 @@ auto davidson(int64_t N, int64_t max_m, const Functor& op, const double* D,
     X[0] = 1.0;
     double AX = 0.0;
     op.operator_action(1, 1., X, N, 0., &AX, N);
-    logger->warn(
-        "N==1 detected: using direct operator action on the trial vector and "
-        "returning AX as the eigenvalue.");
     logger->info(
         "iter =    0, LAM(0) = {:20.12e}, RNORM =   0.000000000000e+00", AX);
     return std::make_pair(size_t(0), AX);

--- a/python/src/qdk_chemistry/plugins/pyscf/scf_solver.py
+++ b/python/src/qdk_chemistry/plugins/pyscf/scf_solver.py
@@ -299,11 +299,9 @@ class PyscfScfSolver(ScfSolver):
         _ovlp = mf.get_ovlp()
 
         if scf_type == SCFType.RESTRICTED and mol.spin != 0:
-            # ROHF/ROKS case - create unrestricted-style orbitals but with same coefficients
+            # ROHF/ROKS case - restricted orbitals (same coefficients for alpha and beta)
             orbitals = Orbitals(
-                mf.mo_coeff,  # Same coefficients for alpha and beta
                 mf.mo_coeff,
-                mf.mo_energy,  # Same energies for alpha and beta
                 mf.mo_energy,
                 ao_overlap=_ovlp,
                 basis_set=basis_set,

--- a/python/tests/test_stability.py
+++ b/python/tests/test_stability.py
@@ -425,18 +425,6 @@ def create_stretched_n2_structure(distance_angstrom=1.2):
     return Structure(symbols, coords)
 
 
-def create_stretched_h2_structure(distance_bohr=4.0):
-    """Create a stretched H2 structure in Bohr units."""
-    symbols = ["H", "H"]
-    coords = np.array(
-        [
-            [0.0, 0.0, 0.0],
-            [distance_bohr, 0.0, 0.0],
-        ]
-    )
-    return Structure(symbols, coords)
-
-
 def create_o2_structure():
     """Create an oxygen molecule (O2) structure."""
     symbols = ["O", "O"]

--- a/python/tests/test_stability.py
+++ b/python/tests/test_stability.py
@@ -734,64 +734,6 @@ class TestStabilityChecker:
         self._check_reference_eigenvalue(result, ref_external, is_internal=False)
 
     @pytest.mark.parametrize(
-        ("backend", "ref_internal", "ref_external"),
-        [
-            ("pyscf", 0.6291346026640, -0.4313775656554),
-            ("qdk", 0.6291346026640, -0.4313775656554),
-        ],
-    )
-    def test_stability_h2_stretched_rhf_sto3g(self, backend, ref_internal, ref_external):
-        """Test restricted RHF stability on stretched H2 with STO-3G."""
-        h2 = create_stretched_h2_structure(distance_bohr=4.0)
-
-        scf_solver = self._create_scf_solver(backend=backend, scf_type="restricted")
-        scf_solver.settings().set("method", "hf")
-        energy, wavefunction = scf_solver.run(h2, 0, 1, "sto-3g")
-        assert abs(energy - (-0.761082247527)) < scf_energy_tolerance
-        assert wavefunction.get_orbitals().is_restricted()
-
-        stability_checker = self._create_stability_checker(backend=backend, internal=True, external=True)
-        stability_checker.settings().set("method", "hf")
-        is_stable, result = stability_checker.run(wavefunction)
-
-        self._assert_basic_stability_result(result, is_stable, has_internal=True, has_external=True)
-        assert result.is_internal_stable() is True
-        assert result.is_external_stable() is False
-        assert is_stable is False
-
-        self._check_reference_eigenvalue(result, ref_internal, is_internal=True)
-        self._check_reference_eigenvalue(result, ref_external, is_internal=False)
-
-    @pytest.mark.parametrize(
-        ("backend", "ref_internal", "ref_external"),
-        [
-            ("pyscf", 0.6291346026640, -0.4313775656554),
-            ("qdk", 0.6291346026640, -0.4313775656554),
-        ],
-    )
-    def test_stability_h2_stretched_uhf_sto3g(self, backend, ref_internal, ref_external):
-        """Test unrestricted UHF stability on stretched H2 with STO-3G."""
-        h2 = create_stretched_h2_structure(distance_bohr=4.0)
-
-        scf_solver = self._create_scf_solver(backend=backend, scf_type="unrestricted")
-        scf_solver.settings().set("method", "hf")
-        energy, wavefunction = scf_solver.run(h2, 0, 1, "sto-3g")
-        assert abs(energy - (-0.761082247527)) < scf_energy_tolerance
-        assert not wavefunction.get_orbitals().is_restricted()
-
-        stability_checker = self._create_stability_checker(backend=backend)
-        stability_checker.settings().set("method", "hf")
-        is_stable, result = stability_checker.run(wavefunction)
-
-        self._assert_basic_stability_result(result, is_stable, has_internal=True, has_external=True)
-        assert result.is_internal_stable() is True
-        assert result.is_external_stable() is False
-        assert is_stable is False
-
-        self._check_reference_eigenvalue(result, ref_internal, is_internal=True)
-        self._check_reference_eigenvalue(result, ref_external, is_internal=False)
-
-    @pytest.mark.parametrize(
         ("backend", "ref_eigenvalue"),
         [
             ("pyscf", -0.07936046244954532),

--- a/python/tests/test_stability.py
+++ b/python/tests/test_stability.py
@@ -425,6 +425,18 @@ def create_stretched_n2_structure(distance_angstrom=1.2):
     return Structure(symbols, coords)
 
 
+def create_stretched_h2_structure(distance_bohr=4.0):
+    """Create a stretched H2 structure in Bohr units."""
+    symbols = ["H", "H"]
+    coords = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [distance_bohr, 0.0, 0.0],
+        ]
+    )
+    return Structure(symbols, coords)
+
+
 def create_o2_structure():
     """Create an oxygen molecule (O2) structure."""
     symbols = ["O", "O"]
@@ -718,6 +730,35 @@ class TestStabilityChecker:
         assert is_stable is (expected_internal_stable and expected_external_stable)
 
         # Check reference eigenvalues
+        self._check_reference_eigenvalue(result, ref_internal, is_internal=True)
+        self._check_reference_eigenvalue(result, ref_external, is_internal=False)
+
+    @pytest.mark.parametrize(
+        ("backend", "ref_internal", "ref_external"),
+        [
+            ("pyscf", 0.6291346026640, -0.4313775656554),
+            ("qdk", 0.6291346026640, -0.4313775656554),
+        ],
+    )
+    def test_stability_h2_stretched_rhf_sto3g(self, backend, ref_internal, ref_external):
+        """Test restricted RHF stability on stretched H2 with STO-3G."""
+        h2 = create_stretched_h2_structure(distance_bohr=4.0)
+
+        scf_solver = self._create_scf_solver(backend=backend, scf_type="restricted")
+        scf_solver.settings().set("method", "hf")
+        energy, wavefunction = scf_solver.run(h2, 0, 1, "sto-3g")
+        assert abs(energy - (-0.761082247527)) < scf_energy_tolerance
+        assert wavefunction.get_orbitals().is_restricted()
+
+        stability_checker = self._create_stability_checker(backend=backend, internal=True, external=True)
+        stability_checker.settings().set("method", "hf")
+        is_stable, result = stability_checker.run(wavefunction)
+
+        self._assert_basic_stability_result(result, is_stable, has_internal=True, has_external=True)
+        assert result.is_internal_stable() is True
+        assert result.is_external_stable() is False
+        assert is_stable is False
+
         self._check_reference_eigenvalue(result, ref_internal, is_internal=True)
         self._check_reference_eigenvalue(result, ref_external, is_internal=False)
 

--- a/python/tests/test_stability.py
+++ b/python/tests/test_stability.py
@@ -763,6 +763,35 @@ class TestStabilityChecker:
         self._check_reference_eigenvalue(result, ref_external, is_internal=False)
 
     @pytest.mark.parametrize(
+        ("backend", "ref_internal", "ref_external"),
+        [
+            ("pyscf", 0.6291346026640, -0.4313775656554),
+            ("qdk", 0.6291346026640, -0.4313775656554),
+        ],
+    )
+    def test_stability_h2_stretched_uhf_sto3g(self, backend, ref_internal, ref_external):
+        """Test unrestricted UHF stability on stretched H2 with STO-3G."""
+        h2 = create_stretched_h2_structure(distance_bohr=4.0)
+
+        scf_solver = self._create_scf_solver(backend=backend, scf_type="unrestricted")
+        scf_solver.settings().set("method", "hf")
+        energy, wavefunction = scf_solver.run(h2, 0, 1, "sto-3g")
+        assert abs(energy - (-0.761082247527)) < scf_energy_tolerance
+        assert not wavefunction.get_orbitals().is_restricted()
+
+        stability_checker = self._create_stability_checker(backend=backend)
+        stability_checker.settings().set("method", "hf")
+        is_stable, result = stability_checker.run(wavefunction)
+
+        self._assert_basic_stability_result(result, is_stable, has_internal=True, has_external=True)
+        assert result.is_internal_stable() is True
+        assert result.is_external_stable() is False
+        assert is_stable is False
+
+        self._check_reference_eigenvalue(result, ref_internal, is_internal=True)
+        self._check_reference_eigenvalue(result, ref_external, is_internal=False)
+
+    @pytest.mark.parametrize(
         ("backend", "ref_eigenvalue"),
         [
             ("pyscf", -0.07936046244954532),


### PR DESCRIPTION
When the rotation vector has only one degree of freedom, the original Davidson eigensolver may return wrong results. The bug is fixed, and warning message is added in the `is_restricted` method of class `Orbitals`.