### PR TITLE
print available options for factory settings

### DIFF
--- a/cpp/include/qdk/chemistry/algorithms/scf.hpp
+++ b/cpp/include/qdk/chemistry/algorithms/scf.hpp
@@ -23,18 +23,18 @@ namespace qdk::chemistry::algorithms {
 class ElectronicStructureSettings : public data::Settings {
  public:
   ElectronicStructureSettings() {
-    set_default("method", "hf",
-                "SCF method: 'hf' for Hartree-Fock, or a DFT functional name. "
-                "See the user manual for the complete list of available options.");
+    set_default(
+        "method", "hf",
+        "SCF method: 'hf' for Hartree-Fock, or a DFT functional name. "
+        "See the user manual for the complete list of available options.");
     set_default("convergence_threshold", 1e-7);
     set_default("max_iterations", 50, "Maximum number of SCF iterations",
                 qdk::chemistry::data::BoundConstraint<int64_t>{
                     1, std::numeric_limits<int64_t>::max()});
     set_default("scf_type", std::string("auto"),
                 "SCF orbital type: 'auto' selects based on spin multiplicity",
-                data::ListConstraint<std::string>{
-                    {std::vector<std::string>{"auto", "restricted",
-                                              "unrestricted"}}});
+                data::ListConstraint<std::string>{{std::vector<std::string>{
+                    "auto", "restricted", "unrestricted"}}});
   }
 };
 

--- a/cpp/include/qdk/chemistry/algorithms/scf.hpp
+++ b/cpp/include/qdk/chemistry/algorithms/scf.hpp
@@ -23,12 +23,18 @@ namespace qdk::chemistry::algorithms {
 class ElectronicStructureSettings : public data::Settings {
  public:
   ElectronicStructureSettings() {
-    set_default("method", "hf");
+    set_default("method", "hf",
+                "SCF method: 'hf' for Hartree-Fock, or a DFT functional name. "
+                "See the user manual for the complete list of available options.");
     set_default("convergence_threshold", 1e-7);
     set_default("max_iterations", 50, "Maximum number of SCF iterations",
                 qdk::chemistry::data::BoundConstraint<int64_t>{
                     1, std::numeric_limits<int64_t>::max()});
-    set_default("scf_type", "auto");
+    set_default("scf_type", std::string("auto"),
+                "SCF orbital type: 'auto' selects based on spin multiplicity",
+                data::ListConstraint<std::string>{
+                    {std::vector<std::string>{"auto", "restricted",
+                                              "unrestricted"}}});
   }
 };
 

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.cpp
@@ -715,18 +715,9 @@ std::shared_ptr<data::Hamiltonian> CholeskyHamiltonianConstructor::_run_impl(
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
       Cb_active_rm = Cb_active;
 
-  // Determine SCF type from settings
-  std::string scf_type = _settings->get<std::string>("scf_type");
-
-  bool is_restricted_calc;
-  if (scf_type == "restricted") {
-    is_restricted_calc = true;
-  } else if (scf_type == "unrestricted") {
-    is_restricted_calc = false;
-  } else {  // "auto"
-    is_restricted_calc = (active_indices_alpha == active_indices_beta) &&
-                         orbitals->is_restricted();
-  }
+  // Determine restricted/unrestricted from orbitals (auto behavior)
+  bool is_restricted_calc = (active_indices_alpha == active_indices_beta) &&
+                            orbitals->is_restricted();
 
   // SCFOrbitalType::RestrictedOpenShell is not supported for Hamiltonian
   // construction, so we only set Restricted for all restricted cases

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.hpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.hpp
@@ -53,7 +53,11 @@ Eigen::MatrixXd build_K_from_cholesky(
 class CholeskyHamiltonianSettings : public qdk::chemistry::data::Settings {
  public:
   CholeskyHamiltonianSettings() {
-    set_default("scf_type", "auto");
+    set_default("scf_type", std::string("auto"),
+                "SCF orbital type: 'auto' selects based on spin multiplicity",
+                data::ListConstraint<std::string>{
+                    {std::vector<std::string>{"auto", "restricted",
+                                              "unrestricted"}}});
     set_default("cholesky_tolerance", 1e-8);
     set_default("eri_threshold", 1e-12,
                 "ERI screening threshold for skipping negligible shell "

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.hpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.hpp
@@ -53,10 +53,6 @@ Eigen::MatrixXd build_K_from_cholesky(
 class CholeskyHamiltonianSettings : public qdk::chemistry::data::Settings {
  public:
   CholeskyHamiltonianSettings() {
-    set_default("scf_type", std::string("auto"),
-                "SCF orbital type: 'auto' selects based on spin multiplicity",
-                data::ListConstraint<std::string>{{std::vector<std::string>{
-                    "auto", "restricted", "unrestricted"}}});
     set_default("cholesky_tolerance", 1e-8);
     set_default("eri_threshold", 1e-12,
                 "ERI screening threshold for skipping negligible shell "

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.hpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/cholesky_hamiltonian.hpp
@@ -55,9 +55,8 @@ class CholeskyHamiltonianSettings : public qdk::chemistry::data::Settings {
   CholeskyHamiltonianSettings() {
     set_default("scf_type", std::string("auto"),
                 "SCF orbital type: 'auto' selects based on spin multiplicity",
-                data::ListConstraint<std::string>{
-                    {std::vector<std::string>{"auto", "restricted",
-                                              "unrestricted"}}});
+                data::ListConstraint<std::string>{{std::vector<std::string>{
+                    "auto", "restricted", "unrestricted"}}});
     set_default("cholesky_tolerance", 1e-8);
     set_default("eri_threshold", 1e-12,
                 "ERI screening threshold for skipping negligible shell "

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/hamiltonian.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/hamiltonian.cpp
@@ -221,18 +221,9 @@ std::shared_ptr<data::Hamiltonian> HamiltonianConstructor::_run_impl(
   // Initialize MOERI
   qcs::MOERI moeri_c(eri);
 
-  // Determine SCF type from settings
-  std::string scf_type = _settings->get<std::string>("scf_type");
-
-  bool is_restricted_calc;
-  if (scf_type == "restricted") {
-    is_restricted_calc = true;
-  } else if (scf_type == "unrestricted") {
-    is_restricted_calc = false;
-  } else {  // "auto"
-    is_restricted_calc = (active_indices_alpha == active_indices_beta) &&
-                         orbitals->is_restricted();
-  }
+  // Determine restricted/unrestricted from orbitals (auto behavior)
+  bool is_restricted_calc = (active_indices_alpha == active_indices_beta) &&
+                            orbitals->is_restricted();
 
   // SCFOrbitalType::RestrictedOpenShell is not supported for Hamiltonian
   // construction, so we only use Restricted in restricted case

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/hamiltonian.hpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/hamiltonian.hpp
@@ -20,9 +20,8 @@ class HamiltonianSettings : public qdk::chemistry::data::Settings {
                     {std::vector<std::string>{"direct", "incore"}}});
     set_default("scf_type", std::string("auto"),
                 "SCF orbital type: 'auto' selects based on spin multiplicity",
-                data::ListConstraint<std::string>{
-                    {std::vector<std::string>{"auto", "restricted",
-                                              "unrestricted"}}});
+                data::ListConstraint<std::string>{{std::vector<std::string>{
+                    "auto", "restricted", "unrestricted"}}});
   }
   ~HamiltonianSettings() override = default;
 };

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/hamiltonian.hpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/hamiltonian.hpp
@@ -18,10 +18,6 @@ class HamiltonianSettings : public qdk::chemistry::data::Settings {
                 "on-the-fly, 'incore' stores all integrals in memory",
                 data::ListConstraint<std::string>{
                     {std::vector<std::string>{"direct", "incore"}}});
-    set_default("scf_type", std::string("auto"),
-                "SCF orbital type: 'auto' selects based on spin multiplicity",
-                data::ListConstraint<std::string>{{std::vector<std::string>{
-                    "auto", "restricted", "unrestricted"}}});
   }
   ~HamiltonianSettings() override = default;
 };

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/hamiltonian.hpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/hamiltonian.hpp
@@ -6,14 +6,23 @@
 
 #include <qdk/chemistry/algorithms/hamiltonian.hpp>
 #include <qdk/chemistry/data/hamiltonian.hpp>
+#include <qdk/chemistry/data/settings.hpp>
 
 namespace qdk::chemistry::algorithms::microsoft {
 
 class HamiltonianSettings : public qdk::chemistry::data::Settings {
  public:
   HamiltonianSettings() {
-    set_default("eri_method", "direct");
-    set_default("scf_type", "auto");
+    set_default("eri_method", std::string("direct"),
+                "ERI evaluation method: 'direct' computes integrals "
+                "on-the-fly, 'incore' stores all integrals in memory",
+                data::ListConstraint<std::string>{
+                    {std::vector<std::string>{"direct", "incore"}}});
+    set_default("scf_type", std::string("auto"),
+                "SCF orbital type: 'auto' selects based on spin multiplicity",
+                data::ListConstraint<std::string>{
+                    {std::vector<std::string>{"auto", "restricted",
+                                              "unrestricted"}}});
   }
   ~HamiltonianSettings() override = default;
 };

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/localization/vvhv.hpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/localization/vvhv.hpp
@@ -21,7 +21,10 @@ namespace qdk::chemistry::algorithms::microsoft {
 class VVHVLocalizerSettings : public IterativeOrbitalLocalizationSettings {
  public:
   VVHVLocalizerSettings() {
-    set_default("minimal_basis", std::string("sto-3g"));
+    set_default("minimal_basis", std::string("sto-3g"),
+                "Minimal basis set for VVHV partitioning",
+                data::ListConstraint<std::string>{
+                    {std::vector<std::string>{"sto-3g", "sto-3g*"}}});
     set_default("weighted_orthogonalization", true);
   }
 };

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/macis_asci.hpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/macis_asci.hpp
@@ -137,7 +137,12 @@ class MacisAsciSettings : public MacisSettings {
         data::BoundConstraint<int64_t>{0, std::numeric_limits<int64_t>::max()});
 
     // Core selection strategy parameter
-    set_default<std::string>("core_selection_strategy", "percentage");
+    set_default<std::string>(
+        "core_selection_strategy", "percentage",
+        "Core determinant selection strategy: 'percentage' uses cumulative "
+        "weight threshold, 'fixed' uses a fixed number of determinants",
+        data::ListConstraint<std::string>{
+            {std::vector<std::string>{"percentage", "fixed"}}});
     set_default<double>("core_selection_threshold",
                         macis_defaults.core_selection_threshold,
                         "Cumulative weight threshold for core selection",

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/stability.hpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/stability.hpp
@@ -46,7 +46,9 @@ class StabilityCheckerSettings : public qdk::chemistry::data::Settings {
     set_default("max_subspace", 80);
     set_default("davidson_tolerance", 1e-8);
     set_default("stability_tolerance", -1e-4);
-    set_default("method", "hf");
+    set_default("method", "hf",
+                "SCF method: 'hf' for Hartree-Fock, or a DFT functional name. "
+                "See the user manual for the complete list of available options.");
   }
 };
 

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/stability.hpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/stability.hpp
@@ -46,9 +46,10 @@ class StabilityCheckerSettings : public qdk::chemistry::data::Settings {
     set_default("max_subspace", 80);
     set_default("davidson_tolerance", 1e-8);
     set_default("stability_tolerance", -1e-4);
-    set_default("method", "hf",
-                "SCF method: 'hf' for Hartree-Fock, or a DFT functional name. "
-                "See the user manual for the complete list of available options.");
+    set_default(
+        "method", "hf",
+        "SCF method: 'hf' for Hartree-Fock, or a DFT functional name. "
+        "See the user manual for the complete list of available options.");
   }
 };
 

--- a/docs/source/user/comprehensive/algorithms/hamiltonian_constructor.rst
+++ b/docs/source/user/comprehensive/algorithms/hamiltonian_constructor.rst
@@ -122,9 +122,6 @@ The native QDK/Chemistry implementation for Hamiltonian construction. Transforms
    * - ``eri_method``
      - string
      - Method for computing electron repulsion integrals ("direct" or "incore")
-   * - ``scf_type``
-     - string
-     - Type of :term:`SCF` reference ("auto", "unrestricted" or "restricted"). Default: "auto" (automatically detected from orbitals)
 
 QDK Cholesky
 ~~~~~~~~~~~~
@@ -147,9 +144,6 @@ Four-center integrals are lazily computed from the three-center integrals on dem
    * - Setting
      - Type
      - Description
-   * - ``scf_type``
-     - string
-     - Type of :term:`SCF` reference ("auto", "unrestricted" or "restricted"). Default: "auto" (automatically detected from orbitals)
    * - ``cholesky_tolerance``
      - float
      - Tolerance for Cholesky decomposition accuracy. Smaller values give higher accuracy but more Cholesky vectors. Default: 1e-8

--- a/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/partially_randomized.py
+++ b/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/partially_randomized.py
@@ -104,7 +104,7 @@ class PartiallyRandomizedSettings(TimeEvolutionSettings):
             "string",
             "general",
             "Commutation check for merging: 'qubit_wise' (per-qubit) or 'general' (standard Pauli).",
-            ("qubit_wise", "general"),
+            ["qubit_wise", "general"],
         )
 
 

--- a/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/qdrift.py
+++ b/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/qdrift.py
@@ -83,7 +83,7 @@ class QDriftSettings(TimeEvolutionSettings):
             "string",
             "general",
             "Commutation check for merging: 'qubit_wise' (per-qubit) or 'general' (standard Pauli).",
-            ("qubit_wise", "general"),
+            ["qubit_wise", "general"],
         )
 
 

--- a/python/src/qdk_chemistry/plugins/pyscf/localization.py
+++ b/python/src/qdk_chemistry/plugins/pyscf/localization.py
@@ -69,9 +69,21 @@ class PyscfLocalizerSettings(Settings):
         """Initialize the localization object with default parameters."""
         Logger.trace_entering()
         super().__init__()
-        self._set_default("method", "string", "pipek-mezey")
+        self._set_default(
+            "method",
+            "string",
+            "pipek-mezey",
+            "Localization algorithm",
+            ["pipek-mezey", "foster-boys", "edmiston-ruedenberg", "cholesky"],
+        )
         self._set_default("occupation_threshold", "double", 1e-10)
-        self._set_default("population_method", "string", "mulliken")
+        self._set_default(
+            "population_method",
+            "string",
+            "mulliken",
+            "Population analysis for Pipek-Mezey localization",
+            ["mulliken", "lowdin", "meta_lowdin", "becke"],
+        )
 
 
 class PyscfLocalizer(OrbitalLocalizer):

--- a/python/src/qdk_chemistry/plugins/pyscf/stability.py
+++ b/python/src/qdk_chemistry/plugins/pyscf/stability.py
@@ -210,7 +210,13 @@ class PyscfStabilitySettings(Settings):
         self._set_default("nroots", "int", 3)
         self._set_default("davidson_tolerance", "double", 1e-8)
         self._set_default("stability_tolerance", "double", -1e-4)
-        self._set_default("method", "string", "hf")
+        self._set_default(
+            "method",
+            "string",
+            "hf",
+            "SCF method: 'hf' for Hartree-Fock, or a DFT functional name. "
+            "See the user manual for the complete list of available options.",
+        )
         self._set_default(
             "xc_grid", "int", 3, "Density functional integration grid level (0=coarse, 9=very fine)", list(range(10))
         )

--- a/python/src/qdk_chemistry/plugins/qiskit/circuit_executor.py
+++ b/python/src/qdk_chemistry/plugins/qiskit/circuit_executor.py
@@ -52,7 +52,23 @@ class QiskitAerSimulatorSettings(Settings):
         Logger.trace_entering()
         super().__init__()
         self._set_default("seed", "int", 42)
-        self._set_default("method", "string", "statevector")
+        self._set_default(
+            "method",
+            "string",
+            "statevector",
+            "Aer simulation method",
+            [
+                "automatic",
+                "statevector",
+                "density_matrix",
+                "stabilizer",
+                "extended_stabilizer",
+                "matrix_product_state",
+                "unitary",
+                "superop",
+                "tensor_network",
+            ],
+        )
         self._set_default("transpile_optimization_level", "int", 0)
         self._set_default("device_backend_name", "string", "", "Name of a fake device backend for noise modeling.")
         self._set_default(

--- a/python/tests/test_algorithms_registry.py
+++ b/python/tests/test_algorithms_registry.py
@@ -401,6 +401,47 @@ class TestStringSettingsHaveGuidance:
         )
 
 
+def _string_settings_with_allowed_values() -> list[tuple[str, str, str, list[str]]]:
+    """Collect (algorithm_type, algorithm_name, setting_name, allowed_values) for all string settings with options."""
+    cases: list[tuple[str, str, str, list[str]]] = []
+    for atype, aname in _REGISTERED_PAIRS:
+        try:
+            info = registry.inspect_settings(atype, aname)
+        except (ImportError, RuntimeError):
+            continue
+        for sname, ptype, _default, _desc, limits in info:
+            if ptype == "str" and isinstance(limits, list) and len(limits) > 0:
+                cases.append((atype, aname, sname, limits))
+    return cases
+
+
+_STRING_SETTINGS_WITH_OPTIONS = _string_settings_with_allowed_values()
+
+
+@pytest.mark.parametrize(
+    ("algorithm_type", "algorithm_name", "setting_name", "allowed_values"),
+    _STRING_SETTINGS_WITH_OPTIONS,
+    ids=[f"{t}/{n}.{s}" for t, n, s, _ in _STRING_SETTINGS_WITH_OPTIONS],
+)
+class TestAllowedStringValuesAccepted:
+    """Every advertised string option must be accepted by the algorithm's settings without error."""
+
+    def test_each_allowed_value_can_be_set(
+        self, algorithm_type: str, algorithm_name: str, setting_name: str, allowed_values: list[str]
+    ):
+        try:
+            algo = registry.create(algorithm_type, algorithm_name)
+        except (ImportError, RuntimeError) as exc:
+            pytest.skip(f"cannot instantiate {algorithm_type}/{algorithm_name}: {exc}")
+
+        for value in allowed_values:
+            algo.settings().set(setting_name, value)
+            assert algo.settings().get(setting_name) == value, (
+                f"{algorithm_type}/{algorithm_name}: setting {setting_name!r} to {value!r} "
+                f"did not persist (got {algo.settings().get(setting_name)!r})"
+            )
+
+
 class TestRegistryRegisterUnregister:
     """Test the register and unregister functions in the registry module."""
 

--- a/python/tests/test_algorithms_registry.py
+++ b/python/tests/test_algorithms_registry.py
@@ -357,6 +357,53 @@ class TestRegistryInspectSettings:
                 # Limits can be tuple (for ranges) or list (for allowed values)
                 assert isinstance(limits, tuple | list), f"Unexpected limits type for {name}: {type(limits)}"
 
+def _all_registered_pairs() -> list[tuple[str, str]]:
+    """All (algorithm_type, algorithm_name) pairs known to the registry."""
+    pairs: list[tuple[str, str]] = []
+    available = registry.available()
+    assert isinstance(available, dict)
+    for atype, names in available.items():
+        for name in names:
+            pairs.append((atype, name))
+    return pairs
+
+
+_REGISTERED_PAIRS = _all_registered_pairs()
+
+
+@pytest.mark.parametrize(
+    ("algorithm_type", "algorithm_name"),
+    _REGISTERED_PAIRS,
+    ids=[f"{t}/{n}" for t, n in _REGISTERED_PAIRS],
+)
+class TestStringSettingsHaveGuidance:
+    """Every string-typed setting must expose a description or an allowed-values list."""
+
+    def test_string_settings_have_description_or_allowed_values(
+        self, algorithm_type: str, algorithm_name: str
+    ):
+        try:
+            info = registry.inspect_settings(algorithm_type, algorithm_name)
+        except (ImportError, RuntimeError) as exc:
+            pytest.skip(f"cannot instantiate {algorithm_type}/{algorithm_name}: {exc}")
+
+        offenders: list[str] = []
+        for sname, ptype, _default, desc, limits in info:
+            if ptype != "str":
+                continue
+            has_desc = isinstance(desc, str) and bool(desc.strip())
+            has_allowed_list = isinstance(limits, list) and len(limits) > 0
+            if not (has_desc or has_allowed_list):
+                offenders.append(
+                    f"  {sname!r}: description={desc!r}, limits={limits!r} (type={type(limits).__name__})"
+                )
+
+        assert not offenders, (
+            f"String-typed settings in {algorithm_type}/{algorithm_name} must expose either "
+            f"a description or an allowed-values list (was a tuple used instead of a list?):\n"
+            + "\n".join(offenders)
+        )
+
 
 class TestRegistryRegisterUnregister:
     """Test the register and unregister functions in the registry module."""

--- a/python/tests/test_algorithms_registry.py
+++ b/python/tests/test_algorithms_registry.py
@@ -357,6 +357,7 @@ class TestRegistryInspectSettings:
                 # Limits can be tuple (for ranges) or list (for allowed values)
                 assert isinstance(limits, tuple | list), f"Unexpected limits type for {name}: {type(limits)}"
 
+
 def _all_registered_pairs() -> list[tuple[str, str]]:
     """All (algorithm_type, algorithm_name) pairs known to the registry."""
     pairs: list[tuple[str, str]] = []
@@ -379,9 +380,7 @@ _REGISTERED_PAIRS = _all_registered_pairs()
 class TestStringSettingsHaveGuidance:
     """Every string-typed setting must expose a description or an allowed-values list."""
 
-    def test_string_settings_have_description_or_allowed_values(
-        self, algorithm_type: str, algorithm_name: str
-    ):
+    def test_string_settings_have_description_or_allowed_values(self, algorithm_type: str, algorithm_name: str):
         try:
             info = registry.inspect_settings(algorithm_type, algorithm_name)
         except (ImportError, RuntimeError) as exc:
@@ -394,14 +393,11 @@ class TestStringSettingsHaveGuidance:
             has_desc = isinstance(desc, str) and bool(desc.strip())
             has_allowed_list = isinstance(limits, list) and len(limits) > 0
             if not (has_desc or has_allowed_list):
-                offenders.append(
-                    f"  {sname!r}: description={desc!r}, limits={limits!r} (type={type(limits).__name__})"
-                )
+                offenders.append(f"  {sname!r}: description={desc!r}, limits={limits!r} (type={type(limits).__name__})")
 
         assert not offenders, (
             f"String-typed settings in {algorithm_type}/{algorithm_name} must expose either "
-            f"a description or an allowed-values list (was a tuple used instead of a list?):\n"
-            + "\n".join(offenders)
+            f"a description or an allowed-values list (was a tuple used instead of a list?):\n" + "\n".join(offenders)
         )
 
 


### PR DESCRIPTION
As issue #473 says, print_settings(factory, method) does not always print all available options. This PR fixes the issue. In cases where HF is the default, and DFTs are all available, we do not give the complete list of DFTs in the result table, instead, we mention in the comment that the user should refer to the manual. I've also put it a "rule": if a future setting expects a string as value, the setting must have a list of available options or a description for user reference, otherwise a test will fail. 

This PR also removes the scf_type setting from hamiltonian factories (4 center and cholesky). The new design matches with the "auto" setting, which mean if 1) the Orbitals is restricted and 2) active spaces are the same between alpha and beta.