### PR TITLE
fix 2RDM spin component order to `(aaaa, aabb, bbbb)`

### DIFF
--- a/cpp/include/qdk/chemistry/data/wavefunction.hpp
+++ b/cpp/include/qdk/chemistry/data/wavefunction.hpp
@@ -224,9 +224,9 @@ class WavefunctionContainer {
    * @param one_rdm_aa Alpha-alpha block of 1-RDM for active orbitals (optional)
    * @param one_rdm_bb Beta-beta block of 1-RDM for active orbitals (optional)
    * @param two_rdm_spin_traced Spin-traced 2-RDM for active orbitals (optional)
-   * @param two_rdm_aabb Alpha-beta-alpha-beta block of 2-RDM for active
-   * orbitals (optional)
    * @param two_rdm_aaaa Alpha-alpha-alpha-alpha block of 2-RDM for active
+   * orbitals (optional)
+   * @param two_rdm_aabb Alpha-alpha-beta-beta block of 2-RDM for active
    * orbitals (optional)
    * @param two_rdm_bbbb Beta-beta-beta-beta block of 2-RDM for active orbitals
    * (optional)
@@ -237,8 +237,8 @@ class WavefunctionContainer {
                         const std::optional<MatrixVariant>& one_rdm_aa,
                         const std::optional<MatrixVariant>& one_rdm_bb,
                         const std::optional<VectorVariant>& two_rdm_spin_traced,
-                        const std::optional<VectorVariant>& two_rdm_aabb,
                         const std::optional<VectorVariant>& two_rdm_aaaa,
+                        const std::optional<VectorVariant>& two_rdm_aabb,
                         const std::optional<VectorVariant>& two_rdm_bbbb,
                         const OrbitalEntropies& entropies = OrbitalEntropies{},
                         WavefunctionType type = WavefunctionType::SelfDual);
@@ -329,7 +329,7 @@ class WavefunctionContainer {
   /**
    * @brief Get spin-dependent two-particle RDMs for active orbitals only
    *
-   * @return Tuple of (aabb, aaaa, bbbb) two-particle RDMs for active orbitals,
+   * @return Tuple of (aaaa, aabb, bbbb) two-particle RDMs for active orbitals,
    * constructed from the canonical symmetry-blocked tensor.
    */
   virtual std::tuple<VectorVariant, VectorVariant, VectorVariant>
@@ -904,7 +904,7 @@ class Wavefunction : public DataClass,
 
   /**
    * @brief Get spin-dependent two-particle RDMs
-   * @return Tuple of (aabb, aaaa, bbbb) two-particle RDMs
+   * @return Tuple of (aaaa, aabb, bbbb) two-particle RDMs
    */
   std::tuple<VectorVariant, VectorVariant, VectorVariant>
   get_active_two_rdm_spin_dependent() const;

--- a/cpp/include/qdk/chemistry/data/wavefunction_containers/cas.hpp
+++ b/cpp/include/qdk/chemistry/data/wavefunction_containers/cas.hpp
@@ -73,9 +73,9 @@ class CasWavefunctionContainer : public WavefunctionContainer {
    * @param one_rdm_aa Alpha-alpha block of 1-RDM for active orbitals (optional)
    * @param one_rdm_bb Beta-beta block of 1-RDM for active orbitals (optional)
    * @param two_rdm_spin_traced Spin-traced 2-RDM for active orbitals (optional)
-   * @param two_rdm_aabb Alpha-alpha-beta-beta block of 2-RDM for active
-   * orbitals (optional)
    * @param two_rdm_aaaa Alpha-alpha-alpha-alpha block of 2-RDM for active
+   * orbitals (optional)
+   * @param two_rdm_aabb Alpha-alpha-beta-beta block of 2-RDM for active
    * orbitals (optional)
    * @param two_rdm_bbbb Beta-beta-beta-beta block of 2-RDM for active orbitals
    * (optional)
@@ -90,8 +90,8 @@ class CasWavefunctionContainer : public WavefunctionContainer {
       const std::optional<MatrixVariant>& one_rdm_aa,
       const std::optional<MatrixVariant>& one_rdm_bb,
       const std::optional<VectorVariant>& two_rdm_spin_traced,
-      const std::optional<VectorVariant>& two_rdm_aabb,
       const std::optional<VectorVariant>& two_rdm_aaaa,
+      const std::optional<VectorVariant>& two_rdm_aabb,
       const std::optional<VectorVariant>& two_rdm_bbbb,
       const OrbitalEntropies& entropies = OrbitalEntropies{},
       WavefunctionType type = WavefunctionType::SelfDual);

--- a/cpp/include/qdk/chemistry/data/wavefunction_containers/cc.hpp
+++ b/cpp/include/qdk/chemistry/data/wavefunction_containers/cc.hpp
@@ -335,7 +335,7 @@ class CoupledClusterContainer : public WavefunctionContainer {
    *       Coupled cluster RDM computation requires the adjoint (bra)
    *       wavefunction with lambda amplitudes.
    *
-   * @return Tuple of (aabb, aaaa, bbbb) two-particle RDMs
+   * @return Tuple of (aaaa, aabb, bbbb) two-particle RDMs
    * @throws std::runtime_error Always throws - requires adjoint wavefunction
    */
   std::tuple<VectorVariant, VectorVariant, VectorVariant>

--- a/cpp/include/qdk/chemistry/data/wavefunction_containers/sci.hpp
+++ b/cpp/include/qdk/chemistry/data/wavefunction_containers/sci.hpp
@@ -71,9 +71,9 @@ class SciWavefunctionContainer : public WavefunctionContainer {
    * @param one_rdm_aa Alpha-alpha block of 1-RDM for active orbitals (optional)
    * @param one_rdm_bb Beta-beta block of 1-RDM for active orbitals (optional)
    * @param two_rdm_spin_traced Spin-traced 2-RDM for active orbitals (optional)
-   * @param two_rdm_aabb Alpha-alpha-beta-beta block of 2-RDM for active
-   * orbitals (optional)
    * @param two_rdm_aaaa Alpha-alpha-alpha-alpha block of 2-RDM for active
+   * orbitals (optional)
+   * @param two_rdm_aabb Alpha-alpha-beta-beta block of 2-RDM for active
    * orbitals (optional)
    * @param two_rdm_bbbb Beta-beta-beta-beta block of 2-RDM for active orbitals
    * (optional)
@@ -88,8 +88,8 @@ class SciWavefunctionContainer : public WavefunctionContainer {
       const std::optional<MatrixVariant>& one_rdm_aa,
       const std::optional<MatrixVariant>& one_rdm_bb,
       const std::optional<VectorVariant>& two_rdm_spin_traced,
-      const std::optional<VectorVariant>& two_rdm_aabb,
       const std::optional<VectorVariant>& two_rdm_aaaa,
+      const std::optional<VectorVariant>& two_rdm_aabb,
       const std::optional<VectorVariant>& two_rdm_bbbb,
       const OrbitalEntropies& entropies = OrbitalEntropies{},
       WavefunctionType type = WavefunctionType::SelfDual);

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/macis_base.hpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/macis_base.hpp
@@ -114,7 +114,7 @@ auto dispatch_by_norb(size_t norb, Args&&... args) {
  *    (coeffs, dets, orbitals)
  *    (coeffs, dets, orbitals, one_rdm_spin_traced, two_rdm_spin_traced)
  *    (coeffs, dets, orbitals, one_rdm_spin_traced, one_rdm_aa, one_rdm_bb,
- *       two_rdm_spin_traced, two_rdm_aabb, two_rdm_aaaa, two_rdm_bbbb,
+ *       two_rdm_spin_traced, two_rdm_aaaa, two_rdm_aabb, two_rdm_bbbb,
  *       single_orbital_entropies, mutual_information, type)
  *
  * @tparam Container Concrete wavefunction container class.
@@ -248,8 +248,8 @@ inline data::Wavefunction build_wavefunction(
       computed_entropies.has_any()) {
     container = std::make_unique<Container>(
         C_vector, dets_configs, hamiltonian.get_orbitals(), std::nullopt,
-        to_mv(one_aa), to_mv(one_bb), std::nullopt, to_vv(two_aabb),
-        to_vv(two_aaaa), to_vv(two_bbbb), computed_entropies,
+        to_mv(one_aa), to_mv(one_bb), std::nullopt, to_vv(two_aaaa),
+        to_vv(two_aabb), to_vv(two_bbbb), computed_entropies,
         data::WavefunctionType::SelfDual);
   } else {
     container = std::make_unique<Container>(C_vector, dets_configs,

--- a/cpp/src/qdk/chemistry/data/wavefunction.cpp
+++ b/cpp/src/qdk/chemistry/data/wavefunction.cpp
@@ -164,8 +164,8 @@ WavefunctionContainer::WavefunctionContainer(WavefunctionType type)
                             std::nullopt,        // one_rdm_aa
                             std::nullopt,        // one_rdm_bb
                             std::nullopt,        // two_rdm_spin_traced
-                            std::nullopt,        // two_rdm_aabb
                             std::nullopt,        // two_rdm_aaaa
+                            std::nullopt,        // two_rdm_aabb
                             std::nullopt,        // two_rdm_bbbb
                             OrbitalEntropies{},  // entropies
                             type) {

--- a/cpp/src/qdk/chemistry/data/wavefunction.cpp
+++ b/cpp/src/qdk/chemistry/data/wavefunction.cpp
@@ -180,8 +180,8 @@ WavefunctionContainer::WavefunctionContainer(
                             std::nullopt,  // one_rdm_aa
                             std::nullopt,  // one_rdm_bb
                             two_rdm_spin_traced,
-                            std::nullopt,  // two_rdm_aabb
                             std::nullopt,  // two_rdm_aaaa
+                            std::nullopt,  // two_rdm_aabb
                             std::nullopt,  // two_rdm_bbbb
                             entropies, type) {
   QDK_LOG_TRACE_ENTERING();
@@ -192,8 +192,8 @@ WavefunctionContainer::WavefunctionContainer(
     const std::optional<ContainerTypes::MatrixVariant>& one_rdm_aa,
     const std::optional<ContainerTypes::MatrixVariant>& one_rdm_bb,
     const std::optional<ContainerTypes::VectorVariant>& two_rdm_spin_traced,
-    const std::optional<ContainerTypes::VectorVariant>& two_rdm_aabb,
     const std::optional<ContainerTypes::VectorVariant>& two_rdm_aaaa,
+    const std::optional<ContainerTypes::VectorVariant>& two_rdm_aabb,
     const std::optional<ContainerTypes::VectorVariant>& two_rdm_bbbb,
     const OrbitalEntropies& entropies, WavefunctionType type)
     : WavefunctionContainer(
@@ -281,9 +281,9 @@ WavefunctionContainer::get_active_two_rdm_spin_dependent() const {
                                          ContainerTypes::VectorVariant> {
         return std::make_tuple(
             ContainerTypes::VectorVariant{sbt.block(
-                {axes::alpha(), axes::alpha(), axes::beta(), axes::beta()})},
-            ContainerTypes::VectorVariant{sbt.block(
                 {axes::alpha(), axes::alpha(), axes::alpha(), axes::alpha()})},
+            ContainerTypes::VectorVariant{sbt.block(
+                {axes::alpha(), axes::alpha(), axes::beta(), axes::beta()})},
             ContainerTypes::VectorVariant{sbt.block(
                 {axes::beta(), axes::beta(), axes::beta(), axes::beta()})});
       },

--- a/cpp/src/qdk/chemistry/data/wavefunction_containers/cas.cpp
+++ b/cpp/src/qdk/chemistry/data/wavefunction_containers/cas.cpp
@@ -29,8 +29,8 @@ CasWavefunctionContainer::CasWavefunctionContainer(
                                std::nullopt,        // one_rdm_aa
                                std::nullopt,        // one_rdm_bb
                                std::nullopt,        // two_rdm_spin_traced
-                               std::nullopt,        // two_rdm_aabb
                                std::nullopt,        // two_rdm_aaaa
+                               std::nullopt,        // two_rdm_aabb
                                std::nullopt,        // two_rdm_bbbb
                                OrbitalEntropies{},  // entropies
                                type) {
@@ -47,8 +47,8 @@ CasWavefunctionContainer::CasWavefunctionContainer(
                                std::nullopt,  // one_rdm_aa
                                std::nullopt,  // one_rdm_bb
                                two_rdm_spin_traced,
-                               std::nullopt,  // two_rdm_aabb
                                std::nullopt,  // two_rdm_aaaa
+                               std::nullopt,  // two_rdm_aabb
                                std::nullopt,  // two_rdm_bbbb
                                entropies, type) {
   QDK_LOG_TRACE_ENTERING();
@@ -61,12 +61,12 @@ CasWavefunctionContainer::CasWavefunctionContainer(
     const std::optional<MatrixVariant>& one_rdm_aa,
     const std::optional<MatrixVariant>& one_rdm_bb,
     const std::optional<VectorVariant>& two_rdm_spin_traced,
-    const std::optional<VectorVariant>& two_rdm_aabb,
     const std::optional<VectorVariant>& two_rdm_aaaa,
+    const std::optional<VectorVariant>& two_rdm_aabb,
     const std::optional<VectorVariant>& two_rdm_bbbb,
     const OrbitalEntropies& entropies, WavefunctionType type)
     : WavefunctionContainer(one_rdm_spin_traced, one_rdm_aa, one_rdm_bb,
-                            two_rdm_spin_traced, two_rdm_aabb, two_rdm_aaaa,
+                            two_rdm_spin_traced, two_rdm_aaaa, two_rdm_aabb,
                             two_rdm_bbbb, entropies, type),
       _coefficients(coeffs),
       _configuration_set(dets, orbitals) {

--- a/cpp/src/qdk/chemistry/data/wavefunction_containers/sci.cpp
+++ b/cpp/src/qdk/chemistry/data/wavefunction_containers/sci.cpp
@@ -31,8 +31,8 @@ SciWavefunctionContainer::SciWavefunctionContainer(
                                std::nullopt,        // one_rdm_aa
                                std::nullopt,        // one_rdm_bb
                                std::nullopt,        // two_rdm_spin_traced
-                               std::nullopt,        // two_rdm_aabb
                                std::nullopt,        // two_rdm_aaaa
+                               std::nullopt,        // two_rdm_aabb
                                std::nullopt,        // two_rdm_bbbb
                                OrbitalEntropies{},  // entropies
                                type) {
@@ -49,8 +49,8 @@ SciWavefunctionContainer::SciWavefunctionContainer(
                                std::nullopt,  // one_rdm_aa
                                std::nullopt,  // one_rdm_bb
                                two_rdm_spin_traced,
-                               std::nullopt,  // two_rdm_aabb
                                std::nullopt,  // two_rdm_aaaa
+                               std::nullopt,  // two_rdm_aabb
                                std::nullopt,  // two_rdm_bbbb
                                entropies, type) {
   QDK_LOG_TRACE_ENTERING();
@@ -63,12 +63,12 @@ SciWavefunctionContainer::SciWavefunctionContainer(
     const std::optional<MatrixVariant>& one_rdm_aa,
     const std::optional<MatrixVariant>& one_rdm_bb,
     const std::optional<VectorVariant>& two_rdm_spin_traced,
-    const std::optional<VectorVariant>& two_rdm_aabb,
     const std::optional<VectorVariant>& two_rdm_aaaa,
+    const std::optional<VectorVariant>& two_rdm_aabb,
     const std::optional<VectorVariant>& two_rdm_bbbb,
     const OrbitalEntropies& entropies, WavefunctionType type)
     : WavefunctionContainer(one_rdm_spin_traced, one_rdm_aa, one_rdm_bb,
-                            two_rdm_spin_traced, two_rdm_aabb, two_rdm_aaaa,
+                            two_rdm_spin_traced, two_rdm_aaaa, two_rdm_aabb,
                             two_rdm_bbbb, entropies, type),
       _coefficients(coeffs),
       _configuration_set(dets, orbitals) {

--- a/cpp/tests/test_mp2.cpp
+++ b/cpp/tests/test_mp2.cpp
@@ -709,7 +709,7 @@ TEST_F(MP2Test, LazyRDMComputationFromAmplitudes) {
       << "Trace: " << rdm1_trace << ", N_electrons: " << n_electrons;
 
   // Verify 2-RDMs are available and have non-zero values
-  auto [two_rdm_aabb, two_rdm_aaaa, two_rdm_bbbb] =
+  auto [two_rdm_aaaa, two_rdm_aabb, two_rdm_bbbb] =
       mp2_container->get_active_two_rdm_spin_dependent();
   std::visit(
       [](const auto& rdm) {

--- a/cpp/tests/test_rdms.cpp
+++ b/cpp/tests/test_rdms.cpp
@@ -412,19 +412,19 @@ TEST_F(WavefunctionRDMTest, TwoRDMSpinDependent) {
 
   auto wf_r_dependent = Wavefunction(std::make_unique<CasWavefunctionContainer>(
       coeffs, dets, base_orbitals, std::nullopt, std::nullopt, std::nullopt,
-      std::nullopt, std::make_optional(two_rdm_aabb),
-      std::make_optional(two_rdm_aaaa), std::make_optional(two_rdm_aaaa)));
+      std::nullopt, std::make_optional(two_rdm_aaaa),
+      std::make_optional(two_rdm_aabb), std::make_optional(two_rdm_aaaa)));
   auto wf_u_dependent = Wavefunction(std::make_unique<CasWavefunctionContainer>(
       coeffs, dets, base_orbitals, std::nullopt, std::nullopt, std::nullopt,
-      std::nullopt, std::make_optional(two_rdm_aabb),
-      std::make_optional(two_rdm_aaaa), std::make_optional(two_rdm_bbbb)));
+      std::nullopt, std::make_optional(two_rdm_aaaa),
+      std::make_optional(two_rdm_aabb), std::make_optional(two_rdm_bbbb)));
 
   EXPECT_TRUE(wf_r_dependent.has_two_rdm_spin_dependent());
   EXPECT_TRUE(wf_u_dependent.has_two_rdm_spin_dependent());
 
-  auto [aabb_r, aaaa_r, bbbb_r] =
+  auto [aaaa_r, aabb_r, bbbb_r] =
       wf_r_dependent.get_active_two_rdm_spin_dependent();
-  auto [aabb_u, aaaa_u, bbbb_u] =
+  auto [aaaa_u, aabb_u, bbbb_u] =
       wf_u_dependent.get_active_two_rdm_spin_dependent();
 
   // For restricted case, bbbb should be equal to aaaa
@@ -452,12 +452,12 @@ TEST_F(WavefunctionRDMTest, TwoRDMSpinDependentTwoArguments) {
 
   auto wf_with_rdm = Wavefunction(std::make_unique<CasWavefunctionContainer>(
       coeffs, dets, base_orbitals, std::nullopt, std::nullopt, std::nullopt,
-      std::nullopt, std::make_optional(two_rdm_aabb),
-      std::make_optional(two_rdm_aaaa), std::make_optional(two_rdm_aaaa)));
+      std::nullopt, std::make_optional(two_rdm_aaaa),
+      std::make_optional(two_rdm_aabb), std::make_optional(two_rdm_aaaa)));
 
   EXPECT_TRUE(wf_with_rdm.has_two_rdm_spin_dependent());
 
-  auto [aabb, aaaa, bbbb] = wf_with_rdm.get_active_two_rdm_spin_dependent();
+  auto [aaaa, aabb, bbbb] = wf_with_rdm.get_active_two_rdm_spin_dependent();
 
   // aabb and aaaa should match input, bbbb should equal aaaa for restricted
   EXPECT_EQ(std::get<Eigen::VectorXd>(aabb), two_rdm_aabb);
@@ -483,12 +483,12 @@ TEST_F(WavefunctionRDMTest, TwoRDMConversions) {
   auto wf_r_dependent = Wavefunction(std::make_unique<CasWavefunctionContainer>(
       coeffs, dets_r, testing::create_test_orbitals(3, norbs, true),
       std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-      std::make_optional(two_rdm_aabb), std::make_optional(two_rdm_aaaa),
+      std::make_optional(two_rdm_aaaa), std::make_optional(two_rdm_aabb),
       std::nullopt));
   auto wf_u_dependent = Wavefunction(std::make_unique<CasWavefunctionContainer>(
       coeffs, dets_u, testing::create_test_orbitals(3, norbs, true),
       std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-      std::make_optional(two_rdm_aabb), std::make_optional(two_rdm_aaaa),
+      std::make_optional(two_rdm_aaaa), std::make_optional(two_rdm_aabb),
       std::make_optional(two_rdm_bbbb)));
 
   EXPECT_TRUE(wf_r_dependent.has_two_rdm_spin_traced());
@@ -558,13 +558,13 @@ TEST_F(WavefunctionRDMTest, OrbitalEntropies) {
   auto wf_r_full = Wavefunction(std::make_unique<CasWavefunctionContainer>(
       coeffs, dets, base_orbitals, std::nullopt, std::make_optional(one_rdm_aa),
       std::make_optional(one_rdm_aa), std::nullopt,
-      std::make_optional(two_rdm_aabb), std::make_optional(two_rdm_aaaa),
+      std::make_optional(two_rdm_aaaa), std::make_optional(two_rdm_aabb),
       std::make_optional(two_rdm_aaaa)));
 
   auto wf_u_full = Wavefunction(std::make_unique<CasWavefunctionContainer>(
       coeffs, dets, base_orbitals, std::nullopt, std::make_optional(one_rdm_aa),
       std::make_optional(one_rdm_bb), std::nullopt,
-      std::make_optional(two_rdm_aabb), std::make_optional(two_rdm_aaaa),
+      std::make_optional(two_rdm_aaaa), std::make_optional(two_rdm_aabb),
       std::make_optional(two_rdm_bbbb)));
 
   // Get the entropies
@@ -787,7 +787,7 @@ TEST_F(WavefunctionRealRDMsTest, N2_Singlet) {
   auto rdm1 = wavefunction->get_active_one_rdm_spin_traced();
   auto [aa, bb] = wavefunction->get_active_one_rdm_spin_dependent();
   auto rdm2 = wavefunction->get_active_two_rdm_spin_traced();
-  auto [aabb, aaaa, bbbb] = wavefunction->get_active_two_rdm_spin_dependent();
+  auto [aaaa, aabb, bbbb] = wavefunction->get_active_two_rdm_spin_dependent();
 
   // transpose aabb to get bbaa
   auto bbaa = transpose_two_rdm_indices(std::get<Eigen::VectorXd>(aabb), norb,
@@ -975,9 +975,9 @@ TEST_F(WavefunctionRDMTest, ActiveTwoRdmSbtComplexVariant) {
           ContainerTypes::MatrixVariant{one_bb_c}),
       std::nullopt,
       std::optional<ContainerTypes::VectorVariant>(
-          ContainerTypes::VectorVariant{two_aabb_c}),
-      std::optional<ContainerTypes::VectorVariant>(
           ContainerTypes::VectorVariant{two_aaaa_c}),
+      std::optional<ContainerTypes::VectorVariant>(
+          ContainerTypes::VectorVariant{two_aabb_c}),
       std::optional<ContainerTypes::VectorVariant>(
           ContainerTypes::VectorVariant{two_bbbb_c})));
 

--- a/cpp/tests/test_wfn_cas.cpp
+++ b/cpp/tests/test_wfn_cas.cpp
@@ -545,7 +545,7 @@ TEST_F(CasWavefunctionTest, JsonSerializationRDMs) {
 
   CasWavefunctionContainer original(coeffs, dets, orbitals, std::nullopt,
                                     one_rdm_aa, one_rdm_aa, std::nullopt,
-                                    two_rdm_aabb, two_rdm_aaaa, two_rdm_aaaa);
+                                    two_rdm_aaaa, two_rdm_aabb, two_rdm_aaaa);
 
   // Serialize to JSON
   nlohmann::json j = original.to_json();
@@ -574,9 +574,9 @@ TEST_F(CasWavefunctionTest, JsonSerializationRDMs) {
                   .isApprox(std::get<Eigen::MatrixXd>(rest_one_aa),
                             testing::wf_tolerance));
 
-  auto [orig_two_aabb, orig_two_aaaa, orig_two_bbbb] =
+  auto [orig_two_aaaa, orig_two_aabb, orig_two_bbbb] =
       original.get_active_two_rdm_spin_dependent();
-  auto [rest_two_aabb, rest_two_aaaa, rest_two_bbbb] =
+  auto [rest_two_aaaa, rest_two_aabb, rest_two_bbbb] =
       restored->get_active_two_rdm_spin_dependent();
 
   EXPECT_TRUE(std::get<Eigen::VectorXd>(orig_two_aabb)
@@ -680,9 +680,9 @@ TEST_F(CasWavefunctionTest, JsonSerializationRDMsOpenShell) {
   EXPECT_TRUE(
       restored_one_rdm_r.isApprox(original_one_rdm_r, testing::rdm_tolerance));
 
-  auto [restored_aabb_rdm, restored_aaaa_rdm, restored_bbbb_rdm] =
+  auto [restored_aaaa_rdm, restored_aabb_rdm, restored_bbbb_rdm] =
       restored->get_active_two_rdm_spin_dependent();
-  auto [original_aabb_rdm, original_aaaa_rdm, original_bbbb_rdm] =
+  auto [original_aaaa_rdm, original_aabb_rdm, original_bbbb_rdm] =
       original.get_active_two_rdm_spin_dependent();
 
   // extract data from variants
@@ -794,9 +794,9 @@ TEST_F(CasWavefunctionTest, Hdf5SerializationRDMs) {
     EXPECT_TRUE(restored_one_rdm_r.isApprox(original_one_rdm_r,
                                             testing::rdm_tolerance));
 
-    auto [restored_aabb_rdm, restored_aaaa_rdm, restored_bbbb_rdm] =
+    auto [restored_aaaa_rdm, restored_aabb_rdm, restored_bbbb_rdm] =
         restored->get_active_two_rdm_spin_dependent();
-    auto [original_aabb_rdm, original_aaaa_rdm, original_bbbb_rdm] =
+    auto [original_aaaa_rdm, original_aabb_rdm, original_bbbb_rdm] =
         original.get_active_two_rdm_spin_dependent();
     // extract data from variants
     const auto& restored_aabb_rdm_r =
@@ -927,9 +927,9 @@ TEST_F(CasWavefunctionTest, Hdf5SerializationRDMsOpenShell) {
     EXPECT_TRUE(restored_one_rdm_r.isApprox(original_one_rdm_r,
                                             testing::rdm_tolerance));
 
-    auto [restored_aabb_rdm, restored_aaaa_rdm, restored_bbbb_rdm] =
+    auto [restored_aaaa_rdm, restored_aabb_rdm, restored_bbbb_rdm] =
         restored->get_active_two_rdm_spin_dependent();
-    auto [original_aabb_rdm, original_aaaa_rdm, original_bbbb_rdm] =
+    auto [original_aaaa_rdm, original_aabb_rdm, original_bbbb_rdm] =
         original.get_active_two_rdm_spin_dependent();
 
     // extract data from variants

--- a/cpp/tests/test_wfn_sci.cpp
+++ b/cpp/tests/test_wfn_sci.cpp
@@ -530,9 +530,9 @@ TEST_F(SciWavefunctionTest, Hdf5SerializationRDMs) {
     EXPECT_TRUE(restored_one_rdm_r.isApprox(original_one_rdm_r,
                                             testing::rdm_tolerance));
 
-    auto [restored_aabb_rdm, restored_aaaa_rdm, restored_bbbb_rdm] =
+    auto [restored_aaaa_rdm, restored_aabb_rdm, restored_bbbb_rdm] =
         restored->get_active_two_rdm_spin_dependent();
-    auto [original_aabb_rdm, original_aaaa_rdm, original_bbbb_rdm] =
+    auto [original_aaaa_rdm, original_aabb_rdm, original_bbbb_rdm] =
         original.get_active_two_rdm_spin_dependent();
     // extract data from variants
     const auto& restored_aabb_rdm_r =
@@ -598,7 +598,7 @@ TEST_F(SciWavefunctionTest, JsonSerializationRDMs) {
 
   SciWavefunctionContainer original(coeffs, dets, orbitals, std::nullopt,
                                     one_rdm_aa, one_rdm_aa, std::nullopt,
-                                    two_rdm_aabb, two_rdm_aaaa, two_rdm_aaaa);
+                                    two_rdm_aaaa, two_rdm_aabb, two_rdm_aaaa);
 
   // Serialize to JSON
   nlohmann::json j = original.to_json();
@@ -627,9 +627,9 @@ TEST_F(SciWavefunctionTest, JsonSerializationRDMs) {
                   .isApprox(std::get<Eigen::MatrixXd>(rest_one_aa),
                             testing::wf_tolerance));
 
-  auto [orig_two_aabb, orig_two_aaaa, orig_two_bbbb] =
+  auto [orig_two_aaaa, orig_two_aabb, orig_two_bbbb] =
       original.get_active_two_rdm_spin_dependent();
-  auto [rest_two_aabb, rest_two_aaaa, rest_two_bbbb] =
+  auto [rest_two_aaaa, rest_two_aabb, rest_two_bbbb] =
       restored->get_active_two_rdm_spin_dependent();
 
   EXPECT_TRUE(std::get<Eigen::VectorXd>(orig_two_aabb)
@@ -737,9 +737,9 @@ TEST_F(SciWavefunctionTest, JsonSerializationRDMsOpenShell) {
   EXPECT_TRUE(
       restored_one_rdm_r.isApprox(original_one_rdm_r, testing::rdm_tolerance));
 
-  auto [restored_aabb_rdm, restored_aaaa_rdm, restored_bbbb_rdm] =
+  auto [restored_aaaa_rdm, restored_aabb_rdm, restored_bbbb_rdm] =
       restored->get_active_two_rdm_spin_dependent();
-  auto [original_aabb_rdm, original_aaaa_rdm, original_bbbb_rdm] =
+  auto [original_aaaa_rdm, original_aabb_rdm, original_bbbb_rdm] =
       original.get_active_two_rdm_spin_dependent();
 
   // extract data from variants
@@ -875,9 +875,9 @@ TEST_F(SciWavefunctionTest, Hdf5SerializationRDMsOpenShell) {
     EXPECT_TRUE(restored_one_rdm_r.isApprox(original_one_rdm_r,
                                             testing::rdm_tolerance));
 
-    auto [restored_aabb_rdm, restored_aaaa_rdm, restored_bbbb_rdm] =
+    auto [restored_aaaa_rdm, restored_aabb_rdm, restored_bbbb_rdm] =
         restored->get_active_two_rdm_spin_dependent();
-    auto [original_aabb_rdm, original_aaaa_rdm, original_bbbb_rdm] =
+    auto [original_aaaa_rdm, original_aabb_rdm, original_bbbb_rdm] =
         original.get_active_two_rdm_spin_dependent();
 
     // extract data from variants

--- a/cpp/tests/test_wfn_sd.cpp
+++ b/cpp/tests/test_wfn_sd.cpp
@@ -338,7 +338,7 @@ TEST_F(SlaterdeterminantTest, ClosedShellReducedDensityMatrices) {
   auto one_rdm = std::get<Eigen::MatrixXd>(sd.get_active_one_rdm_spin_traced());
   auto two_rdm = std::get<Eigen::VectorXd>(sd.get_active_two_rdm_spin_traced());
   auto [one_rdm_aa, one_rdm_bb] = sd.get_active_one_rdm_spin_dependent();
-  auto [two_rdm_aabb, two_rdm_aaaa, two_rdm_bbbb] =
+  auto [two_rdm_aaaa, two_rdm_aabb, two_rdm_bbbb] =
       sd.get_active_two_rdm_spin_dependent();
 
   // get bbaa from transposed aabb
@@ -381,7 +381,7 @@ TEST_F(SlaterdeterminantTest, OpenShellReducedDensityMatrices) {
   auto one_rdm = std::get<Eigen::MatrixXd>(sd.get_active_one_rdm_spin_traced());
   auto two_rdm = std::get<Eigen::VectorXd>(sd.get_active_two_rdm_spin_traced());
   auto [one_rdm_aa, one_rdm_bb] = sd.get_active_one_rdm_spin_dependent();
-  auto [two_rdm_aabb, two_rdm_aaaa, two_rdm_bbbb] =
+  auto [two_rdm_aaaa, two_rdm_aabb, two_rdm_bbbb] =
       sd.get_active_two_rdm_spin_dependent();
 
   // get bbaa from transposed aabb
@@ -425,7 +425,7 @@ TEST_F(SlaterdeterminantTest, NonContinuousDeterminantReducedDensityMatrices) {
   auto one_rdm = std::get<Eigen::MatrixXd>(sd.get_active_one_rdm_spin_traced());
   auto two_rdm = std::get<Eigen::VectorXd>(sd.get_active_two_rdm_spin_traced());
   auto [one_rdm_aa, one_rdm_bb] = sd.get_active_one_rdm_spin_dependent();
-  auto [two_rdm_aabb, two_rdm_aaaa, two_rdm_bbbb] =
+  auto [two_rdm_aaaa, two_rdm_aabb, two_rdm_bbbb] =
       sd.get_active_two_rdm_spin_dependent();
 
   // get bbaa from transposed aabb
@@ -477,7 +477,7 @@ TEST_F(SlaterdeterminantTest, EntropiesTest) {
   Configuration det("2ud0200u0u2d");
   SlaterDeterminantContainer sd(det, orbitals);
   sd.get_active_one_rdm_spin_dependent();
-  auto [aabb, aaaa, bbbb] = sd.get_active_two_rdm_spin_dependent();
+  auto [aaaa, aabb, bbbb] = sd.get_active_two_rdm_spin_dependent();
 
   // get entropies
   auto s1 = sd.get_single_orbital_entropies();

--- a/docs/source/_static/examples/cpp/wavefunction_container.cpp
+++ b/docs/source/_static/examples/cpp/wavefunction_container.cpp
@@ -211,7 +211,7 @@ int main() {
   // Get RDMs
   auto [rdm1_aa, rdm1_bb] = sd_wavefunction.get_active_one_rdm_spin_dependent();
   auto rdm1_total = sd_wavefunction.get_active_one_rdm_spin_traced();
-  auto [rdm2_aa, rdm2_aabb, rdm2_bbbb] =
+  auto [rdm2_aabb, rdm2_aaaa, rdm2_bbbb] =
       sd_wavefunction.get_active_two_rdm_spin_dependent();
   auto rdm2_total = sd_wavefunction.get_active_two_rdm_spin_traced();
 

--- a/docs/source/_static/examples/cpp/wavefunction_container.cpp
+++ b/docs/source/_static/examples/cpp/wavefunction_container.cpp
@@ -211,7 +211,7 @@ int main() {
   // Get RDMs
   auto [rdm1_aa, rdm1_bb] = sd_wavefunction.get_active_one_rdm_spin_dependent();
   auto rdm1_total = sd_wavefunction.get_active_one_rdm_spin_traced();
-  auto [rdm2_aabb, rdm2_aaaa, rdm2_bbbb] =
+  auto [rdm2_aaaa, rdm2_aabb, rdm2_bbbb] =
       sd_wavefunction.get_active_two_rdm_spin_dependent();
   auto rdm2_total = sd_wavefunction.get_active_two_rdm_spin_traced();
 

--- a/docs/source/_static/examples/python/wavefunction_container.py
+++ b/docs/source/_static/examples/python/wavefunction_container.py
@@ -203,7 +203,7 @@ n_alpha, n_beta = sd_wavefunction.get_total_num_electrons()
 # Get RDMs
 rdm1_aa, rdm1_bb = sd_wavefunction.get_active_one_rdm_spin_dependent()
 rdm1_total = sd_wavefunction.get_active_one_rdm_spin_traced()
-rdm2_aaaa, rdm2_aabb, rdm2_bbbb = sd_wavefunction.get_active_two_rdm_spin_dependent()
+rdm2_aabb, rdm2_aaaa, rdm2_bbbb = sd_wavefunction.get_active_two_rdm_spin_dependent()
 rdm2_total = sd_wavefunction.get_active_two_rdm_spin_traced()
 
 # Get single orbital entropies

--- a/docs/source/_static/examples/python/wavefunction_container.py
+++ b/docs/source/_static/examples/python/wavefunction_container.py
@@ -7,19 +7,19 @@
 
 import numpy as np
 from qdk_chemistry.data import (
-    Orbitals,
-    SlaterDeterminantContainer,
-    CasWavefunctionContainer,
-    SciWavefunctionContainer,
-    CoupledClusterContainer,
-    MP2Container,
-    Configuration,
-    Wavefunction,
-    Hamiltonian,
-    CanonicalFourCenterHamiltonianContainer,
     BasisSet,
-    Shell,
+    CanonicalFourCenterHamiltonianContainer,
+    CasWavefunctionContainer,
+    Configuration,
+    CoupledClusterContainer,
+    Hamiltonian,
+    MP2Container,
+    Orbitals,
     OrbitalType,
+    SciWavefunctionContainer,
+    Shell,
+    SlaterDeterminantContainer,
+    Wavefunction,
 )
 
 
@@ -203,7 +203,7 @@ n_alpha, n_beta = sd_wavefunction.get_total_num_electrons()
 # Get RDMs
 rdm1_aa, rdm1_bb = sd_wavefunction.get_active_one_rdm_spin_dependent()
 rdm1_total = sd_wavefunction.get_active_one_rdm_spin_traced()
-rdm2_aabb, rdm2_aaaa, rdm2_bbbb = sd_wavefunction.get_active_two_rdm_spin_dependent()
+rdm2_aaaa, rdm2_aabb, rdm2_bbbb = sd_wavefunction.get_active_two_rdm_spin_dependent()
 rdm2_total = sd_wavefunction.get_active_two_rdm_spin_traced()
 
 # Get single orbital entropies

--- a/python/src/pybind11/data/wavefunction.cpp
+++ b/python/src/pybind11/data/wavefunction.cpp
@@ -638,21 +638,21 @@ Examples:
   wavefunction.def(
       "get_active_two_rdm_spin_dependent",
       [](const Wavefunction& self) {
-        auto [aaaa, aabb, bbbb] = self.get_active_two_rdm_spin_dependent();
-        return py::make_tuple(variant_to_python(aaaa), variant_to_python(aabb),
+        auto [aabb, aaaa, bbbb] = self.get_active_two_rdm_spin_dependent();
+        return py::make_tuple(variant_to_python(aabb), variant_to_python(aaaa),
                               variant_to_python(bbbb));
       },
       R"(
 Get spin-dependent two-particle reduced density matrices (RDMs) for active orbitals only.
 
 Returns:
-    tuple: Tuple of (aaaa, aabb, bbbb) two-particle RDMs for active orbitals
+    tuple: Tuple of (aabb, aaaa, bbbb) two-particle RDMs for active orbitals
 
 Raises:
     RuntimeError: If the spin-dependent 2-RDM is not available
 
 Examples:
-    >>> aaaa, aabb, bbbb = wf.get_active_two_rdm_spin_dependent()
+    >>> aabb, aaaa, bbbb = wf.get_active_two_rdm_spin_dependent()
 )");
 
   wavefunction.def(
@@ -818,7 +818,7 @@ Returns:
 
 Examples:
     >>> if wf.has_two_rdm_spin_dependent():
-    ...     aaaa, aabb, bbbb = wf.get_active_two_rdm_spin_dependent()
+    ...     aabb, aaaa, bbbb = wf.get_active_two_rdm_spin_dependent()
 )");
 
   wavefunction.def("has_two_rdm_spin_traced",

--- a/python/src/pybind11/data/wavefunction.cpp
+++ b/python/src/pybind11/data/wavefunction.cpp
@@ -638,21 +638,21 @@ Examples:
   wavefunction.def(
       "get_active_two_rdm_spin_dependent",
       [](const Wavefunction& self) {
-        auto [aabb, aaaa, bbbb] = self.get_active_two_rdm_spin_dependent();
-        return py::make_tuple(variant_to_python(aabb), variant_to_python(aaaa),
+        auto [aaaa, aabb, bbbb] = self.get_active_two_rdm_spin_dependent();
+        return py::make_tuple(variant_to_python(aaaa), variant_to_python(aabb),
                               variant_to_python(bbbb));
       },
       R"(
 Get spin-dependent two-particle reduced density matrices (RDMs) for active orbitals only.
 
 Returns:
-    tuple: Tuple of (aabb, aaaa, bbbb) two-particle RDMs for active orbitals
+    tuple: Tuple of (aaaa, aabb, bbbb) two-particle RDMs for active orbitals
 
 Raises:
     RuntimeError: If the spin-dependent 2-RDM is not available
 
 Examples:
-    >>> aabb, aaaa, bbbb = wf.get_active_two_rdm_spin_dependent()
+    >>> aaaa, aabb, bbbb = wf.get_active_two_rdm_spin_dependent()
 )");
 
   wavefunction.def(
@@ -818,7 +818,7 @@ Returns:
 
 Examples:
     >>> if wf.has_two_rdm_spin_dependent():
-    ...     aabb, aaaa, bbbb = wf.get_active_two_rdm_spin_dependent()
+    ...     aaaa, aabb, bbbb = wf.get_active_two_rdm_spin_dependent()
 )");
 
   wavefunction.def("has_two_rdm_spin_traced",
@@ -1114,14 +1114,14 @@ Examples:
                       std::optional<ContainerTypes::MatrixVariant> one_rdm_bb,
                       std::optional<ContainerTypes::VectorVariant>
                           two_rdm_spin_traced,
-                      std::optional<ContainerTypes::VectorVariant> two_rdm_aabb,
                       std::optional<ContainerTypes::VectorVariant> two_rdm_aaaa,
+                      std::optional<ContainerTypes::VectorVariant> two_rdm_aabb,
                       std::optional<ContainerTypes::VectorVariant> two_rdm_bbbb,
                       py::object entropies, WavefunctionType type) {
             return SciWavefunctionContainer(
                 coeffs, dets, std::move(orbitals), one_rdm_spin_traced,
-                one_rdm_aa, one_rdm_bb, two_rdm_spin_traced, two_rdm_aabb,
-                two_rdm_aaaa, two_rdm_bbbb, parse_entropies(entropies), type);
+                one_rdm_aa, one_rdm_bb, two_rdm_spin_traced, two_rdm_aaaa,
+                two_rdm_aabb, two_rdm_bbbb, parse_entropies(entropies), type);
           }),
           R"(
 Constructs a SCI wavefunction container with full RDM data.
@@ -1134,8 +1134,8 @@ Args:
     one_rdm_aa (numpy.ndarray | None): Alpha-alpha block of one-particle RDM
     one_rdm_bb (numpy.ndarray | None): Beta-beta block of one-particle RDM
     two_rdm_spin_traced (numpy.ndarray | None): Spin-traced two-particle reduced density matrix
-    two_rdm_aabb (numpy.ndarray | None): Alpha-beta-beta-alpha block of two-particle RDM
     two_rdm_aaaa (numpy.ndarray | None): Alpha-alpha-alpha-alpha block of two-particle RDM
+    two_rdm_aabb (numpy.ndarray | None): Alpha-alpha-beta-beta block of two-particle RDM
     two_rdm_bbbb (numpy.ndarray | None): Beta-beta-beta-beta block of two-particle RDM
     entropies (dict | None): Orbital entropies, with optional keys
         ``"single_orbital"`` (1-D), ``"two_orbital"`` (2-D),
@@ -1148,15 +1148,15 @@ Examples:
     >>> dets = [qdk_chemistry.Configuration("33221100"), qdk_chemistry.Configuration("33221001")]
     >>> container = qdk_chemistry.SciWavefunctionContainer(coeffs, dets, orbitals,
     ...     one_rdm, one_rdm_aa, one_rdm_bb,
-    ...     two_rdm, two_rdm_aabb, two_rdm_aaaa, two_rdm_bbbb)
+    ...     two_rdm, two_rdm_aaaa, two_rdm_aabb, two_rdm_bbbb)
 )",
           py::arg("coeffs"), py::arg("dets"), py::arg("orbitals"),
           py::arg("one_rdm_spin_traced") = std::nullopt,
           py::arg("one_rdm_aa") = std::nullopt,
           py::arg("one_rdm_bb") = std::nullopt,
           py::arg("two_rdm_spin_traced") = std::nullopt,
-          py::arg("two_rdm_aabb") = std::nullopt,
           py::arg("two_rdm_aaaa") = std::nullopt,
+          py::arg("two_rdm_aabb") = std::nullopt,
           py::arg("two_rdm_bbbb") = std::nullopt,
           py::arg("entropies") = py::none(),
           py::arg("type") = WavefunctionType::SelfDual)
@@ -1246,14 +1246,14 @@ Examples:
                       std::optional<ContainerTypes::MatrixVariant> one_rdm_bb,
                       std::optional<ContainerTypes::VectorVariant>
                           two_rdm_spin_traced,
-                      std::optional<ContainerTypes::VectorVariant> two_rdm_aabb,
                       std::optional<ContainerTypes::VectorVariant> two_rdm_aaaa,
+                      std::optional<ContainerTypes::VectorVariant> two_rdm_aabb,
                       std::optional<ContainerTypes::VectorVariant> two_rdm_bbbb,
                       py::object entropies, WavefunctionType type) {
             return CasWavefunctionContainer(
                 coeffs, dets, std::move(orbitals), one_rdm_spin_traced,
-                one_rdm_aa, one_rdm_bb, two_rdm_spin_traced, two_rdm_aabb,
-                two_rdm_aaaa, two_rdm_bbbb, parse_entropies(entropies), type);
+                one_rdm_aa, one_rdm_bb, two_rdm_spin_traced, two_rdm_aaaa,
+                two_rdm_aabb, two_rdm_bbbb, parse_entropies(entropies), type);
           }),
           R"(
 Constructs a CAS wavefunction container with full RDM data.
@@ -1266,8 +1266,8 @@ Args:
     one_rdm_aa (numpy.ndarray | None): Alpha-alpha block of one-particle RDM
     one_rdm_bb (numpy.ndarray | None): Beta-beta block of one-particle RDM
     two_rdm_spin_traced (numpy.ndarray | None): Spin-traced two-particle reduced density matrix
-    two_rdm_aabb (numpy.ndarray | None): Alpha-beta-beta-alpha block of two-particle RDM
     two_rdm_aaaa (numpy.ndarray | None): Alpha-alpha-alpha-alpha block of two-particle RDM
+    two_rdm_aabb (numpy.ndarray | None): Alpha-alpha-beta-beta block of two-particle RDM
     two_rdm_bbbb (numpy.ndarray | None): Beta-beta-beta-beta block of two-particle RDM
     entropies (dict | None): Orbital entropies, with optional keys
         ``"single_orbital"`` (1-D), ``"two_orbital"`` (2-D),
@@ -1280,15 +1280,15 @@ Examples:
     >>> dets = [qdk_chemistry.Configuration("33221100"), qdk_chemistry.Configuration("33221001")]
     >>> container = qdk_chemistry.CasWavefunctionContainer(coeffs, dets, orbitals,
     ...     one_rdm, one_rdm_aa, one_rdm_bb,
-    ...     two_rdm, two_rdm_aabb, two_rdm_aaaa, two_rdm_bbbb)
+    ...     two_rdm, two_rdm_aaaa, two_rdm_aabb, two_rdm_bbbb)
 )",
           py::arg("coeffs"), py::arg("dets"), py::arg("orbitals"),
           py::arg("one_rdm_spin_traced") = std::nullopt,
           py::arg("one_rdm_aa") = std::nullopt,
           py::arg("one_rdm_bb") = std::nullopt,
           py::arg("two_rdm_spin_traced") = std::nullopt,
-          py::arg("two_rdm_aabb") = std::nullopt,
           py::arg("two_rdm_aaaa") = std::nullopt,
+          py::arg("two_rdm_aabb") = std::nullopt,
           py::arg("two_rdm_bbbb") = std::nullopt,
           py::arg("entropies") = py::none(),
           py::arg("type") = WavefunctionType::SelfDual)

--- a/python/src/qdk_chemistry/plugins/pyscf/mcscf.py
+++ b/python/src/qdk_chemistry/plugins/pyscf/mcscf.py
@@ -431,7 +431,7 @@ class PyscfMcscfCalculator(MultiConfigurationScf):
         except RuntimeError:
             use_spin_traced = True
         try:
-            two_rdm_aabb, two_rdm_aaaa, two_rdm_bbbb = wfn.get_active_two_rdm_spin_dependent()
+            two_rdm_aaaa, two_rdm_aabb, two_rdm_bbbb = wfn.get_active_two_rdm_spin_dependent()
         except RuntimeError:
             use_spin_traced = True
 

--- a/python/tests/test_wavefunction.py
+++ b/python/tests/test_wavefunction.py
@@ -983,7 +983,7 @@ class TestWavefunctionRdmIntegraion:
         one_rdm = wfn.get_active_one_rdm_spin_traced()
         two_rdm = wfn.get_active_two_rdm_spin_traced()
         one_rdm_aa, one_rdm_bb = wfn.get_active_one_rdm_spin_dependent()
-        two_rdm_ab, two_rdm_aa, two_rdm_bb = wfn.get_active_two_rdm_spin_dependent()
+        two_rdm_aa, two_rdm_ab, two_rdm_bb = wfn.get_active_two_rdm_spin_dependent()
 
         two_rdm = np.reshape(two_rdm, (norb, norb, norb, norb))
         two_rdm_aa = np.reshape(two_rdm_aa, (norb, norb, norb, norb))
@@ -1063,7 +1063,7 @@ class TestWavefunctionRdmIntegraion:
         one_rdm = wfn.get_active_one_rdm_spin_traced()
         two_rdm = wfn.get_active_two_rdm_spin_traced()
         one_rdm_aa, one_rdm_bb = wfn.get_active_one_rdm_spin_dependent()
-        two_rdm_ab, two_rdm_aa, two_rdm_bb = wfn.get_active_two_rdm_spin_dependent()
+        two_rdm_aa, two_rdm_ab, two_rdm_bb = wfn.get_active_two_rdm_spin_dependent()
 
         two_rdm = np.reshape(two_rdm, (norb, norb, norb, norb))
         two_rdm_aa = np.reshape(two_rdm_aa, (norb, norb, norb, norb))
@@ -1149,7 +1149,7 @@ class TestWavefunctionRdmIntegraion:
 
         # Verify RDMs exist before save
         original_1rdm_aa, _ = wfn_sci.get_active_one_rdm_spin_dependent()
-        original_2rdm_aabb, original_2rdm_aaaa, _ = wfn_sci.get_active_two_rdm_spin_dependent()
+        original_2rdm_aaaa, original_2rdm_aabb, _ = wfn_sci.get_active_two_rdm_spin_dependent()
 
         # Save and reload using tmp_path
         h5_file = tmp_path / "test_wavefunction.wavefunction.h5"
@@ -1161,7 +1161,7 @@ class TestWavefunctionRdmIntegraion:
         after_1rdm_aa, _ = wfn_loaded.get_active_one_rdm_spin_dependent()
 
         assert wfn_loaded.has_two_rdm_spin_dependent(), "two rdm is not available"
-        after_2rdm_aabb, after_2rdm_aaaa, _ = wfn_loaded.get_active_two_rdm_spin_dependent()
+        after_2rdm_aaaa, after_2rdm_aabb, _ = wfn_loaded.get_active_two_rdm_spin_dependent()
 
         assert np.allclose(original_1rdm_aa, after_1rdm_aa, atol=rdm_tolerance)
         assert np.allclose(original_2rdm_aaaa, after_2rdm_aaaa, atol=rdm_tolerance)
@@ -1196,7 +1196,7 @@ class TestWavefunctionRdmIntegraion:
 
         # Verify RDMs exist before save
         original_1rdm_aa, _ = wfn_cas.get_active_one_rdm_spin_dependent()
-        original_2rdm_aabb, original_2rdm_aaaa, _ = wfn_cas.get_active_two_rdm_spin_dependent()
+        original_2rdm_aaaa, original_2rdm_aabb, _ = wfn_cas.get_active_two_rdm_spin_dependent()
 
         # Save and reload using tmp_path
         h5_file = tmp_path / "test_wavefunction.wavefunction.h5"
@@ -1208,7 +1208,7 @@ class TestWavefunctionRdmIntegraion:
         after_1rdm_aa, _ = wfn_loaded.get_active_one_rdm_spin_dependent()
 
         assert wfn_loaded.has_two_rdm_spin_dependent(), "two rdm is not available"
-        after_2rdm_aabb, after_2rdm_aaaa, _ = wfn_loaded.get_active_two_rdm_spin_dependent()
+        after_2rdm_aaaa, after_2rdm_aabb, _ = wfn_loaded.get_active_two_rdm_spin_dependent()
 
         assert np.allclose(original_1rdm_aa, after_1rdm_aa, atol=rdm_tolerance)
         assert np.allclose(original_2rdm_aaaa, after_2rdm_aaaa, atol=rdm_tolerance)


### PR DESCRIPTION
The function `get_active_two_rdm_spin_dependent()` currently returns spin components in order: `(aabb, aaaa, bbbb)`.

This PR will fix the order to `(aaaa, aabb, bbbb)`

----
**Original text before discussion:** 

The correct spin components order for the `get_active_two_rdm_spin_dependent()` is `(aabb, aaaa, bbbb)`.

Most places were correct, but a few cases in docs reported  `(aaaa, aabb, bbbb)`.

(Note, the two body integrals are given in order `(aaaa, aabb, bbbb)`, though. Is there a reason why this uses a different order?)
