### PR TITLE
Verstraete-Cirac mapping

### DIFF
--- a/cpp/include/qdk/chemistry/data/lattice_graph.hpp
+++ b/cpp/include/qdk/chemistry/data/lattice_graph.hpp
@@ -232,7 +232,7 @@ class LatticeGraph : public DataClass {
    * @throws std::invalid_argument If n == 0.
    */
   static LatticeGraph chain(std::uint64_t n, bool periodic = false,
-                            double t = 1.0);
+                            double t = 1.0, bool optimal_ordering = false);
 
   /**
    * @brief Create a two-dimensional square lattice.
@@ -266,7 +266,7 @@ class LatticeGraph : public DataClass {
    */
   static LatticeGraph square(std::uint64_t nx, std::uint64_t ny,
                              bool periodic_x = false, bool periodic_y = false,
-                             double t = 1.0);
+                             double t = 1.0, bool optimal_ordering = false);
 
   /**
    * @brief Create a two-dimensional triangular lattice.
@@ -305,7 +305,8 @@ class LatticeGraph : public DataClass {
   static LatticeGraph triangular(std::uint64_t nx, std::uint64_t ny,
                                  bool periodic_x = false,
                                  bool periodic_y = false, double t = 1.0,
-                                 int coloring_seed = 0);
+                                 int coloring_seed = 0,
+                                 bool optimal_ordering = false);
 
   /**
    * @brief Create a two-dimensional honeycomb lattice.
@@ -344,7 +345,8 @@ class LatticeGraph : public DataClass {
    */
   static LatticeGraph honeycomb(std::uint64_t nx, std::uint64_t ny,
                                 bool periodic_x = false,
-                                bool periodic_y = false, double t = 1.0);
+                                bool periodic_y = false, double t = 1.0,
+                                bool optimal_ordering = false);
 
   /**
    * @brief Create a two-dimensional kagome lattice.
@@ -394,7 +396,8 @@ class LatticeGraph : public DataClass {
    */
   static LatticeGraph kagome(std::uint64_t nx, std::uint64_t ny,
                              bool periodic_x = false, bool periodic_y = false,
-                             double t = 1.0, int coloring_seed = 0);
+                             double t = 1.0, int coloring_seed = 0,
+                             bool optimal_ordering = false);
 
   /**
    * @brief Edge coloring stored at construction time, if any.
@@ -494,6 +497,22 @@ class LatticeGraph : public DataClass {
   /** @brief Check if a sparse matrix is symmetric within a numerical tolerance.
    */
   static bool _check_symmetry(const Eigen::SparseMatrix<double>& mat);
+
+  /**
+   * @brief Permutes the vertices of the lattice graph according to the given
+   * path.
+   *
+   * Reorders the sparse adjacency matrix using Eigen's permutation operations
+   * and updates the edge coloring to align with the new vertex indexing.
+   *
+   * @param graph The source lattice graph to permute.
+   * @param path The sequence of original vertex indices representing the target
+   * permutation.
+   * @return A new LatticeGraph with the permuted adjacency matrix and edge
+   * coloring.
+   */
+  static LatticeGraph permute(const LatticeGraph& graph,
+                              const std::vector<std::uint64_t>& path);
 
   /// Number of sites (vertices) in the lattice
   std::uint64_t _num_sites;

--- a/cpp/include/qdk/chemistry/data/lattice_graph.hpp
+++ b/cpp/include/qdk/chemistry/data/lattice_graph.hpp
@@ -232,7 +232,7 @@ class LatticeGraph : public DataClass {
    * @throws std::invalid_argument If n == 0.
    */
   static LatticeGraph chain(std::uint64_t n, bool periodic = false,
-                            double t = 1.0, bool optimal_ordering = false);
+                            double t = 1.0, bool dfs_ordering = false);
 
   /**
    * @brief Create a two-dimensional square lattice.
@@ -266,7 +266,7 @@ class LatticeGraph : public DataClass {
    */
   static LatticeGraph square(std::uint64_t nx, std::uint64_t ny,
                              bool periodic_x = false, bool periodic_y = false,
-                             double t = 1.0, bool optimal_ordering = false);
+                             double t = 1.0, bool dfs_ordering = false);
 
   /**
    * @brief Create a two-dimensional triangular lattice.
@@ -306,7 +306,7 @@ class LatticeGraph : public DataClass {
                                  bool periodic_x = false,
                                  bool periodic_y = false, double t = 1.0,
                                  int coloring_seed = 0,
-                                 bool optimal_ordering = false);
+                                 bool dfs_ordering = false);
 
   /**
    * @brief Create a two-dimensional honeycomb lattice.
@@ -346,7 +346,7 @@ class LatticeGraph : public DataClass {
   static LatticeGraph honeycomb(std::uint64_t nx, std::uint64_t ny,
                                 bool periodic_x = false,
                                 bool periodic_y = false, double t = 1.0,
-                                bool optimal_ordering = false);
+                                bool dfs_ordering = false);
 
   /**
    * @brief Create a two-dimensional kagome lattice.
@@ -397,7 +397,7 @@ class LatticeGraph : public DataClass {
   static LatticeGraph kagome(std::uint64_t nx, std::uint64_t ny,
                              bool periodic_x = false, bool periodic_y = false,
                              double t = 1.0, int coloring_seed = 0,
-                             bool optimal_ordering = false);
+                             bool dfs_ordering = false);
 
   /**
    * @brief Edge coloring stored at construction time, if any.
@@ -479,6 +479,22 @@ class LatticeGraph : public DataClass {
    */
   static LatticeGraph from_hdf5(H5::Group& group);
 
+  /**
+   * @brief Permutes the vertices of the lattice graph according to the given
+   * path.
+   *
+   * Reorders the sparse adjacency matrix using Eigen's permutation operations
+   * and updates the edge coloring to align with the new vertex indexing.
+   *
+   * @param graph The source lattice graph to permute.
+   * @param path The sequence of original vertex indices representing the target
+   * permutation.
+   * @return A new LatticeGraph with the permuted adjacency matrix and edge
+   * coloring.
+   */
+  static LatticeGraph permute(const LatticeGraph& graph,
+                              const std::vector<std::uint64_t>& path);
+
  private:
   void hash_update(qdk::chemistry::utils::HashContext& ctx) const override;
 
@@ -497,22 +513,6 @@ class LatticeGraph : public DataClass {
   /** @brief Check if a sparse matrix is symmetric within a numerical tolerance.
    */
   static bool _check_symmetry(const Eigen::SparseMatrix<double>& mat);
-
-  /**
-   * @brief Permutes the vertices of the lattice graph according to the given
-   * path.
-   *
-   * Reorders the sparse adjacency matrix using Eigen's permutation operations
-   * and updates the edge coloring to align with the new vertex indexing.
-   *
-   * @param graph The source lattice graph to permute.
-   * @param path The sequence of original vertex indices representing the target
-   * permutation.
-   * @return A new LatticeGraph with the permuted adjacency matrix and edge
-   * coloring.
-   */
-  static LatticeGraph permute(const LatticeGraph& graph,
-                              const std::vector<std::uint64_t>& path);
 
   /// Number of sites (vertices) in the lattice
   std::uint64_t _num_sites;

--- a/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
+++ b/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
@@ -263,12 +263,9 @@ class MajoranaMapping : public DataClass {
    * Maps fermionic modes on a `LatticeGraph` to qubits.
    *
    * @param lattice The `LatticeGraph` connectivity.
-   * @param num_spin_species Number of spin species (usually 2 for spinful, 1
-   *        for spinless). Default: 2.
    * @return MajoranaMapping with name ``"verstraete-cirac"``.
    */
-  static MajoranaMapping verstraete_cirac(const LatticeGraph& lattice,
-                                          std::size_t num_spin_species = 2);
+  static MajoranaMapping verstraete_cirac(const LatticeGraph& lattice);
 
  private:
   MajoranaMapping(

--- a/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
+++ b/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
@@ -20,6 +20,8 @@ namespace qdk::chemistry::data {
 
 class Hamiltonian;
 
+class LatticeGraph;
+
 /**
  * @brief Data class describing a fermion-to-qubit encoding.
  *
@@ -103,6 +105,12 @@ class MajoranaMapping : public DataClass {
     return tapering_;
   }
 
+  /// Grid X dimension (for Verstraete-Cirac mapping).
+  std::size_t grid_nx() const { return grid_nx_; }
+
+  /// Grid Y dimension (for Verstraete-Cirac mapping).
+  std::size_t grid_ny() const { return grid_ny_; }
+
   /**
    * @brief Return a copy with tapering removed and the base encoding name
    *        restored.
@@ -162,6 +170,19 @@ class MajoranaMapping : public DataClass {
                                    const std::string& type);
 
   // --- Factory methods for standard encodings ---
+
+  /**
+   * @brief Verstraete-Cirac encoding.
+   *
+   * Maps fermionic modes on a 2D square lattice to qubits.
+   *
+   * @param lattice The 2D square lattice connectivity.
+   * @param num_spin_species Number of spin species (usually 2 for spinful, 1
+   * for spinless). Default: 2.
+   * @return MajoranaMapping with name ``"verstraete-cirac"``.
+   */
+  static MajoranaMapping verstraete_cirac(const LatticeGraph& lattice,
+                                          std::size_t num_spin_species = 2);
 
   /**
    * @brief Jordan-Wigner encoding.
@@ -252,7 +273,8 @@ class MajoranaMapping : public DataClass {
       std::vector<std::pair<std::complex<double>, SparsePauliWord>> bilinears,
       std::string name, std::size_t num_modes, std::size_t num_qubits,
       std::string base_encoding,
-      std::optional<TaperingSpecification> tapering = std::nullopt);
+      std::optional<TaperingSpecification> tapering = std::nullopt,
+      std::size_t grid_nx = 0, std::size_t grid_ny = 0);
 
   /// Majorana-to-Pauli table (empty for bilinear-only mappings).
   std::vector<SparsePauliWord> table_;

--- a/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
+++ b/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
@@ -260,9 +260,9 @@ class MajoranaMapping : public DataClass {
   /**
    * @brief Verstraete-Cirac encoding.
    *
-   * Maps fermionic modes on a 2D square lattice to qubits.
+   * Maps fermionic modes on a `LatticeGraph` to qubits.
    *
-   * @param lattice The 2D square lattice connectivity.
+   * @param lattice The `LatticeGraph` connectivity.
    * @param num_spin_species Number of spin species (usually 2 for spinful, 1
    *        for spinless). Default: 2.
    * @return MajoranaMapping with name ``"verstraete-cirac"``.

--- a/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
+++ b/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
@@ -105,11 +105,14 @@ class MajoranaMapping : public DataClass {
     return tapering_;
   }
 
-  /// Grid X dimension (for Verstraete-Cirac mapping).
-  std::size_t grid_nx() const { return grid_nx_; }
-
-  /// Grid Y dimension (for Verstraete-Cirac mapping).
-  std::size_t grid_ny() const { return grid_ny_; }
+  /**
+   * @brief Stabilizer terms carried by this mapping.
+   * @return Reference to the vector of stabilizers.
+   */
+  const std::vector<std::pair<std::complex<double>, SparsePauliWord>>&
+  stabilizers() const {
+    return stabilizers_;
+  }
 
   /**
    * @brief Return a copy with tapering removed and the base encoding name
@@ -170,19 +173,6 @@ class MajoranaMapping : public DataClass {
                                    const std::string& type);
 
   // --- Factory methods for standard encodings ---
-
-  /**
-   * @brief Verstraete-Cirac encoding.
-   *
-   * Maps fermionic modes on a 2D square lattice to qubits.
-   *
-   * @param lattice The 2D square lattice connectivity.
-   * @param num_spin_species Number of spin species (usually 2 for spinful, 1
-   * for spinless). Default: 2.
-   * @return MajoranaMapping with name ``"verstraete-cirac"``.
-   */
-  static MajoranaMapping verstraete_cirac(const LatticeGraph& lattice,
-                                          std::size_t num_spin_species = 2);
 
   /**
    * @brief Jordan-Wigner encoding.
@@ -267,6 +257,19 @@ class MajoranaMapping : public DataClass {
   static MajoranaMapping symmetry_conserving_bravyi_kitaev(
       std::size_t num_modes, std::size_t n_alpha, std::size_t n_beta);
 
+  /**
+   * @brief Verstraete-Cirac encoding.
+   *
+   * Maps fermionic modes on a 2D square lattice to qubits.
+   *
+   * @param lattice The 2D square lattice connectivity.
+   * @param num_spin_species Number of spin species (usually 2 for spinful, 1
+   *        for spinless). Default: 2.
+   * @return MajoranaMapping with name ``"verstraete-cirac"``.
+   */
+  static MajoranaMapping verstraete_cirac(const LatticeGraph& lattice,
+                                          std::size_t num_spin_species = 2);
+
  private:
   MajoranaMapping(
       std::vector<SparsePauliWord> table,
@@ -274,7 +277,8 @@ class MajoranaMapping : public DataClass {
       std::string name, std::size_t num_modes, std::size_t num_qubits,
       std::string base_encoding,
       std::optional<TaperingSpecification> tapering = std::nullopt,
-      std::size_t grid_nx = 0, std::size_t grid_ny = 0);
+      std::vector<std::pair<std::complex<double>, SparsePauliWord>>
+          stabilizers = {});
 
   /// Majorana-to-Pauli table (empty for bilinear-only mappings).
   std::vector<SparsePauliWord> table_;
@@ -302,6 +306,9 @@ class MajoranaMapping : public DataClass {
 
   /// Feed the mapping's identifying data into a content hash.
   void hash_update(qdk::chemistry::utils::HashContext& ctx) const override;
+
+  /// Optional stabilizer terms.
+  std::vector<std::pair<std::complex<double>, SparsePauliWord>> stabilizers_;
 
   /// Upper-triangle index: (j, k) with j < k, M = 2*num_modes.
   std::size_t bilinear_index(std::size_t j, std::size_t k) const {

--- a/cpp/src/qdk/chemistry/data/lattice_graph.cpp
+++ b/cpp/src/qdk/chemistry/data/lattice_graph.cpp
@@ -29,6 +29,19 @@ static void add_edge(std::vector<Triplet>& triplets, int i, int j, double t) {
   triplets.emplace_back(j, i, t);
 }
 
+/**
+ * @brief Depth-first search (DFS) helper to find a Hamiltonian path in a sparse
+ * graph.
+ *
+ * Recursively visits unvisited neighbor vertices to build a path that visits
+ * every vertex in the graph exactly once.
+ *
+ * @param curr    The vertex index currently being visited.
+ * @param adj     The sparse adjacency matrix of the graph.
+ * @param visited Tracks which vertices have already been visited.
+ * @param path    Stores the sequence of vertices in the current path.
+ * @return True if a Hamiltonian path is found, false otherwise.
+ */
 bool find_hamiltonian_path_dfs(std::uint64_t curr,
                                const Eigen::SparseMatrix<double>& adj,
                                std::vector<bool>& visited,
@@ -53,6 +66,16 @@ bool find_hamiltonian_path_dfs(std::uint64_t curr,
   return false;
 }
 
+/**
+ * @brief Search for a Hamiltonian path in the given sparse graph.
+ *
+ * Tries to find a path that visits every vertex exactly once, starting the
+ * search from each possible vertex in the graph.
+ *
+ * @param adj The sparse adjacency matrix representing the graph.
+ * @return A vector of vertex indices in path order, or an empty vector if no
+ * path exists.
+ */
 std::vector<std::uint64_t> find_hamiltonian_path(
     const Eigen::SparseMatrix<double>& adj) {
   std::uint64_t V = adj.rows();
@@ -203,7 +226,7 @@ std::uint64_t LatticeGraph::num_edges() const {
 }
 
 LatticeGraph LatticeGraph::chain(std::uint64_t n, bool periodic, double t,
-                                 bool optimal_ordering) {
+                                 bool dfs_ordering) {
   if (n == 0) {
     throw std::invalid_argument("chain: n must be > 0.");
   }
@@ -227,7 +250,7 @@ LatticeGraph LatticeGraph::chain(std::uint64_t n, bool periodic, double t,
   adj.makeCompressed();
   LatticeGraph g(std::move(adj),
                  chain_coloring(static_cast<std::int64_t>(N), periodic));
-  if (optimal_ordering) {
+  if (dfs_ordering) {
     auto path = detail::find_hamiltonian_path(g.sparse_adjacency_matrix());
     if (!path.empty()) {
       return permute(g, path);
@@ -241,7 +264,7 @@ LatticeGraph LatticeGraph::chain(std::uint64_t n, bool periodic, double t,
 
 LatticeGraph LatticeGraph::square(std::uint64_t nx, std::uint64_t ny,
                                   bool periodic_x, bool periodic_y, double t,
-                                  bool optimal_ordering) {
+                                  bool dfs_ordering) {
   if (nx == 0 || ny == 0) {
     throw std::invalid_argument("square: nx and ny must be > 0.");
   }
@@ -286,7 +309,7 @@ LatticeGraph LatticeGraph::square(std::uint64_t nx, std::uint64_t ny,
   adj.makeCompressed();
   LatticeGraph g(std::move(adj),
                  square_coloring(Nx, Ny, periodic_x, periodic_y));
-  if (optimal_ordering) {
+  if (dfs_ordering) {
     auto path = detail::find_hamiltonian_path(g.sparse_adjacency_matrix());
     if (!path.empty()) {
       return permute(g, path);
@@ -301,7 +324,7 @@ LatticeGraph LatticeGraph::square(std::uint64_t nx, std::uint64_t ny,
 LatticeGraph LatticeGraph::triangular(std::uint64_t nx, std::uint64_t ny,
                                       bool periodic_x, bool periodic_y,
                                       double t, int coloring_seed,
-                                      bool optimal_ordering) {
+                                      bool dfs_ordering) {
   if (nx == 0 || ny == 0) {
     throw std::invalid_argument("triangular: nx and ny must be > 0.");
   }
@@ -357,7 +380,7 @@ LatticeGraph LatticeGraph::triangular(std::uint64_t nx, std::uint64_t ny,
   // No known deterministic coloring for triangular lattices with arbitrary
   // periodic boundaries; use greedy with multiple trials instead.
   LatticeGraph g(std::move(adj), greedy_edge_coloring(adj, coloring_seed, 32));
-  if (optimal_ordering) {
+  if (dfs_ordering) {
     auto path = detail::find_hamiltonian_path(g.sparse_adjacency_matrix());
     if (!path.empty()) {
       return permute(g, path);
@@ -371,8 +394,8 @@ LatticeGraph LatticeGraph::triangular(std::uint64_t nx, std::uint64_t ny,
 
 LatticeGraph LatticeGraph::honeycomb(std::uint64_t nx, std::uint64_t ny,
                                      bool periodic_x, bool periodic_y, double t,
-                                     bool optimal_ordering) {
-  (void)optimal_ordering;
+                                     bool dfs_ordering) {
+  (void)dfs_ordering;
   if (nx == 0 || ny == 0) {
     throw std::invalid_argument("honeycomb: nx and ny must be > 0.");
   }
@@ -425,8 +448,8 @@ LatticeGraph LatticeGraph::honeycomb(std::uint64_t nx, std::uint64_t ny,
 
 LatticeGraph LatticeGraph::kagome(std::uint64_t nx, std::uint64_t ny,
                                   bool periodic_x, bool periodic_y, double t,
-                                  int coloring_seed, bool optimal_ordering) {
-  (void)optimal_ordering;
+                                  int coloring_seed, bool dfs_ordering) {
+  (void)dfs_ordering;
   if (nx == 0 || ny == 0) {
     throw std::invalid_argument("kagome: nx and ny must be > 0.");
   }

--- a/cpp/src/qdk/chemistry/data/lattice_graph.cpp
+++ b/cpp/src/qdk/chemistry/data/lattice_graph.cpp
@@ -1055,7 +1055,7 @@ LatticeGraph LatticeGraph::permute(const LatticeGraph& graph,
   for (std::uint64_t i = 0; i < V; ++i) {
     P.indices()[static_cast<Eigen::Index>(i)] = static_cast<int>(path[i]);
   }
-  Eigen::SparseMatrix<double> new_adj = P * adj * P.transpose();
+  Eigen::SparseMatrix<double> new_adj = P.transpose() * adj * P;
   new_adj.makeCompressed();
 
   std::vector<std::uint64_t> inv_p(V);

--- a/cpp/src/qdk/chemistry/data/lattice_graph.cpp
+++ b/cpp/src/qdk/chemistry/data/lattice_graph.cpp
@@ -28,6 +28,44 @@ static void add_edge(std::vector<Triplet>& triplets, int i, int j, double t) {
   triplets.emplace_back(i, j, t);
   triplets.emplace_back(j, i, t);
 }
+
+bool find_hamiltonian_path_dfs(std::uint64_t curr,
+                               const Eigen::SparseMatrix<double>& adj,
+                               std::vector<bool>& visited,
+                               std::vector<std::uint64_t>& path) {
+  path.push_back(curr);
+  if (path.size() == static_cast<std::size_t>(adj.rows())) {
+    return true;
+  }
+  visited[curr] = true;
+
+  // Iterate directly over the sparse matrix columns/rows for neighbors
+  for (Eigen::SparseMatrix<double>::InnerIterator it(adj, curr); it; ++it) {
+    std::uint64_t neighbor = it.row();
+    if (neighbor != curr && !visited[neighbor]) {
+      if (find_hamiltonian_path_dfs(neighbor, adj, visited, path)) {
+        return true;
+      }
+    }
+  }
+  visited[curr] = false;
+  path.pop_back();
+  return false;
+}
+
+std::vector<std::uint64_t> find_hamiltonian_path(
+    const Eigen::SparseMatrix<double>& adj) {
+  std::uint64_t V = adj.rows();
+  std::vector<bool> visited(V, false);
+  std::vector<std::uint64_t> path;
+  for (std::uint64_t start = 0; start < V; ++start) {
+    if (find_hamiltonian_path_dfs(start, adj, visited, path)) {
+      return path;
+    }
+  }
+  return {};
+}
+
 }  // namespace detail
 
 LatticeGraph::LatticeGraph(
@@ -164,7 +202,8 @@ std::uint64_t LatticeGraph::num_edges() const {
   return count;
 }
 
-LatticeGraph LatticeGraph::chain(std::uint64_t n, bool periodic, double t) {
+LatticeGraph LatticeGraph::chain(std::uint64_t n, bool periodic, double t,
+                                 bool optimal_ordering) {
   if (n == 0) {
     throw std::invalid_argument("chain: n must be > 0.");
   }
@@ -186,12 +225,23 @@ LatticeGraph LatticeGraph::chain(std::uint64_t n, bool periodic, double t) {
   Eigen::SparseMatrix<double> adj(N, N);
   adj.setFromTriplets(triplets.begin(), triplets.end());
   adj.makeCompressed();
-  return LatticeGraph(std::move(adj),
-                      chain_coloring(static_cast<std::int64_t>(N), periodic));
+  LatticeGraph g(std::move(adj),
+                 chain_coloring(static_cast<std::int64_t>(N), periodic));
+  if (optimal_ordering) {
+    auto path = detail::find_hamiltonian_path(g.sparse_adjacency_matrix());
+    if (!path.empty()) {
+      return permute(g, path);
+    } else {
+      throw std::runtime_error(
+          "No Hamiltonian path found in the lattice graph.");
+    }
+  }
+  return g;
 }
 
 LatticeGraph LatticeGraph::square(std::uint64_t nx, std::uint64_t ny,
-                                  bool periodic_x, bool periodic_y, double t) {
+                                  bool periodic_x, bool periodic_y, double t,
+                                  bool optimal_ordering) {
   if (nx == 0 || ny == 0) {
     throw std::invalid_argument("square: nx and ny must be > 0.");
   }
@@ -234,13 +284,24 @@ LatticeGraph LatticeGraph::square(std::uint64_t nx, std::uint64_t ny,
   Eigen::SparseMatrix<double> adj(N, N);
   adj.setFromTriplets(triplets.begin(), triplets.end());
   adj.makeCompressed();
-  return LatticeGraph(std::move(adj),
-                      square_coloring(Nx, Ny, periodic_x, periodic_y));
+  LatticeGraph g(std::move(adj),
+                 square_coloring(Nx, Ny, periodic_x, periodic_y));
+  if (optimal_ordering) {
+    auto path = detail::find_hamiltonian_path(g.sparse_adjacency_matrix());
+    if (!path.empty()) {
+      return permute(g, path);
+    } else {
+      throw std::runtime_error(
+          "No Hamiltonian path found in the lattice graph.");
+    }
+  }
+  return g;
 }
 
 LatticeGraph LatticeGraph::triangular(std::uint64_t nx, std::uint64_t ny,
                                       bool periodic_x, bool periodic_y,
-                                      double t, int coloring_seed) {
+                                      double t, int coloring_seed,
+                                      bool optimal_ordering) {
   if (nx == 0 || ny == 0) {
     throw std::invalid_argument("triangular: nx and ny must be > 0.");
   }
@@ -295,13 +356,23 @@ LatticeGraph LatticeGraph::triangular(std::uint64_t nx, std::uint64_t ny,
   adj.makeCompressed();
   // No known deterministic coloring for triangular lattices with arbitrary
   // periodic boundaries; use greedy with multiple trials instead.
-  return LatticeGraph(std::move(adj),
-                      greedy_edge_coloring(adj, coloring_seed, 32));
+  LatticeGraph g(std::move(adj), greedy_edge_coloring(adj, coloring_seed, 32));
+  if (optimal_ordering) {
+    auto path = detail::find_hamiltonian_path(g.sparse_adjacency_matrix());
+    if (!path.empty()) {
+      return permute(g, path);
+    } else {
+      throw std::runtime_error(
+          "No Hamiltonian path found in the lattice graph.");
+    }
+  }
+  return g;
 }
 
 LatticeGraph LatticeGraph::honeycomb(std::uint64_t nx, std::uint64_t ny,
-                                     bool periodic_x, bool periodic_y,
-                                     double t) {
+                                     bool periodic_x, bool periodic_y, double t,
+                                     bool optimal_ordering) {
+  (void)optimal_ordering;
   if (nx == 0 || ny == 0) {
     throw std::invalid_argument("honeycomb: nx and ny must be > 0.");
   }
@@ -354,7 +425,8 @@ LatticeGraph LatticeGraph::honeycomb(std::uint64_t nx, std::uint64_t ny,
 
 LatticeGraph LatticeGraph::kagome(std::uint64_t nx, std::uint64_t ny,
                                   bool periodic_x, bool periodic_y, double t,
-                                  int coloring_seed) {
+                                  int coloring_seed, bool optimal_ordering) {
+  (void)optimal_ordering;
   if (nx == 0 || ny == 0) {
     throw std::invalid_argument("kagome: nx and ny must be > 0.");
   }
@@ -947,6 +1019,40 @@ void LatticeGraph::hash_update(qdk::chemistry::utils::HashContext& ctx) const {
   hash_value(ctx, static_cast<uint64_t>(_num_sites));
   hash_value(ctx, adjacency_);
   hash_value(ctx, _is_symmetric);
+}
+
+LatticeGraph LatticeGraph::permute(const LatticeGraph& graph,
+                                   const std::vector<std::uint64_t>& path) {
+  std::uint64_t V = graph.num_sites();
+  const auto& adj = graph.sparse_adjacency_matrix();
+
+  // Reorder the adjacency matrix using Eigen's PermutationMatrix
+  Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic, int> P(
+      static_cast<Eigen::Index>(V));
+  for (std::uint64_t i = 0; i < V; ++i) {
+    P.indices()[static_cast<Eigen::Index>(i)] = static_cast<int>(path[i]);
+  }
+  Eigen::SparseMatrix<double> new_adj = P * adj * P.transpose();
+  new_adj.makeCompressed();
+
+  std::vector<std::uint64_t> inv_p(V);
+  for (std::uint64_t i = 0; i < V; ++i) {
+    inv_p[path[i]] = i;
+  }
+
+  std::optional<EdgeColoring> new_coloring = std::nullopt;
+  if (graph.edge_coloring().has_value()) {
+    EdgeColoring coloring;
+    for (const auto& [edge, color] : *(graph.edge_coloring())) {
+      std::uint64_t new_u = inv_p[edge.first];
+      std::uint64_t new_v = inv_p[edge.second];
+      auto new_edge = std::minmax(new_u, new_v);
+      coloring[{new_edge.first, new_edge.second}] = color;
+    }
+    new_coloring = std::move(coloring);
+  }
+
+  return LatticeGraph(std::move(new_adj), std::move(new_coloring));
 }
 
 }  // namespace qdk::chemistry::data

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -712,6 +712,83 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
     }
   }
 
+  if (!mapping.stabilizers().empty()) {
+    double h1_sum = 0.0;
+    for (std::size_t p = 0; p < n_spatial; ++p) {
+      for (std::size_t q = 0; q < n_spatial; ++q) {
+        h1_sum += std::abs(h1_alpha[p * n_spatial + q]);
+        if (!spin_symmetric) {
+          h1_sum += std::abs(h1_beta[p * n_spatial + q]);
+        } else {
+          h1_sum += std::abs(h1_alpha[p * n_spatial + q]);
+        }
+      }
+    }
+
+    // If stabilizers are included in the mapping, our total Hamiltonian becomes
+    // H_total = H_physical + H_aux. We add H_aux = λ · Σ_i (I − S_i S_{i+1})
+    // (sum of products of adjacent stabilizers per spin channel) to penalize
+    // unphysical codespace sectors using local terms.
+    double aux_ham_coefficient = 1.0 + h1_sum;
+
+    std::size_t num_stabs = mapping.stabilizers().size();
+    std::size_t half_stabs = num_stabs / 2;
+
+    struct PackedStab {
+      std::complex<double> coeff;
+      PackedPauliWord<NW> word;
+    };
+    std::vector<PackedStab> packed_stabs;
+    packed_stabs.reserve(num_stabs);
+    for (const auto& [coeff, word] : mapping.stabilizers()) {
+      packed_stabs.push_back({coeff, sparse_to_packed<NW>(word)});
+    }
+
+    std::size_t num_penalty_terms = 0;
+    if (half_stabs >= 2) {
+      num_penalty_terms = 2 * (half_stabs - 1);
+    } else {
+      num_penalty_terms = num_stabs;
+    }
+
+    PackedPauliWord<NW> identity{};
+    acc.accumulate(identity,
+                   std::complex<double>(aux_ham_coefficient * num_stabs, 0.0));
+
+    // For each spin sector, we accumulate the single boundary link stabilizer
+    // individually to lift the Z_2 gauge degeneracy, followed by the products
+    // of adjacent link stabilizers (S_i * S_{i+1}) to form loop-plaquette
+    // stabilizers.
+    if (half_stabs >= 1) {
+      auto accumulate_product = [&](std::size_t i, std::size_t j) {
+        const auto& s1 = packed_stabs[i];
+        const auto& s2 = packed_stabs[j];
+        auto [phase_idx, word] = multiply_packed(s1.word, s2.word);
+        std::complex<double> prod_coeff =
+            apply_phase(phase_idx, s1.coeff * s2.coeff);
+        acc.accumulate(word, -aux_ham_coefficient * prod_coeff);
+      };
+      // S[0] * S[0..n/2] for α spin Majoranas
+      acc.accumulate(packed_stabs[0].word,
+                     -aux_ham_coefficient * packed_stabs[0].coeff);
+      for (std::size_t i = 0; i < half_stabs - 1; ++i) {
+        accumulate_product(i, i + 1);
+      }
+
+      // S[n/2] * S[n/2..] for β spin Majoranas
+      acc.accumulate(packed_stabs[half_stabs].word,
+                     -aux_ham_coefficient * packed_stabs[half_stabs].coeff);
+      for (std::size_t i = half_stabs; i < num_stabs - 1; ++i) {
+        accumulate_product(i, i + 1);
+      }
+    } else {
+      // Fallback to individual stabilizers if too few to form products
+      for (const auto& stab : packed_stabs) {
+        acc.accumulate(stab.word, -aux_ham_coefficient * stab.coeff);
+      }
+    }
+  }
+
   // ─── Extract results as sparse Pauli words ──────────────────────
   auto terms = acc.get_terms(threshold);
 

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -757,9 +757,17 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
 
     // For each spin sector, we accumulate the single boundary link stabilizer
     // individually to lift the Z_2 gauge degeneracy, followed by the products
-    // of adjacent link stabilizers (S_i * S_{i+1}) to form loop-plaquette
-    // stabilizers.
+    // of adjacent link stabilizers (paired via Minimum Spanning Tree to
+    // minimize their Pauli weight) to form local loop-plaquette stabilizers.
     if (half_stabs >= 1) {
+      auto get_packed_weight = [](const PackedPauliWord<NW>& pw) -> int {
+        int w = 0;
+        for (std::size_t k = 0; k < NW; ++k) {
+          w += std::popcount(pw.x[k] | pw.z[k]);
+        }
+        return w;
+      };
+
       auto accumulate_product = [&](std::size_t i, std::size_t j) {
         const auto& s1 = packed_stabs[i];
         const auto& s2 = packed_stabs[j];
@@ -768,19 +776,61 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
             apply_phase(phase_idx, s1.coeff * s2.coeff);
         acc.accumulate(word, -aux_ham_coefficient * prod_coeff);
       };
-      // S[0] * S[0..n/2] for α spin Majoranas
-      acc.accumulate(packed_stabs[0].word,
-                     -aux_ham_coefficient * packed_stabs[0].coeff);
-      for (std::size_t i = 0; i < half_stabs - 1; ++i) {
-        accumulate_product(i, i + 1);
-      }
 
-      // S[n/2] * S[n/2..] for β spin Majoranas
-      acc.accumulate(packed_stabs[half_stabs].word,
-                     -aux_ham_coefficient * packed_stabs[half_stabs].coeff);
-      for (std::size_t i = half_stabs; i < num_stabs - 1; ++i) {
-        accumulate_product(i, i + 1);
-      }
+      auto build_mst_and_accumulate = [&](std::size_t start_idx,
+                                          std::size_t count) {
+        // Accumulate the root boundary link stabilizer
+        acc.accumulate(packed_stabs[start_idx].word,
+                       -aux_ham_coefficient * packed_stabs[start_idx].coeff);
+
+        if (count <= 1) return;
+
+        // Prim's algorithm to find the Minimum Spanning Tree of stabilizer
+        // pairings
+        std::vector<bool> in_mst(count, false);
+        std::vector<int> min_weight(count, 1e9);
+        std::vector<std::size_t> parent(count, 0);
+
+        min_weight[0] = 0;
+
+        for (std::size_t step = 0; step < count; ++step) {
+          std::size_t u = 0;
+          int min_val = 1e9;
+          for (std::size_t i = 0; i < count; ++i) {
+            if (!in_mst[i] && min_weight[i] < min_val) {
+              min_val = min_weight[i];
+              u = i;
+            }
+          }
+
+          in_mst[u] = true;
+
+          for (std::size_t v = 0; v < count; ++v) {
+            if (!in_mst[v]) {
+              auto [phase_idx, word] =
+                  multiply_packed(packed_stabs[start_idx + u].word,
+                                  packed_stabs[start_idx + v].word);
+              int w = get_packed_weight(word);
+              if (w < min_weight[v]) {
+                min_weight[v] = w;
+                parent[v] = u;
+              }
+            }
+          }
+        }
+
+        // Accumulate products for the selected MST edges
+        for (std::size_t v = 1; v < count; ++v) {
+          accumulate_product(start_idx + parent[v], start_idx + v);
+        }
+      };
+
+      // Construct MST for α spin Majoranas
+      build_mst_and_accumulate(0, half_stabs);
+
+      // Construct MST for β spin Majoranas
+      build_mst_and_accumulate(half_stabs, half_stabs);
+
     } else {
       // Fallback to individual stabilizers if too few to form products
       for (const auto& stab : packed_stabs) {

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -398,8 +398,6 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
                                     double threshold,
                                     double integral_threshold) {
   const std::size_t n_modes = 2 * n_spatial;
-  const std::size_t num_spin_species =
-      (mapping.num_modes() < 2 * n_spatial) ? 1 : 2;
 
   PackedAccumulator<NW> acc;
 
@@ -433,6 +431,10 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
     }
     return cache;
   };
+
+  const std::size_t num_spin_species =
+      (mapping.num_modes() < 2 * n_spatial) ? 1 : 2;
+  const bool use_spin_symmetric = spin_symmetric && (num_spin_species == 2);
 
   auto ppair_alpha = build_pair_cache(alpha_offset);
   std::vector<PackedPairProduct> ppair_beta;
@@ -481,8 +483,8 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
   for (std::size_t p = 0; p < n_spatial; ++p) {
     for (std::size_t s = 0; s < n_spatial; ++s) {
       double h_a = h1_alpha[p * n_spatial + s];
-      double h_b = spin_symmetric ? h_a : h1_beta[p * n_spatial + s];
-      if (spin_symmetric) {
+      double h_b = use_spin_symmetric ? h_a : h1_beta[p * n_spatial + s];
+      if (use_spin_symmetric) {
         double delta_corr = 0.0;
         for (std::size_t q = 0; q < n_spatial; ++q) {
           delta_corr += eri_provider.aaaa(p, q, q, s);
@@ -512,7 +514,7 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
 
   // ─── Two-body terms ───────────────────────────────────────────────
 
-  if (spin_symmetric) {
+  if (use_spin_symmetric) {
     struct SpinSummedE {
       std::vector<std::pair<std::complex<double>, PackedPauliWord<NW>>> terms;
     };
@@ -526,11 +528,9 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
             const auto& [coeff_a, word_a] = alpha_pair(2 * p + a, 2 * q + b);
             sse.terms.emplace_back(coeff_a * 0.25 * excitation_coeff[a][b],
                                    word_a);
-            if (num_spin_species == 2) {
-              const auto& [coeff_b, word_b] = beta_pair(2 * p + a, 2 * q + b);
-              sse.terms.emplace_back(coeff_b * 0.25 * excitation_coeff[a][b],
-                                     word_b);
-            }
+            const auto& [coeff_b, word_b] = beta_pair(2 * p + a, 2 * q + b);
+            sse.terms.emplace_back(coeff_b * 0.25 * excitation_coeff[a][b],
+                                   word_b);
           }
         }
       }
@@ -676,160 +676,37 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
       }
     }
 
-    if (num_spin_species == 2) {
-      // ββ channel
-      for (std::size_t p = 0; p < n_spatial; ++p) {
-        for (std::size_t q = 0; q < n_spatial; ++q) {
-          for (std::size_t r = 0; r < n_spatial; ++r) {
-            for (std::size_t s = 0; s < n_spatial; ++s) {
-              double eri = eri_bbbb[idx4(p, q, r, s)];
-              if (std::abs(eri) < integral_threshold) continue;
-              accumulate_two_body_product(mode_beta(p), mode_beta(q),
-                                          mode_beta(r), mode_beta(s), eri);
-              if (q == r) {
-                accumulate_epq(mode_beta(p), mode_beta(s), -0.5 * eri);
-              }
-            }
-          }
-        }
-      }
-
-      // αβ + βα cross-spin channels, related by Coulomb symmetry
-      // (pq|rs)=(rs|pq)
-      for (std::size_t p = 0; p < n_spatial; ++p) {
-        for (std::size_t q = 0; q < n_spatial; ++q) {
-          for (std::size_t r = 0; r < n_spatial; ++r) {
-            for (std::size_t s = 0; s < n_spatial; ++s) {
-              double eri = eri_aabb[idx4(p, q, r, s)];
-              if (std::abs(eri) < integral_threshold) continue;
-              accumulate_two_body_product(mode_alpha(p), mode_alpha(q),
-                                          mode_beta(r), mode_beta(s), eri);
-              accumulate_two_body_product(mode_beta(r), mode_beta(s),
-                                          mode_alpha(p), mode_alpha(q), eri);
-            }
-          }
-        }
-      }
-    }
-  }
-
-  if (mapping.base_encoding() == "verstraete-cirac" && mapping.grid_nx() > 0 &&
-      mapping.grid_ny() > 0) {
-    std::uint64_t nx = mapping.grid_nx();
-    std::uint64_t ny = mapping.grid_ny();
-    std::uint64_t V = nx * ny;
-
-    double h1_sum = 0.0;
+    // ββ channel
     for (std::size_t p = 0; p < n_spatial; ++p) {
       for (std::size_t q = 0; q < n_spatial; ++q) {
-        h1_sum += std::abs(h1_alpha[p * n_spatial + q]);
-        if (num_spin_species == 2) {
-          if (!use_spin_symmetric) {
-            h1_sum += std::abs(h1_beta[p * n_spatial + q]);
-          } else {
-            h1_sum += std::abs(h1_alpha[p * n_spatial + q]);
+        const double* row = eri_provider.row_bbbb(p, q);
+        for (std::size_t r = 0; r < n_spatial; ++r) {
+          for (std::size_t s = 0; s < n_spatial; ++s) {
+            double eri = row[r * n_spatial + s];
+            if (std::abs(eri) < integral_threshold) continue;
+            accumulate_two_body_product(mode_beta(p), mode_beta(q),
+                                        mode_beta(r), mode_beta(s), eri);
+            if (q == r) {
+              accumulate_epq(mode_beta(p), mode_beta(s), -0.5 * eri);
+            }
           }
         }
       }
     }
-    // If stabilizers are included in the mapping, our total Hamiltonian becomes
-    // H_total = H_physical + H_aux. We add H_aux = λ · Σ_i (I − S_i) to
-    // penalize unphysical codespace sectors.
-    double aux_ham_coefficient = 1.0 + h1_sum;
 
-    std::size_t num_modes = mapping.num_modes();
-    std::size_t base_modes = 2 * num_modes;
-    auto jw_base = MajoranaMapping::jordan_wigner(base_modes);
-    std::size_t num_spin_species = num_modes / V;
-
-    auto get_snake_coordinates =
-        [&](std::uint64_t index) -> std::pair<std::uint64_t, std::uint64_t> {
-      std::uint64_t row = index / nx;
-      std::uint64_t col;
-      if (row % 2 == 0) {
-        col = index % nx;
-      } else {
-        col = nx - 1 - (index % nx);
-      }
-      return {col, row};
-    };
-
-    auto get_snake_index = [&](std::uint64_t col,
-                               std::uint64_t row) -> std::uint64_t {
-      if (row % 2 == 0) {
-        return row * nx + col;
-      } else {
-        return (row + 1) * nx - 1 - col;
-      }
-    };
-
-    auto get_stabilizer = [&](std::size_t u, std::size_t v)
-        -> std::pair<std::complex<double>, PackedPauliWord<NW>> {
-      std::size_t s_u = (u - 1) / (2 * V);
-      std::size_t i = ((u - 1) / 2) % V;
-      std::size_t j = ((v - 1) / 2) % V;
-
-      std::size_t top = std::min(i, j);
-      std::size_t bot = std::max(i, j);
-      auto coord_top = get_snake_coordinates(top);
-      std::size_t col = coord_top.first;
-
-      std::size_t top_aux_mode = 2 * s_u * V + 2 * top + 1;
-      std::size_t bot_aux_mode = 2 * s_u * V + 2 * bot + 1;
-
-      std::size_t p, q;
-      if (col % 2 == 0) {
-        p = 2 * top_aux_mode;
-        q = 2 * bot_aux_mode + 1;
-      } else {
-        p = 2 * bot_aux_mode;
-        q = 2 * top_aux_mode + 1;
-      }
-
-      auto [coeff_stab, word_stab] = jw_base.bilinear(p, q);
-      return {coeff_stab, sparse_to_packed<NW>(word_stab)};
-    };
-
-    // Calculate number of plaquettes per spin sector: (nx - 1) * (ny - 1)
-    std::size_t num_plaquettes = (nx - 1) * (ny - 1);
-
-    PackedPauliWord<NW> identity{};
-    acc.accumulate(
-        identity,
-        std::complex<double>(
-            aux_ham_coefficient * num_plaquettes * num_spin_species, 0.0));
-
-    for (std::size_t s = 0; s < num_spin_species; ++s) {
-      for (std::uint64_t k = 0; k < nx - 1; ++k) {
-        for (std::uint64_t l = 0; l < ny - 1; ++l) {
-          // Sites of the plaquette
-          std::uint64_t i00 = get_snake_index(k, l);
-          std::uint64_t i10 = get_snake_index(k + 1, l);
-          std::uint64_t i01 = get_snake_index(k, l + 1);
-          std::uint64_t i11 = get_snake_index(k + 1, l + 1);
-
-          // Expanded auxiliary modes
-          std::uint64_t u00 = 2 * s * V + 2 * i00 + 1;
-          std::uint64_t u10 = 2 * s * V + 2 * i10 + 1;
-          std::uint64_t u01 = 2 * s * V + 2 * i01 + 1;
-          std::uint64_t u11 = 2 * s * V + 2 * i11 + 1;
-
-          // Get the 4 link stabilizers
-          auto [c_v1, w_v1] = get_stabilizer(u00, u01);
-          auto [c_v2, w_v2] = get_stabilizer(u10, u11);
-          auto [c_h_bot, w_h_bot] = get_stabilizer(u00, u10);
-          auto [c_h_top, w_h_top] = get_stabilizer(u01, u11);
-
-          // Multiply them: plaquette = w_v1 * w_v2 * w_h_bot * w_h_top
-          auto [phase1, w_tmp1] = multiply_packed(w_v1, w_v2);
-          auto [phase2, w_tmp2] = multiply_packed(w_h_bot, w_h_top);
-          auto [phase3, w_final] = multiply_packed(w_tmp1, w_tmp2);
-
-          std::complex<double> coeff_final =
-              c_v1 * c_v2 * c_h_bot * c_h_top * apply_phase(phase1, 1.0) *
-              apply_phase(phase2, 1.0) * apply_phase(phase3, 1.0);
-
-          acc.accumulate(w_final, -aux_ham_coefficient * coeff_final);
+    // αβ + βα cross-spin channels, related by Coulomb symmetry (pq|rs)=(rs|pq)
+    for (std::size_t p = 0; p < n_spatial; ++p) {
+      for (std::size_t q = 0; q < n_spatial; ++q) {
+        const double* row = eri_provider.row_aabb(p, q);
+        for (std::size_t r = 0; r < n_spatial; ++r) {
+          for (std::size_t s = 0; s < n_spatial; ++s) {
+            double eri = row[r * n_spatial + s];
+            if (std::abs(eri) < integral_threshold) continue;
+            accumulate_two_body_product(mode_alpha(p), mode_alpha(q),
+                                        mode_beta(r), mode_beta(s), eri);
+            accumulate_two_body_product(mode_beta(r), mode_beta(s),
+                                        mode_alpha(p), mode_alpha(q), eri);
+          }
         }
       }
     }

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -732,6 +732,9 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
         }
       }
     }
+    // If stabilizers are included in the mapping, our total Hamiltonian becomes
+    // H_total = H_physical + H_aux. We add H_aux = λ · Σ_i (I − S_i) to
+    // penalize unphysical codespace sectors.
     double aux_ham_coefficient = 1.0 + h1_sum;
 
     std::size_t num_modes = mapping.num_modes();

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -398,6 +398,8 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
                                     double threshold,
                                     double integral_threshold) {
   const std::size_t n_modes = 2 * n_spatial;
+  const std::size_t num_spin_species =
+      (mapping.num_modes() < 2 * n_spatial) ? 1 : 2;
 
   PackedAccumulator<NW> acc;
 
@@ -431,10 +433,6 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
     }
     return cache;
   };
-
-  const std::size_t num_spin_species =
-      (mapping.num_modes() < 2 * n_spatial) ? 1 : 2;
-  const bool use_spin_symmetric = spin_symmetric && (num_spin_species == 2);
 
   auto ppair_alpha = build_pair_cache(alpha_offset);
   std::vector<PackedPairProduct> ppair_beta;
@@ -483,8 +481,8 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
   for (std::size_t p = 0; p < n_spatial; ++p) {
     for (std::size_t s = 0; s < n_spatial; ++s) {
       double h_a = h1_alpha[p * n_spatial + s];
-      double h_b = use_spin_symmetric ? h_a : h1_beta[p * n_spatial + s];
-      if (use_spin_symmetric) {
+      double h_b = spin_symmetric ? h_a : h1_beta[p * n_spatial + s];
+      if (spin_symmetric) {
         double delta_corr = 0.0;
         for (std::size_t q = 0; q < n_spatial; ++q) {
           delta_corr += eri_provider.aaaa(p, q, q, s);
@@ -514,7 +512,7 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
 
   // ─── Two-body terms ───────────────────────────────────────────────
 
-  if (use_spin_symmetric) {
+  if (spin_symmetric) {
     struct SpinSummedE {
       std::vector<std::pair<std::complex<double>, PackedPauliWord<NW>>> terms;
     };
@@ -528,9 +526,11 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
             const auto& [coeff_a, word_a] = alpha_pair(2 * p + a, 2 * q + b);
             sse.terms.emplace_back(coeff_a * 0.25 * excitation_coeff[a][b],
                                    word_a);
-            const auto& [coeff_b, word_b] = beta_pair(2 * p + a, 2 * q + b);
-            sse.terms.emplace_back(coeff_b * 0.25 * excitation_coeff[a][b],
-                                   word_b);
+            if (num_spin_species == 2) {
+              const auto& [coeff_b, word_b] = beta_pair(2 * p + a, 2 * q + b);
+              sse.terms.emplace_back(coeff_b * 0.25 * excitation_coeff[a][b],
+                                     word_b);
+            }
           }
         }
       }
@@ -676,37 +676,157 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
       }
     }
 
-    // ββ channel
-    for (std::size_t p = 0; p < n_spatial; ++p) {
-      for (std::size_t q = 0; q < n_spatial; ++q) {
-        const double* row = eri_provider.row_bbbb(p, q);
-        for (std::size_t r = 0; r < n_spatial; ++r) {
-          for (std::size_t s = 0; s < n_spatial; ++s) {
-            double eri = row[r * n_spatial + s];
-            if (std::abs(eri) < integral_threshold) continue;
-            accumulate_two_body_product(mode_beta(p), mode_beta(q),
-                                        mode_beta(r), mode_beta(s), eri);
-            if (q == r) {
-              accumulate_epq(mode_beta(p), mode_beta(s), -0.5 * eri);
+    if (num_spin_species == 2) {
+      // ββ channel
+      for (std::size_t p = 0; p < n_spatial; ++p) {
+        for (std::size_t q = 0; q < n_spatial; ++q) {
+          for (std::size_t r = 0; r < n_spatial; ++r) {
+            for (std::size_t s = 0; s < n_spatial; ++s) {
+              double eri = eri_bbbb[idx4(p, q, r, s)];
+              if (std::abs(eri) < integral_threshold) continue;
+              accumulate_two_body_product(mode_beta(p), mode_beta(q),
+                                          mode_beta(r), mode_beta(s), eri);
+              if (q == r) {
+                accumulate_epq(mode_beta(p), mode_beta(s), -0.5 * eri);
+              }
+            }
+          }
+        }
+      }
+
+      // αβ + βα cross-spin channels, related by Coulomb symmetry
+      // (pq|rs)=(rs|pq)
+      for (std::size_t p = 0; p < n_spatial; ++p) {
+        for (std::size_t q = 0; q < n_spatial; ++q) {
+          for (std::size_t r = 0; r < n_spatial; ++r) {
+            for (std::size_t s = 0; s < n_spatial; ++s) {
+              double eri = eri_aabb[idx4(p, q, r, s)];
+              if (std::abs(eri) < integral_threshold) continue;
+              accumulate_two_body_product(mode_alpha(p), mode_alpha(q),
+                                          mode_beta(r), mode_beta(s), eri);
+              accumulate_two_body_product(mode_beta(r), mode_beta(s),
+                                          mode_alpha(p), mode_alpha(q), eri);
             }
           }
         }
       }
     }
+  }
 
-    // αβ + βα cross-spin channels, related by Coulomb symmetry (pq|rs)=(rs|pq)
+  if (mapping.base_encoding() == "verstraete-cirac" && mapping.grid_nx() > 0 &&
+      mapping.grid_ny() > 0) {
+    std::uint64_t nx = mapping.grid_nx();
+    std::uint64_t ny = mapping.grid_ny();
+    std::uint64_t V = nx * ny;
+
+    double h1_sum = 0.0;
     for (std::size_t p = 0; p < n_spatial; ++p) {
       for (std::size_t q = 0; q < n_spatial; ++q) {
-        const double* row = eri_provider.row_aabb(p, q);
-        for (std::size_t r = 0; r < n_spatial; ++r) {
-          for (std::size_t s = 0; s < n_spatial; ++s) {
-            double eri = row[r * n_spatial + s];
-            if (std::abs(eri) < integral_threshold) continue;
-            accumulate_two_body_product(mode_alpha(p), mode_alpha(q),
-                                        mode_beta(r), mode_beta(s), eri);
-            accumulate_two_body_product(mode_beta(r), mode_beta(s),
-                                        mode_alpha(p), mode_alpha(q), eri);
+        h1_sum += std::abs(h1_alpha[p * n_spatial + q]);
+        if (num_spin_species == 2) {
+          if (!use_spin_symmetric) {
+            h1_sum += std::abs(h1_beta[p * n_spatial + q]);
+          } else {
+            h1_sum += std::abs(h1_alpha[p * n_spatial + q]);
           }
+        }
+      }
+    }
+    double aux_ham_coefficient = 1.0 + h1_sum;
+
+    std::size_t num_modes = mapping.num_modes();
+    std::size_t base_modes = 2 * num_modes;
+    auto jw_base = MajoranaMapping::jordan_wigner(base_modes);
+    std::size_t num_spin_species = num_modes / V;
+
+    auto get_snake_coordinates =
+        [&](std::uint64_t index) -> std::pair<std::uint64_t, std::uint64_t> {
+      std::uint64_t row = index / nx;
+      std::uint64_t col;
+      if (row % 2 == 0) {
+        col = index % nx;
+      } else {
+        col = nx - 1 - (index % nx);
+      }
+      return {col, row};
+    };
+
+    auto get_snake_index = [&](std::uint64_t col,
+                               std::uint64_t row) -> std::uint64_t {
+      if (row % 2 == 0) {
+        return row * nx + col;
+      } else {
+        return (row + 1) * nx - 1 - col;
+      }
+    };
+
+    auto get_stabilizer = [&](std::size_t u, std::size_t v)
+        -> std::pair<std::complex<double>, PackedPauliWord<NW>> {
+      std::size_t s_u = (u - 1) / (2 * V);
+      std::size_t i = ((u - 1) / 2) % V;
+      std::size_t j = ((v - 1) / 2) % V;
+
+      std::size_t top = std::min(i, j);
+      std::size_t bot = std::max(i, j);
+      auto coord_top = get_snake_coordinates(top);
+      std::size_t col = coord_top.first;
+
+      std::size_t top_aux_mode = 2 * s_u * V + 2 * top + 1;
+      std::size_t bot_aux_mode = 2 * s_u * V + 2 * bot + 1;
+
+      std::size_t p, q;
+      if (col % 2 == 0) {
+        p = 2 * top_aux_mode;
+        q = 2 * bot_aux_mode + 1;
+      } else {
+        p = 2 * bot_aux_mode;
+        q = 2 * top_aux_mode + 1;
+      }
+
+      auto [coeff_stab, word_stab] = jw_base.bilinear(p, q);
+      return {coeff_stab, sparse_to_packed<NW>(word_stab)};
+    };
+
+    // Calculate number of plaquettes per spin sector: (nx - 1) * (ny - 1)
+    std::size_t num_plaquettes = (nx - 1) * (ny - 1);
+
+    PackedPauliWord<NW> identity{};
+    acc.accumulate(
+        identity,
+        std::complex<double>(
+            aux_ham_coefficient * num_plaquettes * num_spin_species, 0.0));
+
+    for (std::size_t s = 0; s < num_spin_species; ++s) {
+      for (std::uint64_t k = 0; k < nx - 1; ++k) {
+        for (std::uint64_t l = 0; l < ny - 1; ++l) {
+          // Sites of the plaquette
+          std::uint64_t i00 = get_snake_index(k, l);
+          std::uint64_t i10 = get_snake_index(k + 1, l);
+          std::uint64_t i01 = get_snake_index(k, l + 1);
+          std::uint64_t i11 = get_snake_index(k + 1, l + 1);
+
+          // Expanded auxiliary modes
+          std::uint64_t u00 = 2 * s * V + 2 * i00 + 1;
+          std::uint64_t u10 = 2 * s * V + 2 * i10 + 1;
+          std::uint64_t u01 = 2 * s * V + 2 * i01 + 1;
+          std::uint64_t u11 = 2 * s * V + 2 * i11 + 1;
+
+          // Get the 4 link stabilizers
+          auto [c_v1, w_v1] = get_stabilizer(u00, u01);
+          auto [c_v2, w_v2] = get_stabilizer(u10, u11);
+          auto [c_h_bot, w_h_bot] = get_stabilizer(u00, u10);
+          auto [c_h_top, w_h_top] = get_stabilizer(u01, u11);
+
+          // Multiply them: plaquette = w_v1 * w_v2 * w_h_bot * w_h_top
+          auto [phase1, w_tmp1] = multiply_packed(w_v1, w_v2);
+          auto [phase2, w_tmp2] = multiply_packed(w_h_bot, w_h_top);
+          auto [phase3, w_final] = multiply_packed(w_tmp1, w_tmp2);
+
+          std::complex<double> coeff_final =
+              c_v1 * c_v2 * c_h_bot * c_h_top * apply_phase(phase1, 1.0) *
+              apply_phase(phase2, 1.0) * apply_phase(phase3, 1.0);
+
+          acc.accumulate(w_final, -aux_ham_coefficient * coeff_final);
         }
       }
     }

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -432,8 +432,15 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
     return cache;
   };
 
+  const std::size_t num_spin_species =
+      (mapping.num_modes() < 2 * n_spatial) ? 1 : 2;
+  const bool use_spin_symmetric = spin_symmetric && (num_spin_species == 2);
+
   auto ppair_alpha = build_pair_cache(alpha_offset);
-  auto ppair_beta = build_pair_cache(beta_offset);
+  std::vector<PackedPairProduct> ppair_beta;
+  if (num_spin_species == 2) {
+    ppair_beta = build_pair_cache(beta_offset);
+  }
 
   auto alpha_pair = [&](std::size_t i,
                         std::size_t j) -> const PackedPairProduct& {
@@ -476,8 +483,8 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
   for (std::size_t p = 0; p < n_spatial; ++p) {
     for (std::size_t s = 0; s < n_spatial; ++s) {
       double h_a = h1_alpha[p * n_spatial + s];
-      double h_b = spin_symmetric ? h_a : h1_beta[p * n_spatial + s];
-      if (spin_symmetric) {
+      double h_b = use_spin_symmetric ? h_a : h1_beta[p * n_spatial + s];
+      if (use_spin_symmetric) {
         double delta_corr = 0.0;
         for (std::size_t q = 0; q < n_spatial; ++q) {
           delta_corr += eri_provider.aaaa(p, q, q, s);
@@ -496,16 +503,18 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
       if (std::abs(h_pq_a) > integral_threshold) {
         accumulate_epq(mode_alpha(p), mode_alpha(q), h_pq_a);
       }
-      double h_pq_b = h1_eff_beta[p * n_spatial + q];
-      if (std::abs(h_pq_b) > integral_threshold) {
-        accumulate_epq(mode_beta(p), mode_beta(q), h_pq_b);
+      if (num_spin_species == 2) {
+        double h_pq_b = h1_eff_beta[p * n_spatial + q];
+        if (std::abs(h_pq_b) > integral_threshold) {
+          accumulate_epq(mode_beta(p), mode_beta(q), h_pq_b);
+        }
       }
     }
   }
 
   // ─── Two-body terms ───────────────────────────────────────────────
 
-  if (spin_symmetric) {
+  if (use_spin_symmetric) {
     struct SpinSummedE {
       std::vector<std::pair<std::complex<double>, PackedPauliWord<NW>>> terms;
     };

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -779,19 +779,33 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
 
       auto build_mst_and_accumulate = [&](std::size_t start_idx,
                                           std::size_t count) {
+        if (count == 0) return;
+
+        // Find the lightest stabilizer as root
+        std::size_t root = 0;
+        int root_weight = get_packed_weight(packed_stabs[start_idx].word);
+        for (std::size_t i = 1; i < count; ++i) {
+          int w = get_packed_weight(packed_stabs[start_idx + i].word);
+          if (w < root_weight) {
+            root = i;
+            root_weight = w;
+          }
+        }
+
         // Accumulate the root boundary link stabilizer
-        acc.accumulate(packed_stabs[start_idx].word,
-                       -aux_ham_coefficient * packed_stabs[start_idx].coeff);
+        acc.accumulate(
+            packed_stabs[start_idx + root].word,
+            -aux_ham_coefficient * packed_stabs[start_idx + root].coeff);
 
         if (count <= 1) return;
 
-        // Prim's algorithm to find the Minimum Spanning Tree of stabilizer
-        // pairings
+        // Prim's algorithm to find the minimum spanning tree of stabilizer
+        // pairings starting from the chosen root
         std::vector<bool> in_mst(count, false);
         std::vector<int> min_weight(count, 1e9);
-        std::vector<std::size_t> parent(count, 0);
+        std::vector<std::size_t> parent(count, root);
 
-        min_weight[0] = 0;
+        min_weight[root] = 0;
 
         for (std::size_t step = 0; step < count; ++step) {
           std::size_t u = 0;
@@ -820,8 +834,10 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
         }
 
         // Accumulate products for the selected MST edges
-        for (std::size_t v = 1; v < count; ++v) {
-          accumulate_product(start_idx + parent[v], start_idx + v);
+        for (std::size_t v = 0; v < count; ++v) {
+          if (v != root) {
+            accumulate_product(start_idx + parent[v], start_idx + v);
+          }
         }
       };
 

--- a/cpp/src/qdk/chemistry/data/majorana_mapping.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping.cpp
@@ -40,7 +40,7 @@ MajoranaMapping::MajoranaMapping(
     std::vector<std::pair<std::complex<double>, SparsePauliWord>> bilinears,
     std::string name, std::size_t num_modes, std::size_t num_qubits,
     std::string base_encoding, std::optional<TaperingSpecification> tapering,
-    std::size_t grid_nx, std::size_t grid_ny)
+    std::vector<std::pair<std::complex<double>, SparsePauliWord>> stabilizers)
     : table_(std::move(table)),
       bilinears_(std::move(bilinears)),
       name_(std::move(name)),
@@ -49,8 +49,7 @@ MajoranaMapping::MajoranaMapping(
       num_qubits_(num_qubits),
       majorana_atomic_(!table_.empty()),
       tapering_(std::move(tapering)),
-      grid_nx_(grid_nx),
-      grid_ny_(grid_ny) {
+      stabilizers_(std::move(stabilizers)) {
   if (base_encoding_.empty()) {
     base_encoding_ = name_;
   }
@@ -168,8 +167,8 @@ MajoranaMapping::bilinear(std::size_t j, std::size_t k) const {
 
 MajoranaMapping MajoranaMapping::without_tapering() const {
   return MajoranaMapping(table_, bilinears_, base_encoding_, num_modes_,
-                         num_qubits_, base_encoding_, std::nullopt, grid_nx_,
-                         grid_ny_);
+                         num_qubits_, base_encoding_, std::nullopt,
+                         stabilizers_);
 }
 
 std::string MajoranaMapping::get_summary() const {
@@ -179,8 +178,8 @@ std::string MajoranaMapping::get_summary() const {
     ss << " '" << name_ << "'";
   }
   ss << "\n  Modes: " << num_modes_ << "\n  Qubits: " << num_qubits_;
-  if (grid_nx_ > 0 || grid_ny_ > 0) {
-    ss << "\n  Grid: " << grid_nx_ << "x" << grid_ny_;
+  if (!stabilizers_.empty()) {
+    ss << "\n  Stabilizers: " << stabilizers_.size();
   }
   if (tapering_) {
     ss << "\n  Tapered qubits: " << tapering_->num_tapered();
@@ -196,9 +195,13 @@ nlohmann::json MajoranaMapping::to_json() const {
   if (tapering_) {
     data["tapering"] = tapering_->to_json();
   }
-  if (grid_nx_ > 0 || grid_ny_ > 0) {
-    data["grid_nx"] = grid_nx_;
-    data["grid_ny"] = grid_ny_;
+  if (!stabilizers_.empty()) {
+    nlohmann::json stab_array = nlohmann::json::array();
+    for (const auto& [coeff, word] : stabilizers_) {
+      stab_array.push_back(
+          {{"real", coeff.real()}, {"imag", coeff.imag()}, {"word", word}});
+    }
+    data["stabilizers"] = stab_array;
   }
   // Bilinear-only mappings: persist the bilinear entries so the mapping can
   // round-trip even when the Majorana table is empty.
@@ -233,8 +236,16 @@ MajoranaMapping MajoranaMapping::from_json(const nlohmann::json& data) {
   if (data.contains("tapering") && !data.at("tapering").is_null()) {
     tapering = TaperingSpecification::from_json(data.at("tapering"));
   }
-  std::size_t grid_nx = data.value("grid_nx", 0);
-  std::size_t grid_ny = data.value("grid_ny", 0);
+  std::vector<std::pair<std::complex<double>, SparsePauliWord>> stabilizers;
+  if (data.contains("stabilizers") && !data.at("stabilizers").is_null()) {
+    for (const auto& entry : data.at("stabilizers")) {
+      double real = entry.at("real").get<double>();
+      double imag = entry.at("imag").get<double>();
+      auto word = entry.at("word").get<SparsePauliWord>();
+      stabilizers.emplace_back(std::complex<double>(real, imag),
+                               std::move(word));
+    }
+  }
 
   // Bilinear-only mapping: table is empty, bilinears stored explicitly.
   if (table.empty() && data.contains("bilinears")) {
@@ -251,14 +262,14 @@ MajoranaMapping MajoranaMapping::from_json(const nlohmann::json& data) {
     return MajoranaMapping(mapping.table_, mapping.bilinears_, std::move(name),
                            mapping.num_modes_, mapping.num_qubits_,
                            std::move(base_encoding), std::move(tapering),
-                           grid_nx, grid_ny);
+                           std::move(stabilizers));
   }
 
   auto mapping = MajoranaMapping::from_table(std::move(table), base_encoding);
   return MajoranaMapping(mapping.table_, mapping.bilinears_, std::move(name),
                          mapping.num_modes_, mapping.num_qubits_,
-                         std::move(base_encoding), std::move(tapering), grid_nx,
-                         grid_ny);
+                         std::move(base_encoding), std::move(tapering),
+                         std::move(stabilizers));
 }
 
 void MajoranaMapping::to_json_file(const std::string& filename) const {

--- a/cpp/src/qdk/chemistry/data/majorana_mapping.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping.cpp
@@ -16,6 +16,35 @@
 #include <vector>
 
 namespace qdk::chemistry::data {
+namespace detail {
+
+nlohmann::json stabilizers_to_json(
+    const std::vector<std::pair<std::complex<double>, SparsePauliWord>>&
+        stabilizers) {
+  nlohmann::json stab_array = nlohmann::json::array();
+  for (const auto& [coeff, word] : stabilizers) {
+    stab_array.push_back(
+        {{"real", coeff.real()}, {"imag", coeff.imag()}, {"word", word}});
+  }
+  return stab_array;
+}
+
+std::vector<std::pair<std::complex<double>, SparsePauliWord>>
+stabilizers_from_json(const nlohmann::json& data) {
+  std::vector<std::pair<std::complex<double>, SparsePauliWord>> stabilizers;
+  if (data.is_array()) {
+    for (const auto& entry : data) {
+      double real = entry.at("real").get<double>();
+      double imag = entry.at("imag").get<double>();
+      auto word = entry.at("word").get<SparsePauliWord>();
+      stabilizers.emplace_back(std::complex<double>(real, imag),
+                               std::move(word));
+    }
+  }
+  return stabilizers;
+}
+
+}  // namespace detail
 
 static void hash_sparse_pauli_word(qdk::chemistry::utils::HashContext& ctx,
                                    const SparsePauliWord& word) {
@@ -196,12 +225,7 @@ nlohmann::json MajoranaMapping::to_json() const {
     data["tapering"] = tapering_->to_json();
   }
   if (!stabilizers_.empty()) {
-    nlohmann::json stab_array = nlohmann::json::array();
-    for (const auto& [coeff, word] : stabilizers_) {
-      stab_array.push_back(
-          {{"real", coeff.real()}, {"imag", coeff.imag()}, {"word", word}});
-    }
-    data["stabilizers"] = stab_array;
+    data["stabilizers"] = detail::stabilizers_to_json(stabilizers_);
   }
   // Bilinear-only mappings: persist the bilinear entries so the mapping can
   // round-trip even when the Majorana table is empty.
@@ -238,13 +262,7 @@ MajoranaMapping MajoranaMapping::from_json(const nlohmann::json& data) {
   }
   std::vector<std::pair<std::complex<double>, SparsePauliWord>> stabilizers;
   if (data.contains("stabilizers") && !data.at("stabilizers").is_null()) {
-    for (const auto& entry : data.at("stabilizers")) {
-      double real = entry.at("real").get<double>();
-      double imag = entry.at("imag").get<double>();
-      auto word = entry.at("word").get<SparsePauliWord>();
-      stabilizers.emplace_back(std::complex<double>(real, imag),
-                               std::move(word));
-    }
+    stabilizers = detail::stabilizers_from_json(data.at("stabilizers"));
   }
 
   // Bilinear-only mapping: table is empty, bilinears stored explicitly.
@@ -259,6 +277,9 @@ MajoranaMapping MajoranaMapping::from_json(const nlohmann::json& data) {
     }
     auto mapping = MajoranaMapping::from_bilinears(
         num_modes, std::move(bilinears), base_encoding);
+    if (name == base_encoding && !tapering && stabilizers.empty()) {
+      return mapping;
+    }
     return MajoranaMapping(mapping.table_, mapping.bilinears_, std::move(name),
                            mapping.num_modes_, mapping.num_qubits_,
                            std::move(base_encoding), std::move(tapering),
@@ -266,6 +287,9 @@ MajoranaMapping MajoranaMapping::from_json(const nlohmann::json& data) {
   }
 
   auto mapping = MajoranaMapping::from_table(std::move(table), base_encoding);
+  if (name == base_encoding && !tapering && stabilizers.empty()) {
+    return mapping;
+  }
   return MajoranaMapping(mapping.table_, mapping.bilinears_, std::move(name),
                          mapping.num_modes_, mapping.num_qubits_,
                          std::move(base_encoding), std::move(tapering),

--- a/cpp/src/qdk/chemistry/data/majorana_mapping.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping.cpp
@@ -39,7 +39,8 @@ MajoranaMapping::MajoranaMapping(
     std::vector<SparsePauliWord> table,
     std::vector<std::pair<std::complex<double>, SparsePauliWord>> bilinears,
     std::string name, std::size_t num_modes, std::size_t num_qubits,
-    std::string base_encoding, std::optional<TaperingSpecification> tapering)
+    std::string base_encoding, std::optional<TaperingSpecification> tapering,
+    std::size_t grid_nx, std::size_t grid_ny)
     : table_(std::move(table)),
       bilinears_(std::move(bilinears)),
       name_(std::move(name)),
@@ -47,7 +48,9 @@ MajoranaMapping::MajoranaMapping(
       num_modes_(num_modes),
       num_qubits_(num_qubits),
       majorana_atomic_(!table_.empty()),
-      tapering_(std::move(tapering)) {
+      tapering_(std::move(tapering)),
+      grid_nx_(grid_nx),
+      grid_ny_(grid_ny) {
   if (base_encoding_.empty()) {
     base_encoding_ = name_;
   }
@@ -165,7 +168,8 @@ MajoranaMapping::bilinear(std::size_t j, std::size_t k) const {
 
 MajoranaMapping MajoranaMapping::without_tapering() const {
   return MajoranaMapping(table_, bilinears_, base_encoding_, num_modes_,
-                         num_qubits_, base_encoding_);
+                         num_qubits_, base_encoding_, std::nullopt, grid_nx_,
+                         grid_ny_);
 }
 
 std::string MajoranaMapping::get_summary() const {
@@ -175,6 +179,9 @@ std::string MajoranaMapping::get_summary() const {
     ss << " '" << name_ << "'";
   }
   ss << "\n  Modes: " << num_modes_ << "\n  Qubits: " << num_qubits_;
+  if (grid_nx_ > 0 || grid_ny_ > 0) {
+    ss << "\n  Grid: " << grid_nx_ << "x" << grid_ny_;
+  }
   if (tapering_) {
     ss << "\n  Tapered qubits: " << tapering_->num_tapered();
   }
@@ -188,6 +195,10 @@ nlohmann::json MajoranaMapping::to_json() const {
                       {"base_encoding", base_encoding_}};
   if (tapering_) {
     data["tapering"] = tapering_->to_json();
+  }
+  if (grid_nx_ > 0 || grid_ny_ > 0) {
+    data["grid_nx"] = grid_nx_;
+    data["grid_ny"] = grid_ny_;
   }
   // Bilinear-only mappings: persist the bilinear entries so the mapping can
   // round-trip even when the Majorana table is empty.
@@ -222,6 +233,8 @@ MajoranaMapping MajoranaMapping::from_json(const nlohmann::json& data) {
   if (data.contains("tapering") && !data.at("tapering").is_null()) {
     tapering = TaperingSpecification::from_json(data.at("tapering"));
   }
+  std::size_t grid_nx = data.value("grid_nx", 0);
+  std::size_t grid_ny = data.value("grid_ny", 0);
 
   // Bilinear-only mapping: table is empty, bilinears stored explicitly.
   if (table.empty() && data.contains("bilinears")) {
@@ -235,21 +248,17 @@ MajoranaMapping MajoranaMapping::from_json(const nlohmann::json& data) {
     }
     auto mapping = MajoranaMapping::from_bilinears(
         num_modes, std::move(bilinears), base_encoding);
-    if (name == base_encoding && !tapering) {
-      return mapping;
-    }
     return MajoranaMapping(mapping.table_, mapping.bilinears_, std::move(name),
                            mapping.num_modes_, mapping.num_qubits_,
-                           std::move(base_encoding), std::move(tapering));
+                           std::move(base_encoding), std::move(tapering),
+                           grid_nx, grid_ny);
   }
 
   auto mapping = MajoranaMapping::from_table(std::move(table), base_encoding);
-  if (name == base_encoding && !tapering) {
-    return mapping;
-  }
   return MajoranaMapping(mapping.table_, mapping.bilinears_, std::move(name),
                          mapping.num_modes_, mapping.num_qubits_,
-                         std::move(base_encoding), std::move(tapering));
+                         std::move(base_encoding), std::move(tapering), grid_nx,
+                         grid_ny);
 }
 
 void MajoranaMapping::to_json_file(const std::string& filename) const {

--- a/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
@@ -3,7 +3,9 @@
 // license information.
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
+#include <qdk/chemistry/data/lattice_graph.hpp>
 #include <qdk/chemistry/data/majorana_mapping.hpp>
 #include <qdk/chemistry/data/tapering.hpp>
 #include <stdexcept>
@@ -331,6 +333,163 @@ MajoranaMapping MajoranaMapping::symmetry_conserving_bravyi_kitaev(
                          "symmetry-conserving-bravyi-kitaev", base.num_modes_,
                          base.num_qubits_, "bravyi-kitaev-tree",
                          std::move(tapering));
+}
+
+namespace detail {
+
+std::pair<std::uint64_t, std::uint64_t> snake_coordinates(std::uint64_t index,
+                                                          std::uint64_t nx,
+                                                          std::uint64_t ny) {
+  std::uint64_t row = index / nx;
+  std::uint64_t col;
+  if (row % 2 == 0) {
+    col = index % nx;
+  } else {
+    col = nx - 1 - (index % nx);
+  }
+  return {col, row};
+}
+
+bool is_vertical_edge(std::uint64_t i, std::uint64_t j, std::uint64_t nx,
+                      std::uint64_t ny) {
+  auto [ix, iy] = snake_coordinates(i, nx, ny);
+  auto [jx, jy] = snake_coordinates(j, nx, ny);
+  return (ix == jx && (iy + 1 == jy || jy + 1 == iy));
+}
+
+}  // namespace detail
+
+MajoranaMapping MajoranaMapping::verstraete_cirac(
+    const LatticeGraph& lattice, std::size_t num_spin_species) {
+  if (num_spin_species == 0) {
+    throw std::invalid_argument(
+        "verstraete_cirac requires num_spin_species > 0");
+  }
+
+  std::uint64_t V = lattice.num_sites();
+  std::uint64_t E = lattice.num_edges();
+
+  // Solve: nx * ny = V, nx + ny = 2V - E
+  double b = double(2 * V - E);
+  double c = double(V);
+  double disc = b * b - 4.0 * c;
+  if (disc < 0) {
+    throw std::invalid_argument(
+        "Lattice graph is not a 2D square lattice with open boundaries");
+  }
+  double r1 = 0.5 * (b - std::sqrt(disc));
+  double r2 = 0.5 * (b + std::sqrt(disc));
+  std::uint64_t nx1 = std::round(r1);
+  std::uint64_t nx2 = std::round(r2);
+
+  auto check_nx = [&](std::uint64_t nx) -> bool {
+    if (nx == 0 || V % nx != 0) return false;
+    std::uint64_t ny = V / nx;
+    std::uint64_t count = 0;
+    const auto& adj = lattice.sparse_adjacency_matrix();
+    for (int k = 0; k < adj.outerSize(); ++k) {
+      for (Eigen::SparseMatrix<double>::InnerIterator it(adj, k); it; ++it) {
+        std::uint64_t i = it.row();
+        std::uint64_t j = it.col();
+        if (i >= j) continue;
+        if (std::abs(int(i - j)) == 1) {
+          if (std::min(i, j) % nx == nx - 1) return false;
+          count++;
+        } else if (std::abs(int(i - j)) == nx) {
+          count++;
+        } else {
+          return false;
+        }
+      }
+    }
+    return count == E;
+  };
+
+  std::uint64_t nx = 0, ny = 0;
+  if (check_nx(nx1)) {
+    nx = nx1;
+    ny = V / nx1;
+  } else if (check_nx(nx2)) {
+    nx = nx2;
+    ny = V / nx2;
+  } else {
+    throw std::invalid_argument(
+        "Lattice graph is not a 2D square lattice with open boundaries");
+  }
+
+  if (nx < 2 || ny < 2) {
+    throw std::invalid_argument(
+        "verstraete_cirac requires a 2D grid of size at least 2x2");
+  }
+
+  std::size_t num_modes = num_spin_species * V;
+  // Combined system has 2 * num_modes modes.
+  std::size_t base_modes = 2 * num_modes;
+  auto jw_base = MajoranaMapping::jordan_wigner(base_modes);
+
+  // Construct upper triangle of bilinears: M * (M - 1) / 2 entries, where M = 2
+  // * num_modes.
+  std::size_t M = 2 * num_modes;
+  std::vector<std::pair<std::complex<double>, SparsePauliWord>> upper_triangle;
+  upper_triangle.reserve(M * (M - 1) / 2);
+
+  for (std::size_t u = 0; u < M; ++u) {
+    for (std::size_t v = u + 1; v < M; ++v) {
+      std::size_t u_mode = u / 2;
+      std::size_t v_mode = v / 2;
+      std::size_t s_u = u_mode / V;
+      std::size_t s_v = v_mode / V;
+      std::size_t i = u_mode % V;
+      std::size_t j = v_mode % V;
+      std::size_t a = u % 2;
+      std::size_t b_idx = v % 2;
+
+      if (s_u == s_v && detail::is_vertical_edge(i, j, nx, ny)) {
+        // Vertical edge: multiply by stabilizer
+        std::uint64_t top = std::min(i, j);
+        std::uint64_t bot = std::max(i, j);
+        auto coord_top = detail::snake_coordinates(top, nx, ny);
+        std::uint64_t col = coord_top.first;
+
+        std::size_t top_aux_mode = 2 * s_u * V + 2 * top + 1;
+        std::size_t bot_aux_mode = 2 * s_u * V + 2 * bot + 1;
+
+        std::size_t p, q;
+        if (col % 2 == 0) {
+          p = 2 * top_aux_mode;
+          q = 2 * bot_aux_mode + 1;
+        } else {
+          p = 2 * bot_aux_mode;
+          q = 2 * top_aux_mode + 1;
+        }
+
+        // Stabilizer S = i * gamma_p * gamma_q
+        auto [coeff_stab, word_stab] = jw_base.bilinear(p, q);
+
+        // System modes:
+        std::size_t r = 2 * (2 * s_u * V + 2 * i) + a;
+        std::size_t s_jw = 2 * (2 * s_v * V + 2 * j) + b_idx;
+        auto [coeff_sys, word_sys] = jw_base.bilinear(r, s_jw);
+
+        auto [phase, word_final] =
+            PauliTermAccumulator::multiply_uncached(word_sys, word_stab);
+        std::complex<double> coeff_final = coeff_sys * coeff_stab * phase;
+
+        upper_triangle.emplace_back(coeff_final, std::move(word_final));
+      } else {
+        // Not a vertical edge
+        std::size_t r = 2 * (2 * s_u * V + 2 * i) + a;
+        std::size_t s_jw = 2 * (2 * s_v * V + 2 * j) + b_idx;
+        auto [coeff, word] = jw_base.bilinear(r, s_jw);
+        upper_triangle.emplace_back(coeff, word);
+      }
+    }
+  }
+
+  return MajoranaMapping(std::vector<SparsePauliWord>{},
+                         std::move(upper_triangle), "verstraete-cirac",
+                         num_modes, 2 * num_modes, "verstraete-cirac",
+                         std::nullopt, nx, ny);
 }
 
 }  // namespace qdk::chemistry::data

--- a/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
@@ -8,6 +8,7 @@
 #include <qdk/chemistry/data/lattice_graph.hpp>
 #include <qdk/chemistry/data/majorana_mapping.hpp>
 #include <qdk/chemistry/data/tapering.hpp>
+#include <queue>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -108,6 +109,39 @@ SparsePauliWord build_sorted_word(
 constexpr std::uint8_t op_x = 1;
 constexpr std::uint8_t op_y = 2;
 constexpr std::uint8_t op_z = 3;
+
+bool find_hamiltonian_path_dfs(
+    std::uint64_t curr, const std::vector<std::vector<std::uint64_t>>& adj,
+    std::vector<bool>& visited, std::vector<std::uint64_t>& path) {
+  path.push_back(curr);
+  if (path.size() == adj.size()) {
+    return true;
+  }
+  visited[curr] = true;
+  for (std::uint64_t neighbor : adj[curr]) {
+    if (!visited[neighbor]) {
+      if (find_hamiltonian_path_dfs(neighbor, adj, visited, path)) {
+        return true;
+      }
+    }
+  }
+  visited[curr] = false;
+  path.pop_back();
+  return false;
+}
+
+std::vector<std::uint64_t> find_hamiltonian_path(
+    const std::vector<std::vector<std::uint64_t>>& adj) {
+  std::uint64_t V = adj.size();
+  std::vector<bool> visited(V, false);
+  std::vector<std::uint64_t> path;
+  for (std::uint64_t start = 0; start < V; ++start) {
+    if (find_hamiltonian_path_dfs(start, adj, visited, path)) {
+      return path;
+    }
+  }
+  return {};
+}
 
 }  // namespace detail
 
@@ -335,101 +369,133 @@ MajoranaMapping MajoranaMapping::symmetry_conserving_bravyi_kitaev(
                          std::move(tapering));
 }
 
-namespace detail {
-
-std::pair<std::uint64_t, std::uint64_t> snake_coordinates(std::uint64_t index,
-                                                          std::uint64_t nx,
-                                                          std::uint64_t ny) {
-  std::uint64_t row = index / nx;
-  std::uint64_t col;
-  if (row % 2 == 0) {
-    col = index % nx;
-  } else {
-    col = nx - 1 - (index % nx);
-  }
-  return {col, row};
-}
-
-bool is_vertical_edge(std::uint64_t i, std::uint64_t j, std::uint64_t nx,
-                      std::uint64_t ny) {
-  auto [ix, iy] = snake_coordinates(i, nx, ny);
-  auto [jx, jy] = snake_coordinates(j, nx, ny);
-  return (ix == jx && (iy + 1 == jy || jy + 1 == iy));
-}
-
-}  // namespace detail
+// ── Factory: Verstraete-Cirac ──────────────────────────────────────────
 
 MajoranaMapping MajoranaMapping::verstraete_cirac(
     const LatticeGraph& lattice, std::size_t num_spin_species) {
+  using namespace detail;
+  const std::string name = "verstraete-cirac";
   if (num_spin_species == 0) {
-    throw std::invalid_argument(
-        "verstraete_cirac requires num_spin_species > 0");
+    throw std::invalid_argument(name + " requires num_spin_species > 0");
   }
-
   std::uint64_t V = lattice.num_sites();
-  std::uint64_t E = lattice.num_edges();
-
-  // Solve: nx * ny = V, nx + ny = 2V - E
-  double b = double(2 * V - E);
-  double c = double(V);
-  double disc = b * b - 4.0 * c;
-  if (disc < 0) {
+  if (V < 3) {
     throw std::invalid_argument(
-        "Lattice graph is not a 2D square lattice with open boundaries");
+        name + " requires a lattice graph with at least 3 sites");
   }
-  double r1 = 0.5 * (b - std::sqrt(disc));
-  double r2 = 0.5 * (b + std::sqrt(disc));
-  std::uint64_t nx1 = std::round(r1);
-  std::uint64_t nx2 = std::round(r2);
 
-  auto check_nx = [&](std::uint64_t nx) -> bool {
-    if (nx == 0 || V % nx != 0) return false;
-    std::uint64_t ny = V / nx;
-    std::uint64_t count = 0;
-    const auto& adj = lattice.sparse_adjacency_matrix();
-    for (int k = 0; k < adj.outerSize(); ++k) {
-      for (Eigen::SparseMatrix<double>::InnerIterator it(adj, k); it; ++it) {
-        std::uint64_t i = it.row();
-        std::uint64_t j = it.col();
-        if (i >= j) continue;
-        if (std::abs(int(i - j)) == 1) {
-          if (std::min(i, j) % nx == nx - 1) return false;
-          count++;
-        } else if (std::abs(int(i - j)) == nx) {
-          count++;
-        } else {
-          return false;
-        }
+  // Find all edges in the lattice (upper triangle of adjacency matrix)
+  std::vector<std::vector<std::uint64_t>> adj_list(V);
+  const auto& adj = lattice.sparse_adjacency_matrix();
+  for (int k = 0; k < adj.outerSize(); ++k) {
+    for (Eigen::SparseMatrix<double>::InnerIterator it(adj, k); it; ++it) {
+      std::uint64_t u = it.row();
+      std::uint64_t v = it.col();
+      if (u != v) {
+        adj_list[u].push_back(v);
       }
     }
-    return count == E;
-  };
-
-  std::uint64_t nx = 0, ny = 0;
-  if (check_nx(nx1)) {
-    nx = nx1;
-    ny = V / nx1;
-  } else if (check_nx(nx2)) {
-    nx = nx2;
-    ny = V / nx2;
-  } else {
-    throw std::invalid_argument(
-        "Lattice graph is not a 2D square lattice with open boundaries");
   }
 
-  if (nx < 2 || ny < 2) {
+  // Find Hamiltonian path dynamically directly from the graph adjacency
+  std::vector<std::uint64_t> snake_path = find_hamiltonian_path(adj_list);
+  if (snake_path.empty()) {
     throw std::invalid_argument(
-        "verstraete_cirac requires a 2D grid of size at least 2x2");
+        name +
+        ": No Hamiltonian path found in the lattice graph. A Hamiltonian path "
+        "is required to construct commuting stabilizers.");
+  }
+
+  // Maps row-major site index to its position in the snake path (system mode
+  // order)
+  std::vector<std::uint64_t> rm_to_snake(V);
+  for (std::uint64_t k = 0; k < V; ++k) {
+    rm_to_snake[snake_path[k]] = k;
   }
 
   std::size_t num_modes = num_spin_species * V;
-  // Combined system has 2 * num_modes modes.
   std::size_t base_modes = 2 * num_modes;
+  std::size_t M = 2 * num_modes;
   auto jw_base = MajoranaMapping::jordan_wigner(base_modes);
 
-  // Construct upper triangle of bilinears: M * (M - 1) / 2 entries, where M = 2
-  // * num_modes.
-  std::size_t M = 2 * num_modes;
+  auto get_sys_majorana = [&](std::uint64_t site, std::size_t spin,
+                              std::size_t a) -> std::size_t {
+    std::size_t snake_idx = rm_to_snake[site];
+    return 2 * (2 * (spin * V + snake_idx)) + a;
+  };
+
+  auto get_aux_majorana = [&](std::uint64_t site, std::size_t spin,
+                              std::size_t a) -> std::size_t {
+    std::size_t snake_idx = rm_to_snake[site];
+    return 2 * (2 * (spin * V + snake_idx) + 1) + a;
+  };
+
+  auto get_bilinear =
+      [&](std::size_t p,
+          std::size_t q) -> std::pair<std::complex<double>, SparsePauliWord> {
+    if (p < q) {
+      auto b = jw_base.bilinear(p, q);
+      return {b.first, b.second};
+    } else {
+      auto b = jw_base.bilinear(q, p);
+      return {-b.first, b.second};
+    }
+  };
+
+  // Find all non-path edges incident to each vertex.
+  // An edge (u, v) is a non-path edge if |rm_to_snake[u] - rm_to_snake[v]| > 1.
+  std::vector<std::vector<std::uint64_t>> non_path_incident(V);
+  for (std::uint64_t u = 0; u < V; ++u) {
+    for (std::uint64_t v : adj_list[u]) {
+      if (u < v) {
+        std::size_t s_u = rm_to_snake[u];
+        std::size_t s_v = rm_to_snake[v];
+        std::size_t diff = (s_u > s_v) ? (s_u - s_v) : (s_v - s_u);
+        if (diff > 1) {
+          non_path_incident[u].push_back(v);
+          non_path_incident[v].push_back(u);
+        }
+      }
+    }
+  }
+
+  // Ensure that no vertex has more than 2 non-path edges (auxiliary space
+  // limit)
+  for (std::uint64_t u = 0; u < V; ++u) {
+    if (non_path_incident[u].size() > 2) {
+      throw std::invalid_argument(name + ": Vertex has " +
+                                  std::to_string(non_path_incident[u].size()) +
+                                  " non-path edges, which exceeds the "
+                                  "2-auxiliary-Majorana limit of the mapping.");
+    }
+  }
+
+  std::vector<std::pair<std::complex<double>, SparsePauliWord>> stabilizers;
+  std::vector<std::map<std::pair<std::uint64_t, std::uint64_t>, std::size_t>>
+      edge_to_stab_idx(num_spin_species);
+
+  for (std::size_t spin = 0; spin < num_spin_species; ++spin) {
+    for (std::uint64_t u = 0; u < V; ++u) {
+      for (std::uint64_t v : non_path_incident[u]) {
+        if (u < v) {
+          auto it_u = std::find(non_path_incident[u].begin(),
+                                non_path_incident[u].end(), v);
+          auto it_v = std::find(non_path_incident[v].begin(),
+                                non_path_incident[v].end(), u);
+          std::size_t a = std::distance(non_path_incident[u].begin(), it_u);
+          std::size_t b = std::distance(non_path_incident[v].begin(), it_v);
+
+          std::size_t p = get_aux_majorana(u, spin, a);
+          std::size_t q = get_aux_majorana(v, spin, b);
+
+          auto [coeff, word] = get_bilinear(p, q);
+          edge_to_stab_idx[spin][{u, v}] = stabilizers.size();
+          stabilizers.emplace_back(coeff, std::move(word));
+        }
+      }
+    }
+  }
+
   std::vector<std::pair<std::complex<double>, SparsePauliWord>> upper_triangle;
   upper_triangle.reserve(M * (M - 1) / 2);
 
@@ -444,52 +510,41 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
       std::size_t a = u % 2;
       std::size_t b_idx = v % 2;
 
-      if (s_u == s_v && detail::is_vertical_edge(i, j, nx, ny)) {
-        // Vertical edge: multiply by stabilizer
-        std::uint64_t top = std::min(i, j);
-        std::uint64_t bot = std::max(i, j);
-        auto coord_top = detail::snake_coordinates(top, nx, ny);
-        std::uint64_t col = coord_top.first;
+      bool connected = (s_u == s_v) && lattice.are_connected(i, j);
 
-        std::size_t top_aux_mode = 2 * s_u * V + 2 * top + 1;
-        std::size_t bot_aux_mode = 2 * s_u * V + 2 * bot + 1;
+      if (connected) {
+        std::size_t snake_i = rm_to_snake[i];
+        std::size_t snake_j = rm_to_snake[j];
+        std::size_t snake_min = std::min(snake_i, snake_j);
+        std::size_t snake_max = std::max(snake_i, snake_j);
 
-        std::size_t p, q;
-        if (col % 2 == 0) {
-          p = 2 * top_aux_mode;
-          q = 2 * bot_aux_mode + 1;
-        } else {
-          p = 2 * bot_aux_mode;
-          q = 2 * top_aux_mode + 1;
+        std::size_t p = get_sys_majorana(i, s_u, a);
+        std::size_t q = get_sys_majorana(j, s_v, b_idx);
+        auto [coeff, word] = get_bilinear(p, q);
+
+        if (snake_max - snake_min > 1) {
+          auto key = std::make_pair(std::min(i, j), std::max(i, j));
+          std::size_t stab_idx = edge_to_stab_idx[s_u].at(key);
+          const auto& stab = stabilizers[stab_idx];
+          auto [phase, new_word] =
+              PauliTermAccumulator::multiply_uncached(word, stab.second);
+          coeff *= stab.first * phase;
+          word = std::move(new_word);
         }
 
-        // Stabilizer S = i * gamma_p * gamma_q
-        auto [coeff_stab, word_stab] = jw_base.bilinear(p, q);
-
-        // System modes:
-        std::size_t r = 2 * (2 * s_u * V + 2 * i) + a;
-        std::size_t s_jw = 2 * (2 * s_v * V + 2 * j) + b_idx;
-        auto [coeff_sys, word_sys] = jw_base.bilinear(r, s_jw);
-
-        auto [phase, word_final] =
-            PauliTermAccumulator::multiply_uncached(word_sys, word_stab);
-        std::complex<double> coeff_final = coeff_sys * coeff_stab * phase;
-
-        upper_triangle.emplace_back(coeff_final, std::move(word_final));
+        upper_triangle.emplace_back(coeff, std::move(word));
       } else {
-        // Not a vertical edge
-        std::size_t r = 2 * (2 * s_u * V + 2 * i) + a;
-        std::size_t s_jw = 2 * (2 * s_v * V + 2 * j) + b_idx;
-        auto [coeff, word] = jw_base.bilinear(r, s_jw);
-        upper_triangle.emplace_back(coeff, word);
+        std::size_t p = get_sys_majorana(i, s_u, a);
+        std::size_t q = get_sys_majorana(j, s_v, b_idx);
+        auto [coeff, word] = get_bilinear(p, q);
+        upper_triangle.emplace_back(coeff, std::move(word));
       }
     }
   }
 
   return MajoranaMapping(std::vector<SparsePauliWord>{},
-                         std::move(upper_triangle), "verstraete-cirac",
-                         num_modes, 2 * num_modes, "verstraete-cirac",
-                         std::nullopt, nx, ny);
+                         std::move(upper_triangle), name, num_modes, base_modes,
+                         name, std::nullopt, std::move(stabilizers));
 }
 
 }  // namespace qdk::chemistry::data

--- a/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
@@ -8,7 +8,6 @@
 #include <qdk/chemistry/data/lattice_graph.hpp>
 #include <qdk/chemistry/data/majorana_mapping.hpp>
 #include <qdk/chemistry/data/tapering.hpp>
-#include <queue>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -110,16 +109,20 @@ constexpr std::uint8_t op_x = 1;
 constexpr std::uint8_t op_y = 2;
 constexpr std::uint8_t op_z = 3;
 
-bool find_hamiltonian_path_dfs(
-    std::uint64_t curr, const std::vector<std::vector<std::uint64_t>>& adj,
-    std::vector<bool>& visited, std::vector<std::uint64_t>& path) {
+bool find_hamiltonian_path_dfs(std::uint64_t curr,
+                               const Eigen::SparseMatrix<double>& adj,
+                               std::vector<bool>& visited,
+                               std::vector<std::uint64_t>& path) {
   path.push_back(curr);
-  if (path.size() == adj.size()) {
+  if (path.size() == static_cast<std::size_t>(adj.rows())) {
     return true;
   }
   visited[curr] = true;
-  for (std::uint64_t neighbor : adj[curr]) {
-    if (!visited[neighbor]) {
+
+  // Iterate directly over the sparse matrix columns/rows for neighbors
+  for (Eigen::SparseMatrix<double>::InnerIterator it(adj, curr); it; ++it) {
+    std::uint64_t neighbor = it.row();
+    if (neighbor != curr && !visited[neighbor]) {
       if (find_hamiltonian_path_dfs(neighbor, adj, visited, path)) {
         return true;
       }
@@ -131,8 +134,8 @@ bool find_hamiltonian_path_dfs(
 }
 
 std::vector<std::uint64_t> find_hamiltonian_path(
-    const std::vector<std::vector<std::uint64_t>>& adj) {
-  std::uint64_t V = adj.size();
+    const Eigen::SparseMatrix<double>& adj) {
+  std::uint64_t V = adj.rows();
   std::vector<bool> visited(V, false);
   std::vector<std::uint64_t> path;
   for (std::uint64_t start = 0; start < V; ++start) {
@@ -375,61 +378,52 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
     const LatticeGraph& lattice, std::size_t num_spin_species) {
   using namespace detail;
   const std::string name = "verstraete-cirac";
-  if (num_spin_species == 0) {
-    throw std::invalid_argument(name + " requires num_spin_species > 0");
+
+  // Support spinless or fermions with spin-½
+  if (num_spin_species != 1 && num_spin_species != 2) {
+    throw std::invalid_argument(name +
+                                " requires num_spin_species to be 1 or 2.");
   }
+
   std::uint64_t V = lattice.num_sites();
   if (V < 3) {
     throw std::invalid_argument(
         name + " requires a lattice graph with at least 3 sites");
   }
 
-  // Find all edges in the lattice (upper triangle of adjacency matrix)
-  std::vector<std::vector<std::uint64_t>> adj_list(V);
+  // Construct a Hamiltonian path from the graph adjacency matrix
   const auto& adj = lattice.sparse_adjacency_matrix();
-  for (int k = 0; k < adj.outerSize(); ++k) {
-    for (Eigen::SparseMatrix<double>::InnerIterator it(adj, k); it; ++it) {
-      std::uint64_t u = it.row();
-      std::uint64_t v = it.col();
-      if (u != v) {
-        adj_list[u].push_back(v);
-      }
-    }
-  }
-
-  // Find Hamiltonian path dynamically directly from the graph adjacency
-  std::vector<std::uint64_t> snake_path = find_hamiltonian_path(adj_list);
-  if (snake_path.empty()) {
-    throw std::invalid_argument(
+  std::vector<std::uint64_t> hamiltonian_path = find_hamiltonian_path(adj);
+  if (hamiltonian_path.empty()) {
+    throw std::runtime_error(
         name +
         ": No Hamiltonian path found in the lattice graph. A Hamiltonian path "
         "is required to construct commuting stabilizers.");
   }
 
-  // Maps row-major site index to its position in the snake path (system mode
-  // order)
-  std::vector<std::uint64_t> rm_to_snake(V);
+  // Map row-major site index to its position in the Hamiltonian path
+  std::vector<std::uint64_t> site_to_path_idx(V);
   for (std::uint64_t k = 0; k < V; ++k) {
-    rm_to_snake[snake_path[k]] = k;
+    site_to_path_idx[hamiltonian_path[k]] = k;
   }
 
   std::size_t num_modes = num_spin_species * V;
   std::size_t base_modes = 2 * num_modes;
-  std::size_t M = 2 * num_modes;
   auto jw_base = MajoranaMapping::jordan_wigner(base_modes);
 
   auto get_sys_majorana = [&](std::uint64_t site, std::size_t spin,
-                              std::size_t a) -> std::size_t {
-    std::size_t snake_idx = rm_to_snake[site];
-    return 2 * (2 * (spin * V + snake_idx)) + a;
+                              std::size_t offset) -> std::size_t {
+    std::size_t path_idx = site_to_path_idx[site];
+    return 2 * (2 * (spin * V + path_idx)) + offset;
   };
 
   auto get_aux_majorana = [&](std::uint64_t site, std::size_t spin,
-                              std::size_t a) -> std::size_t {
-    std::size_t snake_idx = rm_to_snake[site];
-    return 2 * (2 * (spin * V + snake_idx) + 1) + a;
+                              std::size_t offset) -> std::size_t {
+    std::size_t path_idx = site_to_path_idx[site];
+    return 2 * (2 * (spin * V + path_idx) + 1) + offset;
   };
 
+  // Get a Pauli representation of the antisymmetric Majorana bilinear iγ_pγ_q
   auto get_bilinear =
       [&](std::size_t p,
           std::size_t q) -> std::pair<std::complex<double>, SparsePauliWord> {
@@ -442,14 +436,16 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
     }
   };
 
-  // Find all non-path edges incident to each vertex.
-  // An edge (u, v) is a non-path edge if |rm_to_snake[u] - rm_to_snake[v]| > 1.
+  // Find all non-path edges incident to each vertex
   std::vector<std::vector<std::uint64_t>> non_path_incident(V);
-  for (std::uint64_t u = 0; u < V; ++u) {
-    for (std::uint64_t v : adj_list[u]) {
+  for (int k = 0; k < adj.outerSize(); ++k) {
+    for (Eigen::SparseMatrix<double>::InnerIterator it(adj, k); it; ++it) {
+      std::uint64_t u = it.row();
+      std::uint64_t v = it.col();
+      // Since the matrix is symmetric, only process the upper-triangle
       if (u < v) {
-        std::size_t s_u = rm_to_snake[u];
-        std::size_t s_v = rm_to_snake[v];
+        std::size_t s_u = site_to_path_idx[u];
+        std::size_t s_v = site_to_path_idx[v];
         std::size_t diff = (s_u > s_v) ? (s_u - s_v) : (s_v - s_u);
         if (diff > 1) {
           non_path_incident[u].push_back(v);
@@ -459,14 +455,13 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
     }
   }
 
-  // Ensure that no vertex has more than 2 non-path edges (auxiliary space
-  // limit)
+  // Ensure that we have no more than 1 aux Majorana mode per sys mode
   for (std::uint64_t u = 0; u < V; ++u) {
     if (non_path_incident[u].size() > 2) {
-      throw std::invalid_argument(name + ": Vertex has " +
-                                  std::to_string(non_path_incident[u].size()) +
-                                  " non-path edges, which exceeds the "
-                                  "2-auxiliary-Majorana limit of the mapping.");
+      throw std::runtime_error(name + ": Vertex has " +
+                               std::to_string(non_path_incident[u].size()) +
+                               " non-path edges, which exceeds the "
+                               "2-auxiliary-Majorana limit of the mapping.");
     }
   }
 
@@ -475,6 +470,7 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
       edge_to_stab_idx(num_spin_species);
 
   for (std::size_t spin = 0; spin < num_spin_species; ++spin) {
+    // Add 2-body link stabilizers for non-path edges on the lattice
     for (std::uint64_t u = 0; u < V; ++u) {
       for (std::uint64_t v : non_path_incident[u]) {
         if (u < v) {
@@ -490,17 +486,39 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
 
           auto [coeff, word] = get_bilinear(p, q);
           edge_to_stab_idx[spin][{u, v}] = stabilizers.size();
+          edge_to_stab_idx[spin][{v, u}] = stabilizers.size();
           stabilizers.emplace_back(coeff, std::move(word));
         }
+      }
+    }
+
+    // Identify and pair up any remaining unused aux Majorana modes to
+    // lift boundary/corner codespace degeneracy
+    std::vector<std::size_t> unpaired_modes;
+    for (std::uint64_t u = 0; u < V; ++u) {
+      if (non_path_incident[u].size() == 1) {
+        unpaired_modes.push_back(get_aux_majorana(u, spin, 1));
+      } else if (non_path_incident[u].size() == 0) {
+        unpaired_modes.push_back(get_aux_majorana(u, spin, 0));
+        unpaired_modes.push_back(get_aux_majorana(u, spin, 1));
+      }
+    }
+
+    // Unused aux Majorana modes become trivial stabilizers
+    for (std::size_t i = 0; i < unpaired_modes.size(); i += 2) {
+      if (i + 1 < unpaired_modes.size()) {
+        auto [coeff, word] =
+            get_bilinear(unpaired_modes[i], unpaired_modes[i + 1]);
+        stabilizers.emplace_back(coeff, std::move(word));
       }
     }
   }
 
   std::vector<std::pair<std::complex<double>, SparsePauliWord>> upper_triangle;
-  upper_triangle.reserve(M * (M - 1) / 2);
+  upper_triangle.reserve(base_modes * (base_modes - 1) / 2);
 
-  for (std::size_t u = 0; u < M; ++u) {
-    for (std::size_t v = u + 1; v < M; ++v) {
+  for (std::size_t u = 0; u < base_modes; ++u) {
+    for (std::size_t v = u + 1; v < base_modes; ++v) {
       std::size_t u_mode = u / 2;
       std::size_t v_mode = v / 2;
       std::size_t s_u = u_mode / V;
@@ -513,22 +531,26 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
       bool connected = (s_u == s_v) && lattice.are_connected(i, j);
 
       if (connected) {
-        std::size_t snake_i = rm_to_snake[i];
-        std::size_t snake_j = rm_to_snake[j];
-        std::size_t snake_min = std::min(snake_i, snake_j);
-        std::size_t snake_max = std::max(snake_i, snake_j);
+        std::size_t path_i = site_to_path_idx[i];
+        std::size_t path_j = site_to_path_idx[j];
+        std::size_t path_min = std::min(path_i, path_j);
+        std::size_t path_max = std::max(path_i, path_j);
 
         std::size_t p = get_sys_majorana(i, s_u, a);
         std::size_t q = get_sys_majorana(j, s_v, b_idx);
         auto [coeff, word] = get_bilinear(p, q);
 
-        if (snake_max - snake_min > 1) {
+        // For non-local paths, the raw JW bilinear iγ_pγ_q loses its long
+        // Z-string by multiplying by edge stabilizer iγ̃_aγ̃_b
+        if (path_max - path_min > 1) {
           auto key = std::make_pair(std::min(i, j), std::max(i, j));
+          // Fetch the coefficient and Pauli word for the edge
           std::size_t stab_idx = edge_to_stab_idx[s_u].at(key);
-          const auto& stab = stabilizers[stab_idx];
+          const auto& [b_coeff, b_word] = stabilizers[stab_idx];
+
           auto [phase, new_word] =
-              PauliTermAccumulator::multiply_uncached(word, stab.second);
-          coeff *= stab.first * phase;
+              PauliTermAccumulator::multiply_uncached(word, b_word);
+          coeff *= b_coeff * phase;
           word = std::move(new_word);
         }
 

--- a/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
@@ -455,13 +455,14 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
     }
   }
 
-  // Ensure that we have no more than 1 aux Majorana mode per sys mode
+  // Ensure that we have no more than 2 aux Majorana modes per site
   for (std::uint64_t u = 0; u < V; ++u) {
     if (non_path_incident[u].size() > 2) {
-      throw std::runtime_error(name + ": Vertex has " +
-                               std::to_string(non_path_incident[u].size()) +
-                               " non-path edges, which exceeds the "
-                               "2-auxiliary-Majorana limit of the mapping.");
+      throw std::runtime_error(
+          name +
+          " requires no more than 2 aux Majorana modes per "
+          "site. Found vertex with " +
+          std::to_string(non_path_incident[u].size()) + " non-path edges.");
     }
   }
 
@@ -514,6 +515,8 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
     }
   }
 
+  // Build a lookup table of VC bilinears by dressing non-local JW bilinears
+  // with their stabilizer to make everything local.
   std::vector<std::pair<std::complex<double>, SparsePauliWord>> upper_triangle;
   upper_triangle.reserve(base_modes * (base_modes - 1) / 2);
 
@@ -544,7 +547,6 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
         // Z-string by multiplying by edge stabilizer iγ̃_aγ̃_b
         if (path_max - path_min > 1) {
           auto key = std::make_pair(std::min(i, j), std::max(i, j));
-          // Fetch the coefficient and Pauli word for the edge
           std::size_t stab_idx = edge_to_stab_idx[s_u].at(key);
           const auto& [b_coeff, b_word] = stabilizers[stab_idx];
 

--- a/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
@@ -374,16 +374,9 @@ MajoranaMapping MajoranaMapping::symmetry_conserving_bravyi_kitaev(
 
 // ── Factory: Verstraete-Cirac ──────────────────────────────────────────
 
-MajoranaMapping MajoranaMapping::verstraete_cirac(
-    const LatticeGraph& lattice, std::size_t num_spin_species) {
+MajoranaMapping MajoranaMapping::verstraete_cirac(const LatticeGraph& lattice) {
   using namespace detail;
   const std::string name = "verstraete-cirac";
-
-  // Support spinless or fermions with spin-½
-  if (num_spin_species != 1 && num_spin_species != 2) {
-    throw std::invalid_argument(name +
-                                " requires num_spin_species to be 1 or 2.");
-  }
 
   std::uint64_t V = lattice.num_sites();
   if (V < 3) {
@@ -407,35 +400,6 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
     site_to_path_idx[hamiltonian_path[k]] = k;
   }
 
-  std::size_t num_modes = num_spin_species * V;
-  std::size_t base_modes = 2 * num_modes;
-  auto jw_base = MajoranaMapping::jordan_wigner(base_modes);
-
-  auto get_sys_majorana = [&](std::uint64_t site, std::size_t spin,
-                              std::size_t offset) -> std::size_t {
-    std::size_t path_idx = site_to_path_idx[site];
-    return 2 * (2 * (spin * V + path_idx)) + offset;
-  };
-
-  auto get_aux_majorana = [&](std::uint64_t site, std::size_t spin,
-                              std::size_t offset) -> std::size_t {
-    std::size_t path_idx = site_to_path_idx[site];
-    return 2 * (2 * (spin * V + path_idx) + 1) + offset;
-  };
-
-  // Get a Pauli representation of the antisymmetric Majorana bilinear iγ_pγ_q
-  auto get_bilinear =
-      [&](std::size_t p,
-          std::size_t q) -> std::pair<std::complex<double>, SparsePauliWord> {
-    if (p < q) {
-      auto b = jw_base.bilinear(p, q);
-      return {b.first, b.second};
-    } else {
-      auto b = jw_base.bilinear(q, p);
-      return {-b.first, b.second};
-    }
-  };
-
   // Find all non-path edges incident to each vertex
   std::vector<std::vector<std::uint64_t>> non_path_incident(V);
   for (int k = 0; k < adj.outerSize(); ++k) {
@@ -455,22 +419,64 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
     }
   }
 
-  // Ensure that we have no more than 2 aux Majorana modes per site
+  // Count aux fermionic modes per site
+  std::vector<std::size_t> n_aux(V);
+  std::size_t total_n_aux = 0;
   for (std::uint64_t u = 0; u < V; ++u) {
-    if (non_path_incident[u].size() > 2) {
-      throw std::runtime_error(
-          name +
-          " requires no more than 2 aux Majorana modes per "
-          "site. Found vertex with " +
-          std::to_string(non_path_incident[u].size()) + " non-path edges.");
-    }
+    n_aux[u] = (non_path_incident[u].size() + 1) / 2;
+    total_n_aux += n_aux[u];
   }
+
+  std::size_t modes_per_spin = V + total_n_aux;
+  std::size_t num_modes = 2 * V;                 // 2 spin species
+  std::size_t base_qubits = 2 * modes_per_spin;  // total qubits in jw_base
+  std::size_t base_modes = 2 * base_qubits;      // total Majoranas in jw_base
+
+  auto jw_base = MajoranaMapping::jordan_wigner(base_qubits);
+
+  // Precompute mode offsets along the Hamiltonian path
+  std::vector<std::size_t> path_idx_to_mode_offset(V);
+  path_idx_to_mode_offset[0] = 0;
+  for (std::size_t k = 1; k < V; ++k) {
+    std::uint64_t prev_site = hamiltonian_path[k - 1];
+    path_idx_to_mode_offset[k] =
+        path_idx_to_mode_offset[k - 1] + 1 + n_aux[prev_site];
+  }
+
+  auto get_sys_majorana = [&](std::uint64_t site, std::size_t spin,
+                              std::size_t offset) -> std::size_t {
+    std::size_t path_idx = site_to_path_idx[site];
+    std::size_t mode_idx =
+        spin * modes_per_spin + path_idx_to_mode_offset[path_idx];
+    return 2 * mode_idx + offset;
+  };
+
+  auto get_aux_majorana = [&](std::uint64_t site, std::size_t spin,
+                              std::size_t offset) -> std::size_t {
+    std::size_t path_idx = site_to_path_idx[site];
+    std::size_t mode_idx =
+        spin * modes_per_spin + path_idx_to_mode_offset[path_idx];
+    return 2 * (mode_idx + 1) + offset;
+  };
+
+  // Get a Pauli representation of the antisymmetric Majorana bilinear iγ_pγ_q
+  auto get_bilinear =
+      [&](std::size_t p,
+          std::size_t q) -> std::pair<std::complex<double>, SparsePauliWord> {
+    if (p < q) {
+      auto b = jw_base.bilinear(p, q);
+      return {b.first, b.second};
+    } else {
+      auto b = jw_base.bilinear(q, p);
+      return {-b.first, b.second};
+    }
+  };
 
   std::vector<std::pair<std::complex<double>, SparsePauliWord>> stabilizers;
   std::vector<std::map<std::pair<std::uint64_t, std::uint64_t>, std::size_t>>
-      edge_to_stab_idx(num_spin_species);
+      edge_to_stab_idx(2);
 
-  for (std::size_t spin = 0; spin < num_spin_species; ++spin) {
+  for (std::size_t spin = 0; spin < 2; ++spin) {
     // Add 2-body link stabilizers for non-path edges on the lattice
     for (std::uint64_t u = 0; u < V; ++u) {
       for (std::uint64_t v : non_path_incident[u]) {
@@ -497,15 +503,14 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
     // lift boundary/corner codespace degeneracy
     std::vector<std::size_t> unpaired_modes;
     for (std::uint64_t u = 0; u < V; ++u) {
-      if (non_path_incident[u].size() == 1) {
-        unpaired_modes.push_back(get_aux_majorana(u, spin, 1));
-      } else if (non_path_incident[u].size() == 0) {
-        unpaired_modes.push_back(get_aux_majorana(u, spin, 0));
-        unpaired_modes.push_back(get_aux_majorana(u, spin, 1));
+      std::size_t A_u = non_path_incident[u].size();
+      if (A_u % 2 != 0) {
+        unpaired_modes.push_back(get_aux_majorana(u, spin, A_u));
       }
     }
 
     // Unused aux Majorana modes become trivial stabilizers
+    // (we are guaranteed an even number due to the handshaking lemma)
     for (std::size_t i = 0; i < unpaired_modes.size(); i += 2) {
       if (i + 1 < unpaired_modes.size()) {
         auto [coeff, word] =
@@ -516,12 +521,15 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
   }
 
   // Build a lookup table of VC bilinears by dressing non-local JW bilinears
-  // with their stabilizer to make everything local.
+  // with their stabilizer to make everything local
+  std::size_t num_physical_modes = 2 * V;
+  std::size_t num_physical_majoranas = 2 * num_physical_modes;
   std::vector<std::pair<std::complex<double>, SparsePauliWord>> upper_triangle;
-  upper_triangle.reserve(base_modes * (base_modes - 1) / 2);
+  upper_triangle.reserve(num_physical_majoranas * (num_physical_majoranas - 1) /
+                         2);
 
-  for (std::size_t u = 0; u < base_modes; ++u) {
-    for (std::size_t v = u + 1; v < base_modes; ++v) {
+  for (std::size_t u = 0; u < num_physical_majoranas; ++u) {
+    for (std::size_t v = u + 1; v < num_physical_majoranas; ++v) {
       std::size_t u_mode = u / 2;
       std::size_t v_mode = v / 2;
       std::size_t s_u = u_mode / V;
@@ -529,7 +537,7 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
       std::size_t i = u_mode % V;
       std::size_t j = v_mode % V;
       std::size_t a = u % 2;
-      std::size_t b_idx = v % 2;
+      std::size_t b = v % 2;
 
       bool connected = (s_u == s_v) && lattice.are_connected(i, j);
 
@@ -540,7 +548,7 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
         std::size_t path_max = std::max(path_i, path_j);
 
         std::size_t p = get_sys_majorana(i, s_u, a);
-        std::size_t q = get_sys_majorana(j, s_v, b_idx);
+        std::size_t q = get_sys_majorana(j, s_v, b);
         auto [coeff, word] = get_bilinear(p, q);
 
         // For non-local paths, the raw JW bilinear iγ_pγ_q loses its long
@@ -559,7 +567,7 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
         upper_triangle.emplace_back(coeff, std::move(word));
       } else {
         std::size_t p = get_sys_majorana(i, s_u, a);
-        std::size_t q = get_sys_majorana(j, s_v, b_idx);
+        std::size_t q = get_sys_majorana(j, s_v, b);
         auto [coeff, word] = get_bilinear(p, q);
         upper_triangle.emplace_back(coeff, std::move(word));
       }
@@ -567,8 +575,9 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
   }
 
   return MajoranaMapping(std::vector<SparsePauliWord>{},
-                         std::move(upper_triangle), name, num_modes, base_modes,
-                         name, std::nullopt, std::move(stabilizers));
+                         std::move(upper_triangle), name, num_physical_modes,
+                         base_qubits, name, std::nullopt,
+                         std::move(stabilizers));
 }
 
 }  // namespace qdk::chemistry::data

--- a/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
@@ -109,43 +109,6 @@ constexpr std::uint8_t op_x = 1;
 constexpr std::uint8_t op_y = 2;
 constexpr std::uint8_t op_z = 3;
 
-bool find_hamiltonian_path_dfs(std::uint64_t curr,
-                               const Eigen::SparseMatrix<double>& adj,
-                               std::vector<bool>& visited,
-                               std::vector<std::uint64_t>& path) {
-  path.push_back(curr);
-  if (path.size() == static_cast<std::size_t>(adj.rows())) {
-    return true;
-  }
-  visited[curr] = true;
-
-  // Iterate directly over the sparse matrix columns/rows for neighbors
-  for (Eigen::SparseMatrix<double>::InnerIterator it(adj, curr); it; ++it) {
-    std::uint64_t neighbor = it.row();
-    if (neighbor != curr && !visited[neighbor]) {
-      if (find_hamiltonian_path_dfs(neighbor, adj, visited, path)) {
-        return true;
-      }
-    }
-  }
-  visited[curr] = false;
-  path.pop_back();
-  return false;
-}
-
-std::vector<std::uint64_t> find_hamiltonian_path(
-    const Eigen::SparseMatrix<double>& adj) {
-  std::uint64_t V = adj.rows();
-  std::vector<bool> visited(V, false);
-  std::vector<std::uint64_t> path;
-  for (std::uint64_t start = 0; start < V; ++start) {
-    if (find_hamiltonian_path_dfs(start, adj, visited, path)) {
-      return path;
-    }
-  }
-  return {};
-}
-
 }  // namespace detail
 
 // ── Factory: Jordan-Wigner ───────────────────────────────────────────
@@ -384,36 +347,21 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(const LatticeGraph& lattice) {
         name + " requires a lattice graph with at least 3 sites");
   }
 
-  // Construct a Hamiltonian path from the graph adjacency matrix
+  // Since the lattice graph is pre-ordered optimally (if requested) or
+  // processed in default ordering, the node sequence/path is simply 0, 1, ...,
+  // V-1. Identify all non-adjacent edges incident to each vertex.
   const auto& adj = lattice.sparse_adjacency_matrix();
-  std::vector<std::uint64_t> hamiltonian_path = find_hamiltonian_path(adj);
-  if (hamiltonian_path.empty()) {
-    throw std::runtime_error(
-        name +
-        ": No Hamiltonian path found in the lattice graph. A Hamiltonian path "
-        "is required to construct commuting stabilizers.");
-  }
-
-  // Map row-major site index to its position in the Hamiltonian path
-  std::vector<std::uint64_t> site_to_path_idx(V);
-  for (std::uint64_t k = 0; k < V; ++k) {
-    site_to_path_idx[hamiltonian_path[k]] = k;
-  }
-
-  // Find all non-path edges incident to each vertex
-  std::vector<std::vector<std::uint64_t>> non_path_incident(V);
+  std::vector<std::vector<std::uint64_t>> non_adjacent_incident(V);
   for (int k = 0; k < adj.outerSize(); ++k) {
     for (Eigen::SparseMatrix<double>::InnerIterator it(adj, k); it; ++it) {
       std::uint64_t u = it.row();
       std::uint64_t v = it.col();
-      // Since the matrix is symmetric, only process the upper-triangle
+      // Since the matrix is symmetric, only process the upper-triangle (u < v)
       if (u < v) {
-        std::size_t s_u = site_to_path_idx[u];
-        std::size_t s_v = site_to_path_idx[v];
-        std::size_t diff = (s_u > s_v) ? (s_u - s_v) : (s_v - s_u);
+        std::size_t diff = v - u;
         if (diff > 1) {
-          non_path_incident[u].push_back(v);
-          non_path_incident[v].push_back(u);
+          non_adjacent_incident[u].push_back(v);
+          non_adjacent_incident[v].push_back(u);
         }
       }
     }
@@ -423,7 +371,7 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(const LatticeGraph& lattice) {
   std::vector<std::size_t> n_aux(V);
   std::size_t total_n_aux = 0;
   for (std::uint64_t u = 0; u < V; ++u) {
-    n_aux[u] = (non_path_incident[u].size() + 1) / 2;
+    n_aux[u] = (non_adjacent_incident[u].size() + 1) / 2;
     total_n_aux += n_aux[u];
   }
 
@@ -434,28 +382,23 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(const LatticeGraph& lattice) {
 
   auto jw_base = MajoranaMapping::jordan_wigner(base_qubits);
 
-  // Precompute mode offsets along the Hamiltonian path
-  std::vector<std::size_t> path_idx_to_mode_offset(V);
-  path_idx_to_mode_offset[0] = 0;
+  // Precompute mode offsets along the sequence of sites
+  std::vector<std::size_t> site_to_mode_offset(V);
+  site_to_mode_offset[0] = 0;
   for (std::size_t k = 1; k < V; ++k) {
-    std::uint64_t prev_site = hamiltonian_path[k - 1];
-    path_idx_to_mode_offset[k] =
-        path_idx_to_mode_offset[k - 1] + 1 + n_aux[prev_site];
+    std::uint64_t prev_site = k - 1;
+    site_to_mode_offset[k] = site_to_mode_offset[k - 1] + 1 + n_aux[prev_site];
   }
 
   auto get_sys_majorana = [&](std::uint64_t site, std::size_t spin,
                               std::size_t offset) -> std::size_t {
-    std::size_t path_idx = site_to_path_idx[site];
-    std::size_t mode_idx =
-        spin * modes_per_spin + path_idx_to_mode_offset[path_idx];
+    std::size_t mode_idx = spin * modes_per_spin + site_to_mode_offset[site];
     return 2 * mode_idx + offset;
   };
 
   auto get_aux_majorana = [&](std::uint64_t site, std::size_t spin,
                               std::size_t offset) -> std::size_t {
-    std::size_t path_idx = site_to_path_idx[site];
-    std::size_t mode_idx =
-        spin * modes_per_spin + path_idx_to_mode_offset[path_idx];
+    std::size_t mode_idx = spin * modes_per_spin + site_to_mode_offset[site];
     return 2 * (mode_idx + 1) + offset;
   };
 
@@ -477,16 +420,16 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(const LatticeGraph& lattice) {
       edge_to_stab_idx(2);
 
   for (std::size_t spin = 0; spin < 2; ++spin) {
-    // Add 2-body link stabilizers for non-path edges on the lattice
+    // Add 2-body link stabilizers for non-adjacent edges on the lattice
     for (std::uint64_t u = 0; u < V; ++u) {
-      for (std::uint64_t v : non_path_incident[u]) {
+      for (std::uint64_t v : non_adjacent_incident[u]) {
         if (u < v) {
-          auto it_u = std::find(non_path_incident[u].begin(),
-                                non_path_incident[u].end(), v);
-          auto it_v = std::find(non_path_incident[v].begin(),
-                                non_path_incident[v].end(), u);
-          std::size_t a = std::distance(non_path_incident[u].begin(), it_u);
-          std::size_t b = std::distance(non_path_incident[v].begin(), it_v);
+          auto it_u = std::find(non_adjacent_incident[u].begin(),
+                                non_adjacent_incident[u].end(), v);
+          auto it_v = std::find(non_adjacent_incident[v].begin(),
+                                non_adjacent_incident[v].end(), u);
+          std::size_t a = std::distance(non_adjacent_incident[u].begin(), it_u);
+          std::size_t b = std::distance(non_adjacent_incident[v].begin(), it_v);
 
           std::size_t p = get_aux_majorana(u, spin, a);
           std::size_t q = get_aux_majorana(v, spin, b);
@@ -503,7 +446,7 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(const LatticeGraph& lattice) {
     // lift boundary/corner codespace degeneracy
     std::vector<std::size_t> unpaired_modes;
     for (std::uint64_t u = 0; u < V; ++u) {
-      std::size_t A_u = non_path_incident[u].size();
+      std::size_t A_u = non_adjacent_incident[u].size();
       if (A_u % 2 != 0) {
         unpaired_modes.push_back(get_aux_majorana(u, spin, A_u));
       }
@@ -542,10 +485,8 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(const LatticeGraph& lattice) {
       bool connected = (s_u == s_v) && lattice.are_connected(i, j);
 
       if (connected) {
-        std::size_t path_i = site_to_path_idx[i];
-        std::size_t path_j = site_to_path_idx[j];
-        std::size_t path_min = std::min(path_i, path_j);
-        std::size_t path_max = std::max(path_i, path_j);
+        std::size_t path_min = std::min(i, j);
+        std::size_t path_max = std::max(i, j);
 
         std::size_t p = get_sys_majorana(i, s_u, a);
         std::size_t q = get_sys_majorana(j, s_v, b);

--- a/cpp/tests/test_lattice_graph.cpp
+++ b/cpp/tests/test_lattice_graph.cpp
@@ -642,12 +642,21 @@ TEST_F(LatticeGraphTest, Permute) {
   auto sq = LatticeGraph::square(3, 2, false, false);
   ASSERT_TRUE(sq.edge_coloring().has_value());
 
-  // Define a permutation path: e.g., [0, 3, 4, 1, 2, 5]
-  std::vector<std::uint64_t> path = {0, 3, 4, 1, 2, 5};
+  // Define a permutation path that is not an involution:
+  std::vector<std::uint64_t> path = {1, 2, 0, 4, 5, 3};
   auto permuted = LatticeGraph::permute(sq, path);
 
   EXPECT_EQ(permuted.num_sites(), sq.num_sites());
   EXPECT_EQ(permuted.num_edges(), sq.num_edges());
+
+  // Verify that new vertex i corresponds to old vertex path[i] (locks down
+  // permutation direction)
+  for (std::uint64_t i = 0; i < 6; ++i) {
+    for (std::uint64_t j = i + 1; j < 6; ++j) {
+      EXPECT_EQ(permuted.are_connected(i, j),
+                sq.are_connected(path[i], path[j]));
+    }
+  }
 
   // Inverse permutation mapping for checking:
   // inv_p[old_site] = new_site

--- a/cpp/tests/test_lattice_graph.cpp
+++ b/cpp/tests/test_lattice_graph.cpp
@@ -629,3 +629,59 @@ TEST_F(LatticeGraphTest, KagomeColoringSeed) {
   EXPECT_EQ(*kg_a.edge_coloring(), *kg_b.edge_coloring());
   check_valid_edge_coloring(*kg_a.edge_coloring());
 }
+
+TEST_F(LatticeGraphTest, Permute) {
+  // Create a 2x3 square lattice (6 sites):
+  // 3 -- 4 -- 5
+  // |    |    |
+  // 0 -- 1 -- 2
+  //
+  // Adjacency connections:
+  // (0,1), (1,2), (3,4), (4,5) [horizontal]
+  // (0,3), (1,4), (2,5) [vertical]
+  auto sq = LatticeGraph::square(3, 2, false, false);
+  ASSERT_TRUE(sq.edge_coloring().has_value());
+
+  // Define a permutation path: e.g., [0, 3, 4, 1, 2, 5]
+  std::vector<std::uint64_t> path = {0, 3, 4, 1, 2, 5};
+  auto permuted = LatticeGraph::permute(sq, path);
+
+  EXPECT_EQ(permuted.num_sites(), sq.num_sites());
+  EXPECT_EQ(permuted.num_edges(), sq.num_edges());
+
+  // Inverse permutation mapping for checking:
+  // inv_p[old_site] = new_site
+  std::vector<std::uint64_t> inv_p(6);
+  for (std::uint64_t i = 0; i < 6; ++i) {
+    inv_p[path[i]] = i;
+  }
+
+  // Assert are_connected(i,j) after permute matches the remapped coloring keys
+  const auto& new_coloring = *permuted.edge_coloring();
+  for (std::uint64_t i = 0; i < 6; ++i) {
+    for (std::uint64_t j = i + 1; j < 6; ++j) {
+      bool connected = permuted.are_connected(i, j);
+      auto key = std::make_pair(i, j);
+      bool in_coloring = (new_coloring.count(key) > 0);
+      EXPECT_EQ(connected, in_coloring);
+
+      if (connected) {
+        // Find corresponding old vertices
+        std::uint64_t old_u = path[i];
+        std::uint64_t old_v = path[j];
+        auto old_key = std::minmax(old_u, old_v);
+        // Assert color matches
+        EXPECT_EQ(new_coloring.at(key),
+                  sq.edge_coloring()->at({old_key.first, old_key.second}));
+      }
+    }
+  }
+
+  // Confirms dfs_ordering=true yields path-consecutive adjacency
+  auto ordered_sq = LatticeGraph::square(3, 3, false, false, 1.0, true);
+  for (std::uint64_t i = 0; i < ordered_sq.num_sites() - 1; ++i) {
+    EXPECT_TRUE(ordered_sq.are_connected(i, i + 1))
+        << "ordered_sq sites " << i << " and " << (i + 1)
+        << " are not connected";
+  }
+}

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -611,3 +611,24 @@
     year={1992},
     doi={10.1016/0375-9601(92)90335-J}
 }
+@article{Verstraete2005,
+    title={Mapping local {Hamiltonians} of fermions onto local {Hamiltonians} of spins},
+    author={F. Verstraete and J. I. Cirac},
+    journal={Journal of Statistical Mechanics: Theory and Experiment},
+    volume={2005},
+    number={09},
+    pages={P09012},
+    year={2005},
+    doi={10.1088/1742-5468/2005/09/P09012}
+}
+@article{Whitfield2016,
+    title={Local spin operators for fermion simulations},
+    author={James D. Whitfield and Vojt{\v{e}}ch Havl{\'i}{\v{c}}ek and Matthias Troyer},
+    journal={Physical Review A},
+    volume={94},
+    number={3},
+    pages={030301},
+    year={2016},
+    doi={10.1103/PhysRevA.94.030301},
+    url={https://arxiv.org/abs/1605.09789}
+}

--- a/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
+++ b/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
@@ -55,7 +55,7 @@ Bravyi-Kitaev tree :cite:`Havlicek2017`
 .. _encoding-verstraete-cirac:
 
 Verstraete-Cirac :cite:`Verstraete2005`
-   An auxiliary-qubit encoding designed for 2D lattices. It eliminates non-local Z-strings by introducing flag qubits that locally track parity. Max Pauli weight of nearest-neighbor hops remains constant regardless of lattice size. Use :meth:`~qdk_chemistry.data.MajoranaMapping.verstraete_cirac` with a :class:`~qdk_chemistry.data.LatticeGraph`.
+   An auxiliary-qubit encoding that operates on a general connected :class:`~qdk_chemistry.data.LatticeGraph` that admits a Hamiltonian path. It eliminates non-local Z-strings by introducing auxiliary qubits that locally track parity. For 2D square grids, the maximum Pauli weight of nearest-neighbor hopping terms remains constant regardless of the grid size. Use :meth:`~qdk_chemistry.data.MajoranaMapping.verstraete_cirac` with a :class:`~qdk_chemistry.data.LatticeGraph`.
 
 Using the QubitMapper
 ---------------------

--- a/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
+++ b/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
@@ -55,7 +55,7 @@ Bravyi-Kitaev tree :cite:`Havlicek2017`
 .. _encoding-verstraete-cirac:
 
 Verstraete-Cirac :cite:`Verstraete2005`
-   An auxiliary-qubit encoding that operates on a general connected :class:`~qdk_chemistry.data.LatticeGraph` that admits a Hamiltonian path. It eliminates non-local Z-strings by introducing auxiliary qubits that locally track parity. For 2D square grids, the maximum Pauli weight of nearest-neighbor hopping terms remains constant regardless of the grid size. Use :meth:`~qdk_chemistry.data.MajoranaMapping.verstraete_cirac` with a :class:`~qdk_chemistry.data.LatticeGraph`.
+   An auxiliary qubit encoding that eliminates non-local Z-strings by locally tracking parity. It operates on any connected :class:`~qdk_chemistry.data.LatticeGraph`; an optional Hamiltonian-path reordering (``dfs_ordering=True`` on the lattice factories) minimizes the number of auxiliary qubits and stabilizers. Use :meth:`~qdk_chemistry.data.MajoranaMapping.verstraete_cirac` with a :class:`~qdk_chemistry.data.LatticeGraph`.
 
 Using the QubitMapper
 ---------------------

--- a/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
+++ b/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
@@ -52,6 +52,10 @@ Symmetry-conserving Bravyi-Kitaev :cite:`Bravyi2017tapering`
 Bravyi-Kitaev tree :cite:`Havlicek2017`
    A tree-based variant of the Bravyi-Kitaev transformation that uses a different qubit indexing strategy.
 
+.. _encoding-verstraete-cirac:
+
+Verstraete-Cirac :cite:`Verstraete2005`
+   An auxiliary-qubit encoding designed for 2D lattices. It eliminates non-local Z-strings by introducing flag qubits that locally track parity. Max Pauli weight of nearest-neighbor hops remains constant regardless of lattice size. Use :meth:`~qdk_chemistry.data.MajoranaMapping.verstraete_cirac` with a :class:`~qdk_chemistry.data.LatticeGraph`.
 
 Using the QubitMapper
 ---------------------
@@ -188,7 +192,7 @@ This is a **table-driven** backend: it reads the Pauli-string table from the :cl
 Any valid ``MajoranaMapping`` works — factory-produced or custom user-defined tables.
 The mapping's ``name`` and ``base_encoding`` are used only for metadata on the output, not to select a transform.
 
-Supported encodings: :ref:`Jordan-Wigner <encoding-jordan-wigner>`, :ref:`Bravyi-Kitaev <encoding-bravyi-kitaev>`, :ref:`Bravyi-Kitaev tree <encoding-bk-tree>`, :ref:`Parity <encoding-parity>`, :ref:`SCBK <encoding-scbk>`, and any custom encoding
+Supported encodings: :ref:`Jordan-Wigner <encoding-jordan-wigner>`, :ref:`Bravyi-Kitaev <encoding-bravyi-kitaev>`, :ref:`Bravyi-Kitaev tree <encoding-bk-tree>`, :ref:`Parity <encoding-parity>`, :ref:`SCBK <encoding-scbk>`, :ref:`Verstraete-Cirac <encoding-verstraete-cirac>`, and any custom encoding
 
 The native mapper uses blocked spin-orbital ordering internally (alpha orbitals first, then beta orbitals).
 Use ``QubitHamiltonian.to_interleaved()`` for alternative qubit orderings if needed.

--- a/python/src/pybind11/data/lattice_graph.cpp
+++ b/python/src/pybind11/data/lattice_graph.cpp
@@ -295,8 +295,7 @@ Examples:
     >>> ring = LatticeGraph.chain(6, periodic=True)
 )",
                            py::arg("n"), py::arg("periodic") = false,
-                           py::arg("t") = 1.0,
-                           py::arg("optimal_ordering") = false);
+                           py::arg("t") = 1.0, py::arg("dfs_ordering") = false);
 
   lattice_graph.def_static("square", &LatticeGraph::square, R"(
 Create a two-dimensional square lattice.
@@ -334,7 +333,7 @@ Raises:
                            py::arg("nx"), py::arg("ny"),
                            py::arg("periodic_x") = false,
                            py::arg("periodic_y") = false, py::arg("t") = 1.0,
-                           py::arg("optimal_ordering") = false);
+                           py::arg("dfs_ordering") = false);
 
   lattice_graph.def_static(
       "triangular", &LatticeGraph::triangular, R"(
@@ -376,7 +375,7 @@ Raises:
 )",
       py::arg("nx"), py::arg("ny"), py::arg("periodic_x") = false,
       py::arg("periodic_y") = false, py::arg("t") = 1.0,
-      py::arg("coloring_seed") = 0, py::arg("optimal_ordering") = false);
+      py::arg("coloring_seed") = 0, py::arg("dfs_ordering") = false);
 
   lattice_graph.def_static("honeycomb", &LatticeGraph::honeycomb, R"(
 Create a two-dimensional honeycomb lattice.
@@ -420,7 +419,7 @@ Raises:
                            py::arg("nx"), py::arg("ny"),
                            py::arg("periodic_x") = false,
                            py::arg("periodic_y") = false, py::arg("t") = 1.0,
-                           py::arg("optimal_ordering") = false);
+                           py::arg("dfs_ordering") = false);
 
   lattice_graph.def_static(
       "kagome", &LatticeGraph::kagome, R"(
@@ -473,7 +472,7 @@ Raises:
 )",
       py::arg("nx"), py::arg("ny"), py::arg("periodic_x") = false,
       py::arg("periodic_y") = false, py::arg("t") = 1.0,
-      py::arg("coloring_seed") = 0, py::arg("optimal_ordering") = false);
+      py::arg("coloring_seed") = 0, py::arg("dfs_ordering") = false);
 
   lattice_graph.def("__repr__", [](const LatticeGraph &self) {
     return "<LatticeGraph sites=" + std::to_string(self.num_sites()) +

--- a/python/src/pybind11/data/lattice_graph.cpp
+++ b/python/src/pybind11/data/lattice_graph.cpp
@@ -295,7 +295,8 @@ Examples:
     >>> ring = LatticeGraph.chain(6, periodic=True)
 )",
                            py::arg("n"), py::arg("periodic") = false,
-                           py::arg("t") = 1.0);
+                           py::arg("t") = 1.0,
+                           py::arg("optimal_ordering") = false);
 
   lattice_graph.def_static("square", &LatticeGraph::square, R"(
 Create a two-dimensional square lattice.
@@ -332,9 +333,11 @@ Raises:
 )",
                            py::arg("nx"), py::arg("ny"),
                            py::arg("periodic_x") = false,
-                           py::arg("periodic_y") = false, py::arg("t") = 1.0);
+                           py::arg("periodic_y") = false, py::arg("t") = 1.0,
+                           py::arg("optimal_ordering") = false);
 
-  lattice_graph.def_static("triangular", &LatticeGraph::triangular, R"(
+  lattice_graph.def_static(
+      "triangular", &LatticeGraph::triangular, R"(
 Create a two-dimensional triangular lattice.
 
 Sites are indexed in row-major order: site index = y * nx + x.
@@ -371,10 +374,9 @@ Returns:
 Raises:
     ValueError: If nx or ny is 0.
 )",
-                           py::arg("nx"), py::arg("ny"),
-                           py::arg("periodic_x") = false,
-                           py::arg("periodic_y") = false, py::arg("t") = 1.0,
-                           py::arg("coloring_seed") = 0);
+      py::arg("nx"), py::arg("ny"), py::arg("periodic_x") = false,
+      py::arg("periodic_y") = false, py::arg("t") = 1.0,
+      py::arg("coloring_seed") = 0, py::arg("optimal_ordering") = false);
 
   lattice_graph.def_static("honeycomb", &LatticeGraph::honeycomb, R"(
 Create a two-dimensional honeycomb lattice.
@@ -417,9 +419,11 @@ Raises:
 )",
                            py::arg("nx"), py::arg("ny"),
                            py::arg("periodic_x") = false,
-                           py::arg("periodic_y") = false, py::arg("t") = 1.0);
+                           py::arg("periodic_y") = false, py::arg("t") = 1.0,
+                           py::arg("optimal_ordering") = false);
 
-  lattice_graph.def_static("kagome", &LatticeGraph::kagome, R"(
+  lattice_graph.def_static(
+      "kagome", &LatticeGraph::kagome, R"(
 Create a two-dimensional kagome lattice.
 
 The kagome lattice has three sites per unit cell, arranged as
@@ -467,10 +471,9 @@ Returns:
 Raises:
     ValueError: If nx or ny is 0.
 )",
-                           py::arg("nx"), py::arg("ny"),
-                           py::arg("periodic_x") = false,
-                           py::arg("periodic_y") = false, py::arg("t") = 1.0,
-                           py::arg("coloring_seed") = 0);
+      py::arg("nx"), py::arg("ny"), py::arg("periodic_x") = false,
+      py::arg("periodic_y") = false, py::arg("t") = 1.0,
+      py::arg("coloring_seed") = 0, py::arg("optimal_ordering") = false);
 
   lattice_graph.def("__repr__", [](const LatticeGraph &self) {
     return "<LatticeGraph sites=" + std::to_string(self.num_sites()) +

--- a/python/src/pybind11/data/majorana_mapping.cpp
+++ b/python/src/pybind11/data/majorana_mapping.cpp
@@ -235,7 +235,7 @@ bilinear(j, k) is available on both forms.
           py::arg("num_modes"), py::arg("symmetries"),
           "Construct a symmetry-conserving Bravyi-Kitaev encoding.")
       .def_static("verstraete_cirac", &MajoranaMapping::verstraete_cirac,
-                  py::arg("lattice"), py::arg("num_spin_species") = 2,
+                  py::arg("lattice"),
                   "Construct a Verstraete-Cirac encoding.");
 
   mapping

--- a/python/src/pybind11/data/majorana_mapping.cpp
+++ b/python/src/pybind11/data/majorana_mapping.cpp
@@ -9,6 +9,7 @@
 
 #include <nlohmann/json.hpp>
 #include <qdk/chemistry/data/hamiltonian.hpp>
+#include <qdk/chemistry/data/lattice_graph.hpp>
 #include <qdk/chemistry/data/majorana_mapping.hpp>
 #include <qdk/chemistry/data/pauli_operator.hpp>
 #include <qdk/chemistry/data/tapering.hpp>
@@ -147,6 +148,8 @@ bilinear(j, k) is available on both forms.
       .def_property_readonly("num_qubits", &MajoranaMapping::num_qubits)
       .def_property_readonly("name", &MajoranaMapping::name)
       .def_property_readonly("base_encoding", &MajoranaMapping::base_encoding)
+      .def_property_readonly("grid_nx", &MajoranaMapping::grid_nx)
+      .def_property_readonly("grid_ny", &MajoranaMapping::grid_ny)
       .def_property_readonly("table", &MajoranaMapping::table)
       .def_property_readonly("tapering",
                              [](const MajoranaMapping& self)
@@ -200,6 +203,9 @@ bilinear(j, k) is available on both forms.
       });
 
   mapping
+      .def_static("verstraete_cirac", &MajoranaMapping::verstraete_cirac,
+                  py::arg("lattice"), py::arg("num_spin_species") = 2,
+                  "Construct a Verstraete-Cirac encoding.")
       .def_static("jordan_wigner", &MajoranaMapping::jordan_wigner,
                   py::arg("num_modes"), "Construct a Jordan-Wigner encoding.")
       .def_static("bravyi_kitaev", &MajoranaMapping::bravyi_kitaev,

--- a/python/src/pybind11/data/majorana_mapping.cpp
+++ b/python/src/pybind11/data/majorana_mapping.cpp
@@ -235,8 +235,7 @@ bilinear(j, k) is available on both forms.
           py::arg("num_modes"), py::arg("symmetries"),
           "Construct a symmetry-conserving Bravyi-Kitaev encoding.")
       .def_static("verstraete_cirac", &MajoranaMapping::verstraete_cirac,
-                  py::arg("lattice"),
-                  "Construct a Verstraete-Cirac encoding.");
+                  py::arg("lattice"), "Construct a Verstraete-Cirac encoding.");
 
   mapping
       .def(

--- a/python/src/pybind11/data/majorana_mapping.cpp
+++ b/python/src/pybind11/data/majorana_mapping.cpp
@@ -148,14 +148,13 @@ bilinear(j, k) is available on both forms.
       .def_property_readonly("num_qubits", &MajoranaMapping::num_qubits)
       .def_property_readonly("name", &MajoranaMapping::name)
       .def_property_readonly("base_encoding", &MajoranaMapping::base_encoding)
-      .def_property_readonly("grid_nx", &MajoranaMapping::grid_nx)
-      .def_property_readonly("grid_ny", &MajoranaMapping::grid_ny)
       .def_property_readonly("table", &MajoranaMapping::table)
       .def_property_readonly("tapering",
                              [](const MajoranaMapping& self)
                                  -> std::optional<TaperingSpecification> {
                                return self.tapering();
                              })
+      .def_property_readonly("stabilizers", &MajoranaMapping::stabilizers)
       .def_property_readonly("is_majorana_atomic",
                              &MajoranaMapping::is_majorana_atomic)
       .def(
@@ -203,9 +202,6 @@ bilinear(j, k) is available on both forms.
       });
 
   mapping
-      .def_static("verstraete_cirac", &MajoranaMapping::verstraete_cirac,
-                  py::arg("lattice"), py::arg("num_spin_species") = 2,
-                  "Construct a Verstraete-Cirac encoding.")
       .def_static("jordan_wigner", &MajoranaMapping::jordan_wigner,
                   py::arg("num_modes"), "Construct a Jordan-Wigner encoding.")
       .def_static("bravyi_kitaev", &MajoranaMapping::bravyi_kitaev,
@@ -237,7 +233,10 @@ bilinear(j, k) is available on both forms.
                 num_modes, n_alpha, n_beta);
           },
           py::arg("num_modes"), py::arg("symmetries"),
-          "Construct a symmetry-conserving Bravyi-Kitaev encoding.");
+          "Construct a symmetry-conserving Bravyi-Kitaev encoding.")
+      .def_static("verstraete_cirac", &MajoranaMapping::verstraete_cirac,
+                  py::arg("lattice"), py::arg("num_spin_species") = 2,
+                  "Construct a Verstraete-Cirac encoding.");
 
   mapping
       .def(

--- a/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
+++ b/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
@@ -161,14 +161,10 @@ class QdkQubitMapper(QubitMapper):
         n_spin_orbitals = 2 * n_spatial
         spin_symmetric = hamiltonian.get_orbitals().is_restricted()
 
-        allowed_modes: tuple[int, ...] = (
-            (n_spin_orbitals,) if hamiltonian.has_two_body_integrals() else (n_spatial, n_spin_orbitals)
-        )
-
-        if base_mapping.num_modes not in allowed_modes:
+        if base_mapping.num_modes != n_spin_orbitals:
             raise ValueError(
                 f"MajoranaMapping has {base_mapping.num_modes} modes but the Hamiltonian has "
-                f"{n_spatial} spatial orbitals (which requires one of {allowed_modes} modes). "
+                f"{n_spin_orbitals} spin-orbitals (2 x {n_spatial} spatial orbitals). "
                 f"Use MajoranaMapping.jordan_wigner(num_modes={n_spin_orbitals}) or equivalent."
             )
 

--- a/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
+++ b/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
@@ -161,10 +161,10 @@ class QdkQubitMapper(QubitMapper):
         n_spin_orbitals = 2 * n_spatial
         spin_symmetric = hamiltonian.get_orbitals().is_restricted()
 
-        if base_mapping.num_modes != n_spin_orbitals:
+        if base_mapping.num_modes not in (n_spatial, n_spin_orbitals):
             raise ValueError(
                 f"MajoranaMapping has {base_mapping.num_modes} modes but the Hamiltonian has "
-                f"{n_spin_orbitals} spin-orbitals (2 x {n_spatial} spatial orbitals). "
+                f"{n_spatial} spatial orbitals (which requires either {n_spatial} or {n_spin_orbitals} modes). "
                 f"Use MajoranaMapping.jordan_wigner(num_modes={n_spin_orbitals}) or equivalent."
             )
 

--- a/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
+++ b/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
@@ -161,10 +161,14 @@ class QdkQubitMapper(QubitMapper):
         n_spin_orbitals = 2 * n_spatial
         spin_symmetric = hamiltonian.get_orbitals().is_restricted()
 
-        if base_mapping.num_modes not in (n_spatial, n_spin_orbitals):
+        allowed_modes: tuple[int, ...] = (
+            (n_spin_orbitals,) if hamiltonian.has_two_body_integrals() else (n_spatial, n_spin_orbitals)
+        )
+
+        if base_mapping.num_modes not in allowed_modes:
             raise ValueError(
                 f"MajoranaMapping has {base_mapping.num_modes} modes but the Hamiltonian has "
-                f"{n_spatial} spatial orbitals (which requires either {n_spatial} or {n_spin_orbitals} modes). "
+                f"{n_spatial} spatial orbitals (which requires one of {allowed_modes} modes). "
                 f"Use MajoranaMapping.jordan_wigner(num_modes={n_spin_orbitals}) or equivalent."
             )
 

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -43,19 +43,35 @@ class TestVerstraeteCiracMapping:
         mapping_4x4 = MajoranaMapping.verstraete_cirac(lattice_4x4)
         assert len(mapping_4x4.stabilizers) > 0
 
-        # Invalid spin species count should raise ValueError / invalid_argument
-        with pytest.raises(ValueError, match="spin"):
-            MajoranaMapping.verstraete_cirac(lattice_2x2, num_spin_species=0)
-
     def test_general_lattices(self) -> None:
-        """Verify that QubitMapper consumes VC mapping for general 2D lattices."""
+        """Verify that QubitMapper consumes VC mapping for general lattices."""
         mapper = create("qubit_mapper", "qdk")
-        for nx, ny in [(2, 2), (2, 3), (3, 3), (4, 4)]:
-            lattice = LatticeGraph.square(nx, ny)
+        lattices = [
+            LatticeGraph.square(2, 2),
+            LatticeGraph.square(3, 3),
+            LatticeGraph.honeycomb(2, 2, periodic_x=True, periodic_y=True),
+            LatticeGraph.triangular(2, 2),
+        ]
+        for lattice in lattices:
             ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
-            mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=1)
+            mapping = MajoranaMapping.verstraete_cirac(lattice)
             qh = mapper.run(ham, mapping)
-            assert qh.num_qubits == 2 * nx * ny
+            assert qh.num_qubits == mapping.num_qubits
+            assert mapping.num_qubits - len(mapping.stabilizers) == 2 * lattice.num_sites
+
+    def test_honeycomb_and_higher_connectivity(self) -> None:
+        """Verify honeycomb (degree 3) and triangular/kagome (higher degree up to 6) lattices work."""
+        lattice_honeycomb = LatticeGraph.honeycomb(2, 2, periodic_x=True, periodic_y=True)
+        mapping_honeycomb = MajoranaMapping.verstraete_cirac(lattice_honeycomb)
+        assert len(mapping_honeycomb.stabilizers) > 0
+        
+        lattice_triangular = LatticeGraph.triangular(2, 2)
+        mapping_triangular = MajoranaMapping.verstraete_cirac(lattice_triangular)
+        assert len(mapping_triangular.stabilizers) > 0
+
+        lattice_kagome = LatticeGraph.kagome(2, 2, periodic_x=True, periodic_y=True)
+        mapping_kagome = MajoranaMapping.verstraete_cirac(lattice_kagome)
+        assert len(mapping_kagome.stabilizers) > 0
 
     def test_majorana_raises_error(self) -> None:
         """Verstraete-Cirac mapping is bilinear-only and majorana(k) should raise ValueError."""
@@ -134,28 +150,26 @@ class TestVerstraeteCiracMapping:
             lattice = LatticeGraph.square(nx, ny)
             ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
 
-            # Verify stabilizer properties for both spinless (nss=1) and spinful (nss=2) cases
-            for nss in [1, 2]:
-                mapping = MajoranaMapping.verstraete_cirac(lattice, nss)
-                assert len(mapping.stabilizers) == nss * nx * ny
+            mapping = MajoranaMapping.verstraete_cirac(lattice)
+            assert mapping.num_qubits - len(mapping.stabilizers) == 2 * lattice.num_sites
 
-                qh_vc = mapper.run(ham, mapping)
+            qh_vc = mapper.run(ham, mapping)
 
-                # Convert stabilizers to Pauli labels
-                stabs = []
-                for _, word in mapping.stabilizers:
-                    label = sparse_pauli_word_to_label(word, qh_vc.num_qubits)
-                    stabs.append(label)
+            # Convert stabilizers to Pauli labels
+            stabs = []
+            for _, word in mapping.stabilizers:
+                label = sparse_pauli_word_to_label(word, qh_vc.num_qubits)
+                stabs.append(label)
 
-                # Check mutual commutation of stabilizers: [S_i, S_j] = 0
-                for i in range(len(stabs)):
-                    for j in range(i + 1, len(stabs)):
-                        assert commute(stabs[i], stabs[j]), f"Stabilizers {i} and {j} do not commute!"
+            # Check mutual commutation of stabilizers: [S_i, S_j] = 0
+            for i in range(len(stabs)):
+                for j in range(i + 1, len(stabs)):
+                    assert commute(stabs[i], stabs[j]), f"Stabilizers {i} and {j} do not commute!"
 
-                # Check commutation with Hamiltonian: [H, S_i] = 0
-                for i, stab in enumerate(stabs):
-                    for p_term in qh_vc.pauli_strings:
-                        assert commute(stab, p_term), f"Stabilizer {i} does not commute with Hamiltonian term {p_term}!"
+            # Check commutation with Hamiltonian: [H, S_i] = 0
+            for i, stab in enumerate(stabs):
+                for p_term in qh_vc.pauli_strings:
+                    assert commute(stab, p_term), f"Stabilizer {i} does not commute with Hamiltonian term {p_term}!"
 
     def test_pauli_weight_scaling(self) -> None:
         """Check nearest-neighbor hopping terms in the mapped qubit Hamiltonian.
@@ -204,7 +218,7 @@ class TestVerstraeteCiracSpectral:
         Model parameters: t = 1.0, U = 4.0, half-filling (epsilon = -U/2 = -2.0).
         """
         lattice = LatticeGraph.square(2, 2, periodic_x=True)
-        n_modes = 8  # 4 spatial sites * 2 spin species
+        n_modes = 8  # 4 spatial sites * 2 spins
         hamiltonian = create_hubbard_hamiltonian(lattice, epsilon=-2.0, t=1.0, U=4.0)
         mapper = create("qubit_mapper", "qdk")
 
@@ -214,11 +228,11 @@ class TestVerstraeteCiracSpectral:
         eigs_jw, _ = eigsh(h_jw, k=10, which="SA")
         unique_jw = np.unique(np.round(np.sort(eigs_jw), 6))
 
-        vc_mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=2)
+        vc_mapping = MajoranaMapping.verstraete_cirac(lattice)
         qh_vc = mapper.run(hamiltonian, vc_mapping)
 
         # Verify system size and extract lowest unique eigenvalues
-        assert qh_vc.num_qubits == 2 * n_modes
+        assert qh_vc.num_qubits == vc_mapping.num_qubits
         h_vc = qh_vc.to_matrix(sparse=True)
         eigs_vc, _ = eigsh(h_vc, k=10, which="SA")
         unique_vc = np.unique(np.round(np.sort(eigs_vc), 6))
@@ -226,14 +240,14 @@ class TestVerstraeteCiracSpectral:
         # Ensure lowest physical energy levels match baseline
         np.testing.assert_allclose(unique_vc[:2], unique_jw[:2], atol=1e-10)
 
-    def test_spectral_validation_3x3_huckel(self) -> None:
-        """Compare eigenvalues of 3x3 Hückel model under VC and JW mappings.
+    def test_spectral_validation_3x2_huckel(self) -> None:
+        """Compare eigenvalues of 3x2 Hückel model under VC and JW mappings.
 
         Validates that the lowest eigenstates of the penalized Hamiltonian are
         in the +1 codespace sector of the generated loop-plaquette stabilizers.
         """
-        lattice = LatticeGraph.square(3, 3)
-        n_modes = 9  # 9 spatial sites * 1 spin species (spinless)
+        lattice = LatticeGraph.square(3, 2)
+        n_modes = 12  # 6 spatial sites * 2 spins
         hamiltonian = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
         mapper = create("qubit_mapper", "qdk")
 
@@ -243,11 +257,11 @@ class TestVerstraeteCiracSpectral:
         eigs_jw, _ = eigsh(h_jw, k=10, which="SA")
         unique_jw = np.unique(np.round(np.sort(eigs_jw), 6))
 
-        vc_mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=1)
+        vc_mapping = MajoranaMapping.verstraete_cirac(lattice)
         qh_vc = mapper.run(hamiltonian, vc_mapping)
 
         # Extract lowest eigenstates and their respective eigenstates
-        assert qh_vc.num_qubits == 2 * n_modes
+        assert qh_vc.num_qubits == vc_mapping.num_qubits
         h_vc = qh_vc.to_matrix(sparse=True)
         eigs_vc, vecs_vc = eigsh(h_vc, k=10, which="SA")
 

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -22,8 +22,8 @@ class TestVerstraeteCiracMapping:
     """Tests covering the Verstraete-Cirac mapping factory, dimensions, and properties."""
 
     def test_factory_and_dimensions(self) -> None:
-        """Test that VC factory accepts correct grid dimensions and rejects invalid ones."""
-        # Testing valid grids: square and rectangular
+        """Test that VC factory accepts valid lattices (>= 3 sites) and rejects lattices with < 3 sites."""
+        # Testing valid lattices with >= 3 sites
         lattice_2x2 = LatticeGraph.square(2, 2)
         mapping_2x2 = MajoranaMapping.verstraete_cirac(lattice_2x2)
         assert len(mapping_2x2.stabilizers) > 0
@@ -43,6 +43,11 @@ class TestVerstraeteCiracMapping:
         mapping_4x4 = MajoranaMapping.verstraete_cirac(lattice_4x4)
         assert len(mapping_4x4.stabilizers) > 0
 
+        # Testing invalid lattices with < 3 sites
+        lattice_1x2 = LatticeGraph.square(1, 2)
+        with pytest.raises(ValueError, match="requires a lattice graph with at least 3 sites"):
+            MajoranaMapping.verstraete_cirac(lattice_1x2)
+
     def test_majorana_raises_error(self) -> None:
         """Verstraete-Cirac mapping is bilinear-only and majorana(k) should raise ValueError."""
         lattice = LatticeGraph.square(2, 2)
@@ -58,8 +63,8 @@ class TestVerstraeteCiracMapping:
         assert len(base.stabilizers) == len(mapping.stabilizers)
         assert base.name == "verstraete-cirac"
 
-    def test_serialization_round_trip(self) -> None:
-        """Verify that Verstraete-Cirac mapping survives JSON and HDF5 serialization round-trips."""
+    def test_json_serialization(self) -> None:
+        """Verify that Verstraete-Cirac mapping survives JSON serialization."""
         lattice = LatticeGraph.square(2, 2)
         mapping = MajoranaMapping.verstraete_cirac(lattice)
 
@@ -85,6 +90,17 @@ class TestVerstraeteCiracMapping:
             assert p_orig == p_json
             assert np.isclose(c_orig, c_json, atol=1e-10)
 
+    def test_hdf5_serialization(self) -> None:
+        """Verify that Verstraete-Cirac mapping survives HDF5 serialization."""
+        lattice = LatticeGraph.square(2, 2)
+        mapping = MajoranaMapping.verstraete_cirac(lattice)
+
+        # Construct a simple Hubbard Hamiltonian on the lattice
+        ham = create_hubbard_hamiltonian(lattice, epsilon=-2.0, t=1.0, U=4.0)
+        mapper = create("qubit_mapper", "qdk")
+        qh_orig = mapper.run(ham, mapping)
+        terms_orig = sorted(zip(qh_orig.pauli_strings, qh_orig.coefficients, strict=False))
+
         # HDF5 Round-trip
         with tempfile.NamedTemporaryFile(suffix=".h5") as f:
             with h5py.File(f.name, "w") as hf:
@@ -104,7 +120,19 @@ class TestVerstraeteCiracMapping:
             assert p_orig == p_h5
             assert np.isclose(c_orig, c_h5, atol=1e-10)
 
-    def test_stabilizers_and_commutation(self) -> None:
+    @pytest.mark.parametrize(
+        ("lattice_type", "args", "kwargs"),
+        [
+            ("square", (2, 2), {}),
+            ("square", (3, 3), {}),
+            ("square", (3, 4), {}),
+            ("honeycomb", (2, 2), {"periodic_x": True, "periodic_y": True}),
+            ("triangular", (2, 2), {}),
+            ("kagome", (2, 2), {"periodic_x": True, "periodic_y": True}),
+            ("kagome", (3, 3), {}),
+        ],
+    )
+    def test_stabilizers_and_commutation(self, lattice_type: str, args: tuple, kwargs: dict) -> None:
         """Verify that stabilizers mutually commute and commute with mapped H for various lattices."""
 
         def commute(p1: str, p2: str) -> bool:
@@ -116,41 +144,32 @@ class TestVerstraeteCiracMapping:
             return (anti_commutes % 2) == 0
 
         mapper = create("qubit_mapper", "qdk")
-        lattices = [
-            LatticeGraph.square(2, 2),
-            LatticeGraph.square(3, 3),
-            LatticeGraph.square(3, 4),
-            LatticeGraph.honeycomb(2, 2, periodic_x=True, periodic_y=True),
-            LatticeGraph.triangular(2, 2),
-            LatticeGraph.kagome(2, 2, periodic_x=True, periodic_y=True),
-            LatticeGraph.kagome(3, 3),
-        ]
+        lattice = getattr(LatticeGraph, lattice_type)(*args, **kwargs)
 
-        for lattice in lattices:
-            ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
-            mapping = MajoranaMapping.verstraete_cirac(lattice)
+        ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
+        mapping = MajoranaMapping.verstraete_cirac(lattice)
 
-            assert mapping.num_qubits - len(mapping.stabilizers) == 2 * lattice.num_sites
-            assert len(mapping.stabilizers) > 0
+        assert mapping.num_qubits - len(mapping.stabilizers) == 2 * lattice.num_sites
+        assert len(mapping.stabilizers) > 0
 
-            qh_vc = mapper.run(ham, mapping)
-            assert qh_vc.num_qubits == mapping.num_qubits
+        qh_vc = mapper.run(ham, mapping)
+        assert qh_vc.num_qubits == mapping.num_qubits
 
-            # Convert stabilizers to Pauli labels
-            stabs = []
-            for _, word in mapping.stabilizers:
-                label = sparse_pauli_word_to_label(word, qh_vc.num_qubits)
-                stabs.append(label)
+        # Convert stabilizers to Pauli labels
+        stabs = []
+        for _, word in mapping.stabilizers:
+            label = sparse_pauli_word_to_label(word, qh_vc.num_qubits)
+            stabs.append(label)
 
-            # Check mutual commutation of stabilizers: [S_i, S_j] = 0
-            for i in range(len(stabs)):
-                for j in range(i + 1, len(stabs)):
-                    assert commute(stabs[i], stabs[j]), f"Stabilizers {i} and {j} do not commute!"
+        # Check mutual commutation of stabilizers: [S_i, S_j] = 0
+        for i in range(len(stabs)):
+            for j in range(i + 1, len(stabs)):
+                assert commute(stabs[i], stabs[j]), f"Stabilizers {i} and {j} do not commute!"
 
-            # Check commutation with Hamiltonian: [H, S_i] = 0
-            for i, stab in enumerate(stabs):
-                for p_term in qh_vc.pauli_strings:
-                    assert commute(stab, p_term), f"Stabilizer {i} does not commute with Hamiltonian term {p_term}!"
+        # Check commutation with Hamiltonian: [H, S_i] = 0
+        for i, stab in enumerate(stabs):
+            for p_term in qh_vc.pauli_strings:
+                assert commute(stab, p_term), f"Stabilizer {i} does not commute with Hamiltonian term {p_term}!"
 
     def test_pauli_weight_scaling(self) -> None:
         """Check nearest-neighbor hopping terms in the mapped qubit Hamiltonian.
@@ -164,7 +183,7 @@ class TestVerstraeteCiracMapping:
 
         max_weights = []
         for grid_length in [2, 3, 4]:
-            lattice = LatticeGraph.square(grid_length, grid_length, optimal_ordering=True)
+            lattice = LatticeGraph.square(grid_length, grid_length, dfs_ordering=True)
             # Create a simple hopping-only Hamiltonian (U=0) on the L x L lattice
             ham = create_hubbard_hamiltonian(lattice, epsilon=0.0, t=1.0, U=0.0)
 
@@ -198,7 +217,7 @@ class TestVerstraeteCiracSpectral:
 
         Model parameters: t = 1.0, U = 4.0, half-filling (epsilon = -U/2 = -2.0).
         """
-        lattice = LatticeGraph.square(2, 2, periodic_x=True, optimal_ordering=True)
+        lattice = LatticeGraph.square(2, 2, periodic_x=True, dfs_ordering=True)
         n_modes = 8  # 4 spatial sites * 2 spins
         hamiltonian = create_hubbard_hamiltonian(lattice, epsilon=-2.0, t=1.0, U=4.0)
         mapper = create("qubit_mapper", "qdk")
@@ -227,7 +246,7 @@ class TestVerstraeteCiracSpectral:
         Validates that the lowest eigenstates of the penalized Hamiltonian are
         in the +1 codespace sector of the generated loop-plaquette stabilizers.
         """
-        lattice = LatticeGraph.square(3, 2, optimal_ordering=True)
+        lattice = LatticeGraph.square(3, 2, dfs_ordering=True)
         n_modes = 12  # 6 spatial sites * 2 spins
         hamiltonian = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
         mapper = create("qubit_mapper", "qdk")

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -180,33 +180,139 @@ class TestVerstraeteCiracMapping:
             for p_term in qh_vc.pauli_strings:
                 assert commute(stab, p_term), f"Stabilizer {i} does not commute with Hamiltonian term {p_term}!"
 
-    def test_pauli_weight_scaling(self) -> None:
-        """Check nearest-neighbor hopping terms in the mapped qubit Hamiltonian.
+    @pytest.mark.parametrize(
+        ("lattice_type", "kwargs", "max_allowed_weight"),
+        [
+            ("square", {}, 8),
+            ("triangular", {}, 8),
+            ("honeycomb", {}, 12),
+            ("kagome", {}, 12),
+        ],
+        ids=[
+            "square",
+            "triangular",
+            "honeycomb",
+            "kagome",
+        ],
+    )
+    def test_pauli_weight_scaling(self, lattice_type: str, kwargs: dict, max_allowed_weight: int) -> None:
+        """Check if Pauli weights stay below a certain threshold.
 
-        Max Pauli weight of nearest-neighbor hops should be constant for square grids of dimensions:
-        - 2x2 (L=2)
-        - 3x3 (L=3)
-        - 4x4 (L=4)
+        Max Pauli weight of nearest-neighbor hops should be constant for grids of dimensions
+        L = 2, 3, 4.
+
+        We check across multiple lattice topologies (square, triangular, honeycomb, kagome):
+        - Mapped hopping terms retain constant-weight scaling (e.g. max weight 4 or 5)
+        - Mapped stabilizer products S_i * S_{i+1} have weights that are bounded by the
+          analytical Jordan-Wigner overlap formula: w <= delta_start + delta_end + 2,
+          where delta_start and delta_end are the qubit offsets between the stabilizer endpoints
+        - Physical loop-plaquettes are bounded by the topology's respective maximum weight limit
         """
         mapper = create("qubit_mapper", "qdk")
 
+        def multiply_pauli_labels(p1: str, p2: str) -> str:
+            table = {
+                ("I", "I"): "I",
+                ("I", "X"): "X",
+                ("I", "Y"): "Y",
+                ("I", "Z"): "Z",
+                ("X", "I"): "X",
+                ("X", "X"): "I",
+                ("X", "Y"): "Z",
+                ("X", "Z"): "Y",
+                ("Y", "I"): "Y",
+                ("Y", "X"): "Z",
+                ("Y", "Y"): "I",
+                ("Y", "Z"): "X",
+                ("Z", "I"): "Z",
+                ("Z", "X"): "Y",
+                ("Z", "Y"): "X",
+                ("Z", "Z"): "I",
+            }
+            return "".join(table[(c1, c2)] for c1, c2 in zip(p1, p2, strict=False))
+
+        def get_expected_weight(p1: str, p2: str) -> int:
+            indices1 = [idx for idx, char in enumerate(p1) if char != "I"]
+            indices2 = [idx for idx, char in enumerate(p2) if char != "I"]
+            if not indices1 or not indices2:
+                return 0
+            a1, b1 = indices1[0], indices1[-1]
+            a2, b2 = indices2[0], indices2[-1]
+            if a1 > a2:
+                a1, b1, a2, b2 = a2, b2, a1, b1
+            if a2 <= b1:
+                union_size = max(b1, b2) - a1 + 1
+                overlap_int = max(0, min(b1, b2) - a2 - 1)
+                return union_size - overlap_int
+            return (b1 - a1 + 1) + (b2 - a2 + 1)
+
+        def check_local_plaquette(
+            stabs_list: list[str],
+            i_idx: int,
+            w: int,
+            p_str: str,
+            thresh: int,
+            max_weight: int,
+        ) -> None:
+            indices1 = [idx for idx, char in enumerate(stabs_list[i_idx]) if char != "I"]
+            indices2 = [idx for idx, char in enumerate(stabs_list[i_idx + 1]) if char != "I"]
+            if indices1 and indices2:
+                a1, b1 = indices1[0], indices1[-1]
+                a2, b2 = indices2[0], indices2[-1]
+                if abs(a1 - a2) <= thresh and abs(b1 - b2) <= thresh:
+                    assert w <= max_weight, (
+                        f"Local plaquette stabilizer {p_str} has weight {w} > {max_weight}, violating local scaling"
+                    )
+
         max_weights = []
         for grid_length in [2, 3, 4]:
-            lattice = LatticeGraph.square(grid_length, grid_length, dfs_ordering=True)
+            lattice = getattr(LatticeGraph, lattice_type)(grid_length, grid_length, dfs_ordering=True, **kwargs)
             # Create a simple hopping-only Hamiltonian (U=0) on the L x L lattice
             ham = create_hubbard_hamiltonian(lattice, epsilon=0.0, t=1.0, U=0.0)
 
             vc_mapping = MajoranaMapping.verstraete_cirac(lattice)
             qh_vc = mapper.run(ham, vc_mapping)
 
+            # Identify and construct the set of stabilizer penalty terms using the product of stabilizers logic
+            stabs = [sparse_pauli_word_to_label(word, qh_vc.num_qubits) for _, word in vc_mapping.stabilizers]
+            half_stabs = len(stabs) // 2
+
+            penalty_strings = set()
+            if half_stabs >= 1:
+                threshold = (max_allowed_weight - 2) // 2
+
+                penalty_strings.add(stabs[0])
+                for i in range(half_stabs - 1):
+                    prod = multiply_pauli_labels(stabs[i], stabs[i + 1])
+                    penalty_strings.add(prod)
+                    weight = sum(1 for c in prod if c != "I")
+                    expected_weight = get_expected_weight(stabs[i], stabs[i + 1])
+                    assert weight <= expected_weight, (
+                        f"Weight {weight} exceeds analytical expected bound {expected_weight} "
+                        f"for product of stabilizer {i} and {i + 1}"
+                    )
+                    check_local_plaquette(stabs, i, weight, prod, threshold, max_allowed_weight)
+
+                penalty_strings.add(stabs[half_stabs])
+                for i in range(half_stabs, len(stabs) - 1):
+                    prod = multiply_pauli_labels(stabs[i], stabs[i + 1])
+                    penalty_strings.add(prod)
+                    weight = sum(1 for c in prod if c != "I")
+                    expected_weight = get_expected_weight(stabs[i], stabs[i + 1])
+                    assert weight <= expected_weight, (
+                        f"Weight {weight} exceeds analytical expected bound {expected_weight} "
+                        f"for product of stabilizer {i} and {i + 1}"
+                    )
+                    check_local_plaquette(stabs, i, weight, prod, threshold, max_allowed_weight)
+            else:
+                penalty_strings.update(stabs)
+
             weights = []
-            for pauli_str, coeff in zip(qh_vc.pauli_strings, qh_vc.coefficients, strict=False):
+            for pauli_str in qh_vc.pauli_strings:
                 if pauli_str == "I" * len(pauli_str):
                     continue
-                # Skip stabilizer penalty terms. Physical hops have a coefficient of t/2 (0.5 here).
-                # Stabilizer penalty terms are scaled by lambda = 1.0 + ||h_1||_1, which sums all hop
-                # amplitudes and yields >= 17.0 for L >= 2. A threshold of 2.0 (2.0*t) cleanly splits them.
-                if np.abs(coeff) > 2.0:
+                # Skip local plaquette penalty terms
+                if pauli_str in penalty_strings:
                     continue
                 # Weight is the number of non-I characters
                 weight = sum(1 for c in pauli_str if c != "I")
@@ -214,9 +320,17 @@ class TestVerstraeteCiracMapping:
 
             max_weights.append(max(weights))
 
-        assert max_weights[0] == max_weights[1] == max_weights[2], (
-            f"Maximum Pauli weights grew or varied with grid length: {max_weights}"
-        )
+        # Verify that physical terms have constant-weight scaling.
+        # For the triangular lattice, the 2x2 grid is too small to reach the bulk max hopping weight
+        # of 5, so we only assert that the weights are equal/constant for the larger sizes L >= 3.
+        if lattice_type == "triangular":
+            assert max_weights[1] == max_weights[2], (
+                f"Maximum Pauli weights grew with grid length for {lattice_type}: {max_weights}"
+            )
+        else:
+            assert all(w == max_weights[0] for w in max_weights), (
+                f"Maximum Pauli weights grew or varied with grid length for {lattice_type}: {max_weights}"
+            )
 
 
 class TestVerstraeteCiracSpectral:

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -43,36 +43,6 @@ class TestVerstraeteCiracMapping:
         mapping_4x4 = MajoranaMapping.verstraete_cirac(lattice_4x4)
         assert len(mapping_4x4.stabilizers) > 0
 
-    def test_general_lattices(self) -> None:
-        """Verify that QubitMapper consumes VC mapping for general lattices."""
-        mapper = create("qubit_mapper", "qdk")
-        lattices = [
-            LatticeGraph.square(2, 2),
-            LatticeGraph.square(3, 3),
-            LatticeGraph.honeycomb(2, 2, periodic_x=True, periodic_y=True),
-            LatticeGraph.triangular(2, 2),
-        ]
-        for lattice in lattices:
-            ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
-            mapping = MajoranaMapping.verstraete_cirac(lattice)
-            qh = mapper.run(ham, mapping)
-            assert qh.num_qubits == mapping.num_qubits
-            assert mapping.num_qubits - len(mapping.stabilizers) == 2 * lattice.num_sites
-
-    def test_honeycomb_and_higher_connectivity(self) -> None:
-        """Verify honeycomb (degree 3) and triangular/kagome (higher degree up to 6) lattices work."""
-        lattice_honeycomb = LatticeGraph.honeycomb(2, 2, periodic_x=True, periodic_y=True)
-        mapping_honeycomb = MajoranaMapping.verstraete_cirac(lattice_honeycomb)
-        assert len(mapping_honeycomb.stabilizers) > 0
-
-        lattice_triangular = LatticeGraph.triangular(2, 2)
-        mapping_triangular = MajoranaMapping.verstraete_cirac(lattice_triangular)
-        assert len(mapping_triangular.stabilizers) > 0
-
-        lattice_kagome = LatticeGraph.kagome(2, 2, periodic_x=True, periodic_y=True)
-        mapping_kagome = MajoranaMapping.verstraete_cirac(lattice_kagome)
-        assert len(mapping_kagome.stabilizers) > 0
-
     def test_majorana_raises_error(self) -> None:
         """Verstraete-Cirac mapping is bilinear-only and majorana(k) should raise ValueError."""
         lattice = LatticeGraph.square(2, 2)
@@ -135,7 +105,7 @@ class TestVerstraeteCiracMapping:
             assert np.isclose(c_orig, c_h5, atol=1e-10)
 
     def test_stabilizers_and_commutation(self) -> None:
-        """Verify that stabilizers mutually commute and commute with mapped H."""
+        """Verify that stabilizers mutually commute and commute with mapped H for various lattices."""
 
         def commute(p1: str, p2: str) -> bool:
             assert len(p1) == len(p2)
@@ -146,14 +116,25 @@ class TestVerstraeteCiracMapping:
             return (anti_commutes % 2) == 0
 
         mapper = create("qubit_mapper", "qdk")
-        for nx, ny in [(2, 2), (3, 3), (3, 4)]:
-            lattice = LatticeGraph.square(nx, ny)
-            ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
+        lattices = [
+            LatticeGraph.square(2, 2),
+            LatticeGraph.square(3, 3),
+            LatticeGraph.square(3, 4),
+            LatticeGraph.honeycomb(2, 2, periodic_x=True, periodic_y=True),
+            LatticeGraph.triangular(2, 2),
+            LatticeGraph.kagome(2, 2, periodic_x=True, periodic_y=True),
+            LatticeGraph.kagome(3, 3),
+        ]
 
+        for lattice in lattices:
+            ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
             mapping = MajoranaMapping.verstraete_cirac(lattice)
+
             assert mapping.num_qubits - len(mapping.stabilizers) == 2 * lattice.num_sites
+            assert len(mapping.stabilizers) > 0
 
             qh_vc = mapper.run(ham, mapping)
+            assert qh_vc.num_qubits == mapping.num_qubits
 
             # Convert stabilizers to Pauli labels
             stabs = []
@@ -183,7 +164,7 @@ class TestVerstraeteCiracMapping:
 
         max_weights = []
         for grid_length in [2, 3, 4]:
-            lattice = LatticeGraph.square(grid_length, grid_length)
+            lattice = LatticeGraph.square(grid_length, grid_length, optimal_ordering=True)
             # Create a simple hopping-only Hamiltonian (U=0) on the L x L lattice
             ham = create_hubbard_hamiltonian(lattice, epsilon=0.0, t=1.0, U=0.0)
 
@@ -217,7 +198,7 @@ class TestVerstraeteCiracSpectral:
 
         Model parameters: t = 1.0, U = 4.0, half-filling (epsilon = -U/2 = -2.0).
         """
-        lattice = LatticeGraph.square(2, 2, periodic_x=True)
+        lattice = LatticeGraph.square(2, 2, periodic_x=True, optimal_ordering=True)
         n_modes = 8  # 4 spatial sites * 2 spins
         hamiltonian = create_hubbard_hamiltonian(lattice, epsilon=-2.0, t=1.0, U=4.0)
         mapper = create("qubit_mapper", "qdk")
@@ -246,7 +227,7 @@ class TestVerstraeteCiracSpectral:
         Validates that the lowest eigenstates of the penalized Hamiltonian are
         in the +1 codespace sector of the generated loop-plaquette stabilizers.
         """
-        lattice = LatticeGraph.square(3, 2)
+        lattice = LatticeGraph.square(3, 2, optimal_ordering=True)
         n_modes = 12  # 6 spatial sites * 2 spins
         hamiltonian = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
         mapper = create("qubit_mapper", "qdk")

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -203,8 +203,9 @@ class TestVerstraeteCiracMapping:
             for pauli_str, coeff in zip(qh_vc.pauli_strings, qh_vc.coefficients, strict=False):
                 if pauli_str == "I" * len(pauli_str):
                     continue
-                # Skip stabilizer penalty terms (which have coefficient >= 9.0,
-                # whereas nearest-neighbor hops have coefficient <= 1.0)
+                # Skip stabilizer penalty terms. Physical hops have a coefficient of t/2 (0.5 here).
+                # Stabilizer penalty terms are scaled by lambda = 1.0 + ||h_1||_1, which sums all hop
+                # amplitudes and yields >= 17.0 for L >= 2. A threshold of 2.0 (2.0*t) cleanly splits them.
                 if np.abs(coeff) > 2.0:
                     continue
                 # Weight is the number of non-I characters

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -265,19 +265,19 @@ class TestVerstraeteCiracMapping:
                         f"Local plaquette stabilizer {p_str} has weight {w} > {max_weight}, violating local scaling"
                     )
 
-        def get_mst_edges(stabs_list: list[str], start_idx: int, count: int) -> list[tuple[int, int]]:
+        def get_mst_edges(stabs_list: list[str], start_idx: int, count: int, root: int) -> list[tuple[int, int]]:
             if count <= 1:
                 return []
 
             in_mst = [False] * count
-            min_weight = [1000000000] * count
-            parent = [0] * count
+            min_weight = [float("inf")] * count
+            parent = [root] * count
 
-            min_weight[0] = 0
+            min_weight[root] = 0
 
             for _ in range(count):
                 u = -1
-                min_val = 1000000000
+                min_val = float("inf")
                 for i in range(count):
                     if not in_mst[i] and min_weight[i] < min_val:
                         min_val = min_weight[i]
@@ -294,8 +294,9 @@ class TestVerstraeteCiracMapping:
                             parent[v] = u
 
             edges = []
-            for v in range(1, count):
-                edges.append((start_idx + parent[v], start_idx + v))
+            for v in range(count):
+                if v != root:
+                    edges.append((start_idx + parent[v], start_idx + v))
             return edges
 
         max_weights = []
@@ -315,8 +316,17 @@ class TestVerstraeteCiracMapping:
             if half_stabs >= 1:
                 threshold = (max_allowed_weight - 2) // 2
 
-                penalty_strings.add(stabs[0])
-                alpha_edges = get_mst_edges(stabs, 0, half_stabs)
+                # Find the lightest stabilizer as root for alpha
+                root_alpha = 0
+                root_alpha_weight = sum(1 for c in stabs[0] if c != "I")
+                for i in range(1, half_stabs):
+                    w = sum(1 for c in stabs[i] if c != "I")
+                    if w < root_alpha_weight:
+                        root_alpha = i
+                        root_alpha_weight = w
+
+                penalty_strings.add(stabs[root_alpha])
+                alpha_edges = get_mst_edges(stabs, 0, half_stabs, root_alpha)
                 for u, v in alpha_edges:
                     prod = multiply_pauli_labels(stabs[u], stabs[v])
                     penalty_strings.add(prod)
@@ -328,8 +338,17 @@ class TestVerstraeteCiracMapping:
                     )
                     check_local_plaquette(stabs, u, v, weight, prod, threshold, max_allowed_weight)
 
-                penalty_strings.add(stabs[half_stabs])
-                beta_edges = get_mst_edges(stabs, half_stabs, half_stabs)
+                # Find the lightest stabilizer as root for beta
+                root_beta = 0
+                root_beta_weight = sum(1 for c in stabs[half_stabs] if c != "I")
+                for i in range(1, half_stabs):
+                    w = sum(1 for c in stabs[half_stabs + i] if c != "I")
+                    if w < root_beta_weight:
+                        root_beta = i
+                        root_beta_weight = w
+
+                penalty_strings.add(stabs[half_stabs + root_beta])
+                beta_edges = get_mst_edges(stabs, half_stabs, half_stabs, root_beta)
                 for u, v in beta_edges:
                     prod = multiply_pauli_labels(stabs[u], stabs[v])
                     penalty_strings.add(prod)

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -248,14 +248,15 @@ class TestVerstraeteCiracMapping:
 
         def check_local_plaquette(
             stabs_list: list[str],
-            i_idx: int,
+            u_idx: int,
+            v_idx: int,
             w: int,
             p_str: str,
             thresh: int,
             max_weight: int,
         ) -> None:
-            indices1 = [idx for idx, char in enumerate(stabs_list[i_idx]) if char != "I"]
-            indices2 = [idx for idx, char in enumerate(stabs_list[i_idx + 1]) if char != "I"]
+            indices1 = [idx for idx, char in enumerate(stabs_list[u_idx]) if char != "I"]
+            indices2 = [idx for idx, char in enumerate(stabs_list[v_idx]) if char != "I"]
             if indices1 and indices2:
                 a1, b1 = indices1[0], indices1[-1]
                 a2, b2 = indices2[0], indices2[-1]
@@ -263,6 +264,39 @@ class TestVerstraeteCiracMapping:
                     assert w <= max_weight, (
                         f"Local plaquette stabilizer {p_str} has weight {w} > {max_weight}, violating local scaling"
                     )
+
+        def get_mst_edges(stabs_list: list[str], start_idx: int, count: int) -> list[tuple[int, int]]:
+            if count <= 1:
+                return []
+
+            in_mst = [False] * count
+            min_weight = [1000000000] * count
+            parent = [0] * count
+
+            min_weight[0] = 0
+
+            for _ in range(count):
+                u = -1
+                min_val = 1000000000
+                for i in range(count):
+                    if not in_mst[i] and min_weight[i] < min_val:
+                        min_val = min_weight[i]
+                        u = i
+
+                in_mst[u] = True
+
+                for v in range(count):
+                    if not in_mst[v]:
+                        prod_str = multiply_pauli_labels(stabs_list[start_idx + u], stabs_list[start_idx + v])
+                        w = sum(1 for c in prod_str if c != "I")
+                        if w < min_weight[v]:
+                            min_weight[v] = w
+                            parent[v] = u
+
+            edges = []
+            for v in range(1, count):
+                edges.append((start_idx + parent[v], start_idx + v))
+            return edges
 
         max_weights = []
         for grid_length in [2, 3, 4]:
@@ -282,28 +316,30 @@ class TestVerstraeteCiracMapping:
                 threshold = (max_allowed_weight - 2) // 2
 
                 penalty_strings.add(stabs[0])
-                for i in range(half_stabs - 1):
-                    prod = multiply_pauli_labels(stabs[i], stabs[i + 1])
+                alpha_edges = get_mst_edges(stabs, 0, half_stabs)
+                for u, v in alpha_edges:
+                    prod = multiply_pauli_labels(stabs[u], stabs[v])
                     penalty_strings.add(prod)
                     weight = sum(1 for c in prod if c != "I")
-                    expected_weight = get_expected_weight(stabs[i], stabs[i + 1])
+                    expected_weight = get_expected_weight(stabs[u], stabs[v])
                     assert weight <= expected_weight, (
                         f"Weight {weight} exceeds analytical expected bound {expected_weight} "
-                        f"for product of stabilizer {i} and {i + 1}"
+                        f"for product of stabilizer {u} and {v}"
                     )
-                    check_local_plaquette(stabs, i, weight, prod, threshold, max_allowed_weight)
+                    check_local_plaquette(stabs, u, v, weight, prod, threshold, max_allowed_weight)
 
                 penalty_strings.add(stabs[half_stabs])
-                for i in range(half_stabs, len(stabs) - 1):
-                    prod = multiply_pauli_labels(stabs[i], stabs[i + 1])
+                beta_edges = get_mst_edges(stabs, half_stabs, half_stabs)
+                for u, v in beta_edges:
+                    prod = multiply_pauli_labels(stabs[u], stabs[v])
                     penalty_strings.add(prod)
                     weight = sum(1 for c in prod if c != "I")
-                    expected_weight = get_expected_weight(stabs[i], stabs[i + 1])
+                    expected_weight = get_expected_weight(stabs[u], stabs[v])
                     assert weight <= expected_weight, (
                         f"Weight {weight} exceeds analytical expected bound {expected_weight} "
-                        f"for product of stabilizer {i} and {i + 1}"
+                        f"for product of stabilizer {u} and {v}"
                     )
-                    check_local_plaquette(stabs, i, weight, prod, threshold, max_allowed_weight)
+                    check_local_plaquette(stabs, u, v, weight, prod, threshold, max_allowed_weight)
             else:
                 penalty_strings.update(stabs)
 

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -1,0 +1,195 @@
+"""Tests for Verstraete-Cirac fermion-to-qubit mapping."""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import tempfile
+
+import h5py
+import numpy as np
+import pytest
+from scipy.sparse.linalg import eigsh
+
+from qdk_chemistry.algorithms import create
+from qdk_chemistry.data import LatticeGraph, MajoranaMapping, QubitHamiltonian
+from qdk_chemistry.utils.model_hamiltonians import create_hubbard_hamiltonian, create_huckel_hamiltonian
+
+
+class TestVerstraeteCiracMapping:
+    """Tests covering the Verstraete-Cirac mapping factory, dimensions, and properties."""
+
+    def test_factory_and_dimensions(self) -> None:
+        """Test that VC factory accepts correct grid dimensions and rejects invalid ones."""
+        # Valid even x_dimension grids
+        lattice_2x2 = LatticeGraph.square(2, 2)
+        mapping_2x2 = MajoranaMapping.verstraete_cirac(lattice_2x2)
+        assert mapping_2x2.grid_nx == 2
+        assert mapping_2x2.grid_ny == 2
+        assert mapping_2x2.name == "verstraete-cirac"
+        assert mapping_2x2.base_encoding == "verstraete-cirac"
+        assert not mapping_2x2.is_majorana_atomic
+
+        lattice_2x3 = LatticeGraph.square(2, 3)
+        mapping_2x3 = MajoranaMapping.verstraete_cirac(lattice_2x3)
+        assert mapping_2x3.grid_nx == 2
+        assert mapping_2x3.grid_ny == 3
+
+        lattice_4x4 = LatticeGraph.square(4, 4)
+        mapping_4x4 = MajoranaMapping.verstraete_cirac(lattice_4x4)
+        assert mapping_4x4.grid_nx == 4
+        assert mapping_4x4.grid_ny == 4
+
+        lattice_3x3 = LatticeGraph.square(3, 3)
+        mapping_3x3 = MajoranaMapping.verstraete_cirac(lattice_3x3)
+        assert mapping_3x3.grid_nx == 3
+        assert mapping_3x3.grid_ny == 3
+
+        # Invalid spin species count should raise ValueError / invalid_argument
+        with pytest.raises(ValueError, match="spin"):
+            MajoranaMapping.verstraete_cirac(lattice_2x2, num_spin_species=0)
+
+    def test_general_lattices_single_spin(self) -> None:
+        """Verify that QubitMapper consumes VC mapping for general 2D lattices with single spin species."""
+        mapper = create("qubit_mapper", "qdk")
+        for nx, ny in [(2, 2), (2, 3), (3, 3), (4, 4)]:
+            lattice = LatticeGraph.square(nx, ny)
+            ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
+            mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=1)
+            qh = mapper.run(ham, mapping)
+            assert qh.num_qubits == 2 * nx * ny
+
+    def test_majorana_raises_error(self) -> None:
+        """Verstraete-Cirac mapping is bilinear-only and majorana(k) should raise ValueError."""
+        lattice = LatticeGraph.square(2, 2)
+        mapping = MajoranaMapping.verstraete_cirac(lattice)
+        with pytest.raises(ValueError, match="bilinear-only"):
+            mapping.majorana(0)
+
+    def test_without_tapering(self) -> None:
+        """without_tapering should return the mapping itself (as it has no tapering)."""
+        lattice = LatticeGraph.square(2, 2)
+        mapping = MajoranaMapping.verstraete_cirac(lattice)
+        base = mapping.without_tapering()
+        assert base.grid_nx == 2
+        assert base.grid_ny == 2
+        assert base.name == "verstraete-cirac"
+
+    def test_serialization_round_trip(self) -> None:
+        """Verify that Verstraete-Cirac mapping survives JSON and HDF5 serialization round-trips."""
+        lattice = LatticeGraph.square(2, 2)
+        mapping = MajoranaMapping.verstraete_cirac(lattice)
+
+        # JSON Round-trip
+        json_data = mapping.to_json()
+        loaded_json = MajoranaMapping.from_json(json_data)
+        assert loaded_json.name == mapping.name
+        assert loaded_json.grid_nx == mapping.grid_nx
+        assert loaded_json.grid_ny == mapping.grid_ny
+        assert loaded_json.num_modes == mapping.num_modes
+        assert loaded_json.num_qubits == mapping.num_qubits
+        assert not loaded_json.is_majorana_atomic
+
+        # HDF5 Round-trip
+        with tempfile.NamedTemporaryFile(suffix=".h5") as f:
+            with h5py.File(f.name, "w") as hf:
+                mapping.to_hdf5(hf)
+            with h5py.File(f.name, "r") as hf:
+                loaded_hdf5 = MajoranaMapping.from_hdf5(hf)
+        assert loaded_hdf5.name == mapping.name
+        assert loaded_hdf5.grid_nx == mapping.grid_nx
+        assert loaded_hdf5.grid_ny == mapping.grid_ny
+        assert loaded_hdf5.num_modes == mapping.num_modes
+        assert loaded_hdf5.num_qubits == mapping.num_qubits
+        assert not loaded_hdf5.is_majorana_atomic
+
+
+class TestVerstraeteCiracHubbardSpectral:
+    """Spectral validation of Verstraete-Cirac mapping for Fermi-Hubbard model."""
+
+    def test_spectral_validation_2x2_hubbard(self) -> None:
+        """Compare eigenvalues of 2x2 Hubbard model under VC and Jordan-Wigner mappings.
+
+        Model parameters: t = 1.0, U = 4.0, half-filling (epsilon = -U/2 = -2.0).
+        """
+        # 1. Construct 2x2 square lattice
+        lattice = LatticeGraph.square(2, 2)
+        # 4 sites in lattice, each with 2 spin species -> 8 spin-orbitals / modes
+        n_modes = 8
+
+        # 2. Construct Hubbard Hamiltonian
+        hubbard_ham = create_hubbard_hamiltonian(lattice, epsilon=-2.0, t=1.0, U=4.0)
+
+        # 3. Map using Jordan-Wigner (JW)
+        mapper = create("qubit_mapper", "qdk")
+        jw_mapping = MajoranaMapping.jordan_wigner(num_modes=n_modes)
+        qh_jw = mapper.run(hubbard_ham, jw_mapping)
+
+        # Solve JW eigenvalues using sparse solver
+        h_jw = qh_jw.to_matrix(sparse=True)
+        eigs_jw, _ = eigsh(h_jw, k=10, which="SA")
+        eigs_jw = np.sort(eigs_jw)
+        unique_jw = np.unique(np.round(eigs_jw, 6))
+
+        # 4. Map using Verstraete-Cirac (VC)
+        vc_mapping = MajoranaMapping.verstraete_cirac(lattice)
+        qh_vc = mapper.run(hubbard_ham, vc_mapping)
+
+        # Verify VC number of qubits.
+        assert qh_vc.num_qubits == 2 * n_modes
+
+        # Solve VC eigenvalues using sparse solver
+        h_vc = qh_vc.to_matrix(sparse=True)
+        # Solve for 128 eigenvalues to cover the 64-fold degeneracy of the ground state and first excited state
+        eigs_vc, _ = eigsh(h_vc, k=128, which="SA")
+        eigs_vc = np.sort(eigs_vc)
+        unique_vc = np.unique(np.round(eigs_vc, 6))
+
+        # The unique lowest eigenvalues in the code space of VC must match the unique lowest eigenvalues of JW.
+        # We check the 2 lowest unique eigenvalues.
+        np.testing.assert_allclose(unique_vc[:2], unique_jw[:2], atol=1e-10)
+
+        # Test serialization of the resulting QubitHamiltonian
+        qh_json = qh_vc.to_json()
+        qh_loaded = QubitHamiltonian.from_json(qh_json)
+        assert qh_loaded.num_qubits == qh_vc.num_qubits
+        assert len(qh_loaded.pauli_strings) == len(qh_vc.pauli_strings)
+
+
+class TestVerstraeteCiracPauliWeightScaling:
+    """Verify that nearest-neighbor hop Pauli weight remains constant for grid lengths L in {2, 3, 4}."""
+
+    def test_pauli_weight_scaling(self) -> None:
+        """Check nearest-neighbor hopping terms in the mapped qubit Hamiltonian.
+
+        Max Pauli weight of nearest-neighbor hops should be constant for grids of dimensions:
+        - 2x2 (L=2)
+        - 2x3 (L=3)
+        - 2x4 (L=4)
+        """
+        mapper = create("qubit_mapper", "qdk")
+
+        max_weights = []
+        for grid_length in [2, 3, 4]:
+            lattice = LatticeGraph.square(2, grid_length)
+            # Create a simple hopping-only Hamiltonian (U=0) on the 2xL lattice
+            ham = create_hubbard_hamiltonian(lattice, epsilon=0.0, t=1.0, U=0.0)
+
+            vc_mapping = MajoranaMapping.verstraete_cirac(lattice)
+            qh_vc = mapper.run(ham, vc_mapping)
+
+            weights = []
+            for pauli_str in qh_vc.pauli_strings:
+                if pauli_str == "I" * len(pauli_str):
+                    continue
+                # Weight is the number of non-I characters
+                weight = sum(1 for c in pauli_str if c != "I")
+                weights.append(weight)
+
+            max_weights.append(max(weights))
+
+        # Check that the maximum Pauli weight does not grow with L
+        assert max_weights[0] == max_weights[1] == max_weights[2], (
+            f"Maximum Pauli weights grew or varied with grid length: {max_weights}"
+        )

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -134,26 +134,28 @@ class TestVerstraeteCiracMapping:
             lattice = LatticeGraph.square(nx, ny)
             ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
 
-            mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=1)
-            assert len(mapping.stabilizers) == nx * ny - nx - ny + 1
+            # Verify stabilizer properties for both spinless (nss=1) and spinful (nss=2) cases
+            for nss in [1, 2]:
+                mapping = MajoranaMapping.verstraete_cirac(lattice, nss)
+                assert len(mapping.stabilizers) == nss * nx * ny
 
-            qh_vc = mapper.run(ham, mapping)
+                qh_vc = mapper.run(ham, mapping)
 
-            # Convert stabilizers to Pauli labels
-            stabs = []
-            for _, word in mapping.stabilizers:
-                label = sparse_pauli_word_to_label(word, qh_vc.num_qubits)
-                stabs.append(label)
+                # Convert stabilizers to Pauli labels
+                stabs = []
+                for _, word in mapping.stabilizers:
+                    label = sparse_pauli_word_to_label(word, qh_vc.num_qubits)
+                    stabs.append(label)
 
-            # Check mutual commutation of stabilizers: [S_i, S_j] = 0
-            for i in range(len(stabs)):
-                for j in range(i + 1, len(stabs)):
-                    assert commute(stabs[i], stabs[j]), f"Stabilizers {i} and {j} do not commute!"
+                # Check mutual commutation of stabilizers: [S_i, S_j] = 0
+                for i in range(len(stabs)):
+                    for j in range(i + 1, len(stabs)):
+                        assert commute(stabs[i], stabs[j]), f"Stabilizers {i} and {j} do not commute!"
 
-            # Check commutation with Hamiltonian: [H, S_i] = 0
-            for i, stab in enumerate(stabs):
-                for p_term in qh_vc.pauli_strings:
-                    assert commute(stab, p_term), f"Stabilizer {i} does not commute with Hamiltonian term {p_term}!"
+                # Check commutation with Hamiltonian: [H, S_i] = 0
+                for i, stab in enumerate(stabs):
+                    for p_term in qh_vc.pauli_strings:
+                        assert commute(stab, p_term), f"Stabilizer {i} does not commute with Hamiltonian term {p_term}!"
 
     def test_pauli_weight_scaling(self) -> None:
         """Check nearest-neighbor hopping terms in the mapped qubit Hamiltonian.
@@ -196,85 +198,83 @@ class TestVerstraeteCiracMapping:
 class TestVerstraeteCiracSpectral:
     """Tests covering the spectral validation of the Verstraete-Cirac mapping."""
 
-    @pytest.mark.slow
     def test_spectral_validation_2x2_hubbard(self) -> None:
-        """Compare eigenvalues of 2x2 periodic Fermi-Hubbard model under VC and Jordan-Wigner mappings.
+        """Compare eigenvalues of 2x2 periodic Fermi-Hubbard model under VC and JW mappings.
 
         Model parameters: t = 1.0, U = 4.0, half-filling (epsilon = -U/2 = -2.0).
         """
         lattice = LatticeGraph.square(2, 2, periodic_x=True)
-
-        # 4 sites in lattice, each with 2 spin species -> 8 spin-orbitals / modes
-        n_modes = 8
-
-        hubbard_ham = create_hubbard_hamiltonian(lattice, epsilon=-2.0, t=1.0, U=4.0)
-
+        n_modes = 8  # 4 spatial sites * 2 spin species
+        hamiltonian = create_hubbard_hamiltonian(lattice, epsilon=-2.0, t=1.0, U=4.0)
         mapper = create("qubit_mapper", "qdk")
+
         jw_mapping = MajoranaMapping.jordan_wigner(num_modes=n_modes)
-        qh_jw = mapper.run(hubbard_ham, jw_mapping)
-
-        # Solve JW eigenvalues using sparse solver
-        h_jw = qh_jw.to_matrix(sparse=True)
-        eigs_jw, _ = eigsh(h_jw, k=10, which="SA")
-        eigs_jw = np.sort(eigs_jw)
-        unique_jw = np.unique(np.round(eigs_jw, 6))
-
-        vc_mapping = MajoranaMapping.verstraete_cirac(lattice)
-        qh_vc = mapper.run(hubbard_ham, vc_mapping)
-
-        assert qh_vc.num_qubits == 2 * n_modes
-        h_vc = qh_vc.to_matrix(sparse=True)
-
-        # Solve for 128 eigenvalues to cover the 64-fold degeneracy of the ground state and first excited state
-        eigs_vc, _ = eigsh(h_vc, k=128, which="SA")
-        eigs_vc = np.sort(eigs_vc)
-        unique_vc = np.unique(np.round(eigs_vc, 6))
-
-        # We check the 2 lowest unique eigenvalues.
-        np.testing.assert_allclose(unique_vc[:2], unique_jw[:2], atol=1e-10)
-
-    @pytest.mark.slow
-    def test_spectral_validation_3x3_huckel(self) -> None:
-        """Compare eigenvalues of 3x3 Hückel model under VC and Jordan-Wigner mappings."""
-        lattice = LatticeGraph.square(3, 3)
-
-        # 9 sites in lattice, each with 1 spin species -> 9 spin-orbitals / modes
-        n_modes = 9
-
-        huckel_ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
-
-        mapper = create("qubit_mapper", "qdk")
-        jw_mapping = MajoranaMapping.jordan_wigner(num_modes=n_modes)
-        qh_jw = mapper.run(huckel_ham, jw_mapping)
+        qh_jw = mapper.run(hamiltonian, jw_mapping)
         h_jw = qh_jw.to_matrix(sparse=True)
         eigs_jw, _ = eigsh(h_jw, k=10, which="SA")
         unique_jw = np.unique(np.round(np.sort(eigs_jw), 6))
 
-        mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=1)
-        qh_vc = mapper.run(huckel_ham, mapping)
+        vc_mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=2)
+        qh_vc = mapper.run(hamiltonian, vc_mapping)
+
+        # Verify system size and extract lowest unique eigenvalues
+        assert qh_vc.num_qubits == 2 * n_modes
         h_vc = qh_vc.to_matrix(sparse=True)
+        eigs_vc, _ = eigsh(h_vc, k=10, which="SA")
+        unique_vc = np.unique(np.round(np.sort(eigs_vc), 6))
 
-        # We solve for a few eigenvalues of H_vc and project into the code space (+1 eigenstate of all stabilizers)
-        eigs_vc, vecs_vc = eigsh(h_vc, k=40, which="SA")
+        # Ensure lowest physical energy levels match baseline
+        np.testing.assert_allclose(unique_vc[:2], unique_jw[:2], atol=1e-10)
 
+    def test_spectral_validation_3x3_huckel(self) -> None:
+        """Compare eigenvalues of 3x3 Hückel model under VC and JW mappings.
+
+        Validates that the lowest eigenstates of the penalized Hamiltonian are
+        in the +1 codespace sector of the generated loop-plaquette stabilizers.
+        """
+        lattice = LatticeGraph.square(3, 3)
+        n_modes = 9  # 9 spatial sites * 1 spin species (spinless)
+        hamiltonian = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
+        mapper = create("qubit_mapper", "qdk")
+
+        jw_mapping = MajoranaMapping.jordan_wigner(num_modes=n_modes)
+        qh_jw = mapper.run(hamiltonian, jw_mapping)
+        h_jw = qh_jw.to_matrix(sparse=True)
+        eigs_jw, _ = eigsh(h_jw, k=10, which="SA")
+        unique_jw = np.unique(np.round(np.sort(eigs_jw), 6))
+
+        vc_mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=1)
+        qh_vc = mapper.run(hamiltonian, vc_mapping)
+
+        # Extract lowest eigenstates and their respective eigenstates
+        assert qh_vc.num_qubits == 2 * n_modes
+        h_vc = qh_vc.to_matrix(sparse=True)
+        eigs_vc, vecs_vc = eigsh(h_vc, k=10, which="SA")
+
+        # Construct sparse matrices for each generated loop-plaquette stabilizer
         stabs = []
-        for coeff, word in mapping.stabilizers:
+        for coeff, word in vc_mapping.stabilizers:
             label = sparse_pauli_word_to_label(word, qh_vc.num_qubits)
             qh_stab = QubitHamiltonian([label], np.array([coeff]))
             stabs.append(qh_stab.to_matrix(sparse=True))
 
+        # Project and filter out any unphysical states (out-of-codespace)
         code_space_eigs = []
         for idx in range(len(eigs_vc)):
             vec = vecs_vc[:, idx]
             is_in_code_space = True
+
             for stab in stabs:
-                exp = np.real(vec.conj().T @ (stab @ vec))
-                if not np.isclose(exp, 1.0, atol=1e-4):
+                # Only a simultaneous +1 eigenstate belongs to the physical codespace
+                expectation_value = np.real(vec.conj().T @ (stab @ vec))
+                if not np.isclose(expectation_value, 1.0, atol=1e-4):
                     is_in_code_space = False
                     break
+
             if is_in_code_space:
                 code_space_eigs.append(eigs_vc[idx])
 
+        # Assert that physical states were found and unique energy levels match baseline
         assert len(code_space_eigs) >= 2
         unique_vc = np.unique(np.round(np.sort(code_space_eigs), 6))
         np.testing.assert_allclose(unique_vc[:2], unique_jw[:2], atol=1e-10)

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -64,7 +64,7 @@ class TestVerstraeteCiracMapping:
         lattice_honeycomb = LatticeGraph.honeycomb(2, 2, periodic_x=True, periodic_y=True)
         mapping_honeycomb = MajoranaMapping.verstraete_cirac(lattice_honeycomb)
         assert len(mapping_honeycomb.stabilizers) > 0
-        
+
         lattice_triangular = LatticeGraph.triangular(2, 2)
         mapping_triangular = MajoranaMapping.verstraete_cirac(lattice_triangular)
         assert len(mapping_triangular.stabilizers) > 0

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -131,6 +131,15 @@ class TestVerstraeteCiracMapping:
             ("kagome", (2, 2), {"periodic_x": True, "periodic_y": True}),
             ("kagome", (3, 3), {}),
         ],
+        ids=[
+            "square-2x2",
+            "square-3x3",
+            "square-3x4",
+            "honeycomb-2x2-periodic",
+            "triangular-2x2",
+            "kagome-2x2-periodic",
+            "kagome-3x3",
+        ],
     )
     def test_stabilizers_and_commutation(self, lattice_type: str, args: tuple, kwargs: dict) -> None:
         """Verify that stabilizers mutually commute and commute with mapped H for various lattices."""

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 from scipy.sparse.linalg import eigsh
 
+from qdk_chemistry._core.data import sparse_pauli_word_to_label
 from qdk_chemistry.algorithms import create
 from qdk_chemistry.data import LatticeGraph, MajoranaMapping, QubitHamiltonian
 from qdk_chemistry.utils.model_hamiltonians import create_hubbard_hamiltonian, create_huckel_hamiltonian
@@ -22,36 +23,32 @@ class TestVerstraeteCiracMapping:
 
     def test_factory_and_dimensions(self) -> None:
         """Test that VC factory accepts correct grid dimensions and rejects invalid ones."""
-        # Valid even x_dimension grids
+        # Testing valid grids: square and rectangular
         lattice_2x2 = LatticeGraph.square(2, 2)
         mapping_2x2 = MajoranaMapping.verstraete_cirac(lattice_2x2)
-        assert mapping_2x2.grid_nx == 2
-        assert mapping_2x2.grid_ny == 2
+        assert len(mapping_2x2.stabilizers) > 0
         assert mapping_2x2.name == "verstraete-cirac"
         assert mapping_2x2.base_encoding == "verstraete-cirac"
         assert not mapping_2x2.is_majorana_atomic
 
         lattice_2x3 = LatticeGraph.square(2, 3)
         mapping_2x3 = MajoranaMapping.verstraete_cirac(lattice_2x3)
-        assert mapping_2x3.grid_nx == 2
-        assert mapping_2x3.grid_ny == 3
-
-        lattice_4x4 = LatticeGraph.square(4, 4)
-        mapping_4x4 = MajoranaMapping.verstraete_cirac(lattice_4x4)
-        assert mapping_4x4.grid_nx == 4
-        assert mapping_4x4.grid_ny == 4
+        assert len(mapping_2x3.stabilizers) > 0
 
         lattice_3x3 = LatticeGraph.square(3, 3)
         mapping_3x3 = MajoranaMapping.verstraete_cirac(lattice_3x3)
-        assert mapping_3x3.grid_nx == 3
-        assert mapping_3x3.grid_ny == 3
+        assert len(mapping_3x3.stabilizers) > 0
+
+        lattice_4x4 = LatticeGraph.square(4, 4)
+        mapping_4x4 = MajoranaMapping.verstraete_cirac(lattice_4x4)
+        assert len(mapping_4x4.stabilizers) > 0
 
         # Invalid spin species count should raise ValueError / invalid_argument
         with pytest.raises(ValueError, match="spin"):
             MajoranaMapping.verstraete_cirac(lattice_2x2, num_spin_species=0)
 
-    def test_general_lattices_single_spin(self) -> None:
-        """Verify that QubitMapper consumes VC mapping for general 2D lattices with single spin species."""
+    def test_general_lattices(self) -> None:
+        """Verify that QubitMapper consumes VC mapping for general 2D lattices."""
         mapper = create("qubit_mapper", "qdk")
         for nx, ny in [(2, 2), (2, 3), (3, 3), (4, 4)]:
             lattice = LatticeGraph.square(nx, ny)
@@ -72,8 +69,7 @@ class TestVerstraeteCiracMapping:
         lattice = LatticeGraph.square(2, 2)
         mapping = MajoranaMapping.verstraete_cirac(lattice)
         base = mapping.without_tapering()
-        assert base.grid_nx == 2
-        assert base.grid_ny == 2
+        assert len(base.stabilizers) == len(mapping.stabilizers)
         assert base.name == "verstraete-cirac"
 
     def test_serialization_round_trip(self) -> None:
@@ -81,15 +77,27 @@ class TestVerstraeteCiracMapping:
         lattice = LatticeGraph.square(2, 2)
         mapping = MajoranaMapping.verstraete_cirac(lattice)
 
+        # Construct a simple Hubbard Hamiltonian on the lattice
+        ham = create_hubbard_hamiltonian(lattice, epsilon=-2.0, t=1.0, U=4.0)
+        mapper = create("qubit_mapper", "qdk")
+        qh_orig = mapper.run(ham, mapping)
+
         # JSON Round-trip
         json_data = mapping.to_json()
         loaded_json = MajoranaMapping.from_json(json_data)
         assert loaded_json.name == mapping.name
-        assert loaded_json.grid_nx == mapping.grid_nx
-        assert loaded_json.grid_ny == mapping.grid_ny
         assert loaded_json.num_modes == mapping.num_modes
         assert loaded_json.num_qubits == mapping.num_qubits
         assert not loaded_json.is_majorana_atomic
+
+        qh_json = mapper.run(ham, loaded_json)
+        assert qh_json.num_qubits == qh_orig.num_qubits
+        assert len(qh_json.pauli_strings) == len(qh_orig.pauli_strings)
+        terms_orig = sorted(zip(qh_orig.pauli_strings, qh_orig.coefficients, strict=False))
+        terms_json = sorted(zip(qh_json.pauli_strings, qh_json.coefficients, strict=False))
+        for (p_orig, c_orig), (p_json, c_json) in zip(terms_orig, terms_json, strict=False):
+            assert p_orig == p_json
+            assert np.isclose(c_orig, c_json, atol=1e-10)
 
         # HDF5 Round-trip
         with tempfile.NamedTemporaryFile(suffix=".h5") as f:
@@ -98,30 +106,109 @@ class TestVerstraeteCiracMapping:
             with h5py.File(f.name, "r") as hf:
                 loaded_hdf5 = MajoranaMapping.from_hdf5(hf)
         assert loaded_hdf5.name == mapping.name
-        assert loaded_hdf5.grid_nx == mapping.grid_nx
-        assert loaded_hdf5.grid_ny == mapping.grid_ny
         assert loaded_hdf5.num_modes == mapping.num_modes
         assert loaded_hdf5.num_qubits == mapping.num_qubits
         assert not loaded_hdf5.is_majorana_atomic
 
+        qh_hdf5 = mapper.run(ham, loaded_hdf5)
+        assert qh_hdf5.num_qubits == qh_orig.num_qubits
+        assert len(qh_hdf5.pauli_strings) == len(qh_orig.pauli_strings)
+        terms_hdf5 = sorted(zip(qh_hdf5.pauli_strings, qh_hdf5.coefficients, strict=False))
+        for (p_orig, c_orig), (p_h5, c_h5) in zip(terms_orig, terms_hdf5, strict=False):
+            assert p_orig == p_h5
+            assert np.isclose(c_orig, c_h5, atol=1e-10)
 
-class TestVerstraeteCiracHubbardSpectral:
-    """Spectral validation of Verstraete-Cirac mapping for Fermi-Hubbard model."""
+    def test_stabilizers_and_commutation(self) -> None:
+        """Verify that stabilizers mutually commute and commute with mapped H."""
 
+        def commute(p1: str, p2: str) -> bool:
+            assert len(p1) == len(p2)
+            anti_commutes = 0
+            for c1, c2 in zip(p1, p2, strict=False):
+                if c1 != "I" and c2 not in {"I", c1}:
+                    anti_commutes += 1
+            return (anti_commutes % 2) == 0
+
+        mapper = create("qubit_mapper", "qdk")
+        for nx, ny in [(2, 2), (3, 3), (3, 4)]:
+            lattice = LatticeGraph.square(nx, ny)
+            ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
+
+            mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=1)
+            assert len(mapping.stabilizers) == nx * ny - nx - ny + 1
+
+            qh_vc = mapper.run(ham, mapping)
+
+            # Convert stabilizers to Pauli labels
+            stabs = []
+            for _, word in mapping.stabilizers:
+                label = sparse_pauli_word_to_label(word, qh_vc.num_qubits)
+                stabs.append(label)
+
+            # Check mutual commutation of stabilizers: [S_i, S_j] = 0
+            for i in range(len(stabs)):
+                for j in range(i + 1, len(stabs)):
+                    assert commute(stabs[i], stabs[j]), f"Stabilizers {i} and {j} do not commute!"
+
+            # Check commutation with Hamiltonian: [H, S_i] = 0
+            for i, stab in enumerate(stabs):
+                for p_term in qh_vc.pauli_strings:
+                    assert commute(stab, p_term), f"Stabilizer {i} does not commute with Hamiltonian term {p_term}!"
+
+    def test_pauli_weight_scaling(self) -> None:
+        """Check nearest-neighbor hopping terms in the mapped qubit Hamiltonian.
+
+        Max Pauli weight of nearest-neighbor hops should be constant for square grids of dimensions:
+        - 2x2 (L=2)
+        - 3x3 (L=3)
+        - 4x4 (L=4)
+        """
+        mapper = create("qubit_mapper", "qdk")
+
+        max_weights = []
+        for grid_length in [2, 3, 4]:
+            lattice = LatticeGraph.square(grid_length, grid_length)
+            # Create a simple hopping-only Hamiltonian (U=0) on the L x L lattice
+            ham = create_hubbard_hamiltonian(lattice, epsilon=0.0, t=1.0, U=0.0)
+
+            vc_mapping = MajoranaMapping.verstraete_cirac(lattice)
+            qh_vc = mapper.run(ham, vc_mapping)
+
+            weights = []
+            for pauli_str, coeff in zip(qh_vc.pauli_strings, qh_vc.coefficients, strict=False):
+                if pauli_str == "I" * len(pauli_str):
+                    continue
+                # Skip stabilizer penalty terms (which have coefficient >= 9.0,
+                # whereas nearest-neighbor hops have coefficient <= 1.0)
+                if np.abs(coeff) > 2.0:
+                    continue
+                # Weight is the number of non-I characters
+                weight = sum(1 for c in pauli_str if c != "I")
+                weights.append(weight)
+
+            max_weights.append(max(weights))
+
+        assert max_weights[0] == max_weights[1] == max_weights[2], (
+            f"Maximum Pauli weights grew or varied with grid length: {max_weights}"
+        )
+
+
+class TestVerstraeteCiracSpectral:
+    """Tests covering the spectral validation of the Verstraete-Cirac mapping."""
+
+    @pytest.mark.slow
     def test_spectral_validation_2x2_hubbard(self) -> None:
-        """Compare eigenvalues of 2x2 Hubbard model under VC and Jordan-Wigner mappings.
+        """Compare eigenvalues of 2x2 periodic Fermi-Hubbard model under VC and Jordan-Wigner mappings.
 
         Model parameters: t = 1.0, U = 4.0, half-filling (epsilon = -U/2 = -2.0).
         """
-        # 1. Construct 2x2 square lattice
-        lattice = LatticeGraph.square(2, 2)
+        lattice = LatticeGraph.square(2, 2, periodic_x=True)
+
         # 4 sites in lattice, each with 2 spin species -> 8 spin-orbitals / modes
         n_modes = 8
 
-        # 2. Construct Hubbard Hamiltonian
         hubbard_ham = create_hubbard_hamiltonian(lattice, epsilon=-2.0, t=1.0, U=4.0)
 
-        # 3. Map using Jordan-Wigner (JW)
         mapper = create("qubit_mapper", "qdk")
         jw_mapping = MajoranaMapping.jordan_wigner(num_modes=n_modes)
         qh_jw = mapper.run(hubbard_ham, jw_mapping)
@@ -132,64 +219,62 @@ class TestVerstraeteCiracHubbardSpectral:
         eigs_jw = np.sort(eigs_jw)
         unique_jw = np.unique(np.round(eigs_jw, 6))
 
-        # 4. Map using Verstraete-Cirac (VC)
         vc_mapping = MajoranaMapping.verstraete_cirac(lattice)
         qh_vc = mapper.run(hubbard_ham, vc_mapping)
 
-        # Verify VC number of qubits.
         assert qh_vc.num_qubits == 2 * n_modes
-
-        # Solve VC eigenvalues using sparse solver
         h_vc = qh_vc.to_matrix(sparse=True)
+
         # Solve for 128 eigenvalues to cover the 64-fold degeneracy of the ground state and first excited state
         eigs_vc, _ = eigsh(h_vc, k=128, which="SA")
         eigs_vc = np.sort(eigs_vc)
         unique_vc = np.unique(np.round(eigs_vc, 6))
 
-        # The unique lowest eigenvalues in the code space of VC must match the unique lowest eigenvalues of JW.
         # We check the 2 lowest unique eigenvalues.
         np.testing.assert_allclose(unique_vc[:2], unique_jw[:2], atol=1e-10)
 
-        # Test serialization of the resulting QubitHamiltonian
-        qh_json = qh_vc.to_json()
-        qh_loaded = QubitHamiltonian.from_json(qh_json)
-        assert qh_loaded.num_qubits == qh_vc.num_qubits
-        assert len(qh_loaded.pauli_strings) == len(qh_vc.pauli_strings)
+    @pytest.mark.slow
+    def test_spectral_validation_3x3_huckel(self) -> None:
+        """Compare eigenvalues of 3x3 Hückel model under VC and Jordan-Wigner mappings."""
+        lattice = LatticeGraph.square(3, 3)
 
+        # 9 sites in lattice, each with 1 spin species -> 9 spin-orbitals / modes
+        n_modes = 9
 
-class TestVerstraeteCiracPauliWeightScaling:
-    """Verify that nearest-neighbor hop Pauli weight remains constant for grid lengths L in {2, 3, 4}."""
+        huckel_ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
 
-    def test_pauli_weight_scaling(self) -> None:
-        """Check nearest-neighbor hopping terms in the mapped qubit Hamiltonian.
-
-        Max Pauli weight of nearest-neighbor hops should be constant for grids of dimensions:
-        - 2x2 (L=2)
-        - 2x3 (L=3)
-        - 2x4 (L=4)
-        """
         mapper = create("qubit_mapper", "qdk")
+        jw_mapping = MajoranaMapping.jordan_wigner(num_modes=n_modes)
+        qh_jw = mapper.run(huckel_ham, jw_mapping)
+        h_jw = qh_jw.to_matrix(sparse=True)
+        eigs_jw, _ = eigsh(h_jw, k=10, which="SA")
+        unique_jw = np.unique(np.round(np.sort(eigs_jw), 6))
 
-        max_weights = []
-        for grid_length in [2, 3, 4]:
-            lattice = LatticeGraph.square(2, grid_length)
-            # Create a simple hopping-only Hamiltonian (U=0) on the 2xL lattice
-            ham = create_hubbard_hamiltonian(lattice, epsilon=0.0, t=1.0, U=0.0)
+        mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=1)
+        qh_vc = mapper.run(huckel_ham, mapping)
+        h_vc = qh_vc.to_matrix(sparse=True)
 
-            vc_mapping = MajoranaMapping.verstraete_cirac(lattice)
-            qh_vc = mapper.run(ham, vc_mapping)
+        # We solve for a few eigenvalues of H_vc and project into the code space (+1 eigenstate of all stabilizers)
+        eigs_vc, vecs_vc = eigsh(h_vc, k=40, which="SA")
 
-            weights = []
-            for pauli_str in qh_vc.pauli_strings:
-                if pauli_str == "I" * len(pauli_str):
-                    continue
-                # Weight is the number of non-I characters
-                weight = sum(1 for c in pauli_str if c != "I")
-                weights.append(weight)
+        stabs = []
+        for coeff, word in mapping.stabilizers:
+            label = sparse_pauli_word_to_label(word, qh_vc.num_qubits)
+            qh_stab = QubitHamiltonian([label], np.array([coeff]))
+            stabs.append(qh_stab.to_matrix(sparse=True))
 
-            max_weights.append(max(weights))
+        code_space_eigs = []
+        for idx in range(len(eigs_vc)):
+            vec = vecs_vc[:, idx]
+            is_in_code_space = True
+            for stab in stabs:
+                exp = np.real(vec.conj().T @ (stab @ vec))
+                if not np.isclose(exp, 1.0, atol=1e-4):
+                    is_in_code_space = False
+                    break
+            if is_in_code_space:
+                code_space_eigs.append(eigs_vc[idx])
 
-        # Check that the maximum Pauli weight does not grow with L
-        assert max_weights[0] == max_weights[1] == max_weights[2], (
-            f"Maximum Pauli weights grew or varied with grid length: {max_weights}"
-        )
+        assert len(code_space_eigs) >= 2
+        unique_vc = np.unique(np.round(np.sort(code_space_eigs), 6))
+        np.testing.assert_allclose(unique_vc[:2], unique_jw[:2], atol=1e-10)

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -240,6 +240,7 @@ class TestVerstraeteCiracSpectral:
         # Ensure lowest physical energy levels match baseline
         np.testing.assert_allclose(unique_vc[:2], unique_jw[:2], atol=1e-10)
 
+    @pytest.mark.slow
     def test_spectral_validation_3x2_huckel(self) -> None:
         """Compare eigenvalues of 3x2 Hückel model under VC and JW mappings.
 


### PR DESCRIPTION
# Feature: Verstraete-Cirac Fermion-to-Qubit Encoding

## Description

Closes [#482](https://github.com/microsoft/qdk-chemistry/issues/482).

We implement the **Verstraete-Cirac encoding**, which maps $$N$$ fermionic modes onto $$O(2N)$$ qubits, or 4 Majorana modes per site. The implementation supports an arbitrary `LatticeGraph` topology.

Added a comprehensive test module [test_verstraete_cirac.py](qdk-chemistry/python/tests/test_verstraete_cirac.py) covering all verification paths listed in the criteria below.

---

## Acceptance/Testing Criteria

- [x] **2D Lattice Mapping support**: `MajoranaMapping.verstraete_cirac` correctly constructs mappings for 2D square lattices with more than 3 sites (sizes 2x2, 2x3, 3x3, and 4x4) without errors.
- [x] **Spectral Validation**: Compared the lowest unique eigenvalues of a $2 \times 2$ periodic Fermi-Hubbard model ($t=1$, $U=4$, half-filling) and $3 \times 2$ Hückel model between Jordan-Wigner and the Verstraete-Cirac codespace. The lowest eigenvalues match to within $< 10^{-10}$ absolute error. 
- [x] **Hopping Operator Locality (Constant Pauli Weight)**: Verified that the maximum Pauli weight of mapped nearest-neighbor hopping terms remains constant across these grid dimensions: 2x2, 3x3, 4x4.
- [x] **Serialization**: Verified that the mapping successfully survives JSON and HDF5 serialization round-trips, producing bit-wise identical Pauli strings and coefficients in the resulting `QubitHamiltonian`.

---

## Verification & Test Results
pytest:
```bash
tests/test_verstraete_cirac.py::TestVerstraeteCiracMapping::test_factory_and_dimensions PASSED             [  5%]
tests/test_verstraete_cirac.py::TestVerstraeteCiracMapping::test_majorana_raises_error PASSED              [ 11%]
tests/test_verstraete_cirac.py::TestVerstraeteCiracMapping::test_without_tapering PASSED                   [ 16%]
tests/test_verstraete_cirac.py::TestVerstraeteCiracMapping::test_json_serialization PASSED                 [ 22%]
tests/test_verstraete_cirac.py::TestVerstraeteCiracMapping::test_hdf5_serialization PASSED                 [ 27%]
tests/test_verstraete_cirac.py::TestVerstraeteCiracMapping::test_stabilizers_and_commutation[square-2x2] PASSED [ 33%]
tests/test_verstraete_cirac.py::TestVerstraeteCiracMapping::test_stabilizers_and_commutation[square-3x3] PASSED [ 38%]
tests/test_verstraete_cirac.py::TestVerstraeteCiracMapping::test_stabilizers_and_commutation[square-3x4] PASSED [ 44%]
tests/test_verstraete_cirac.py::TestVerstraeteCiracMapping::test_stabilizers_and_commutation[honeycomb-2x2-periodic] PASSED [ 50%]
tests/test_verstraete_cirac.py::TestVerstraeteCiracMapping::test_stabilizers_and_commutation[triangular-2x2] PASSED [ 55%]
tests/test_verstraete_cirac.py::TestVerstraeteCiracMapping::test_stabilizers_and_commutation[kagome-2x2-periodic] PASSED [ 61%]
tests/test_verstraete_cirac.py::TestVerstraeteCiracMapping::test_stabilizers_and_commutation[kagome-3x3] PASSED [ 66%]
tests/test_verstraete_cirac.py::TestVerstraeteCiracMapping::test_pauli_weight_scaling[square] PASSED       [ 72%]
tests/test_verstraete_cirac.py::TestVerstraeteCiracMapping::test_pauli_weight_scaling[triangular] PASSED   [ 77%]
tests/test_verstraete_cirac.py::TestVerstraeteCiracMapping::test_pauli_weight_scaling[honeycomb] PASSED    [ 83%]
tests/test_verstraete_cirac.py::TestVerstraeteCiracMapping::test_pauli_weight_scaling[kagome] PASSED       [ 88%]
tests/test_verstraete_cirac.py::TestVerstraeteCiracSpectral::test_spectral_validation_2x2_hubbard PASSED   [ 94%]
tests/test_verstraete_cirac.py::TestVerstraeteCiracSpectral::test_spectral_validation_3x2_huckel PASSED    [100%]
```

C++ test:
```bash
[ RUN      ] LatticeGraphTest.Permute
[       OK ] LatticeGraphTest.Permute (0 ms)
```
