### PR TITLE
Add Verstraete-Cirac fermion-to-qubit encoding (#482)

### DIFF
--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -611,3 +611,23 @@
     year={1992},
     doi={10.1016/0375-9601(92)90335-J}
 }
+@article{Verstraete2005,
+    title={Mapping local {Hamiltonians} of fermions to local {Hamiltonians} of spins},
+    author={Frank Verstraete and J. Ignacio Cirac},
+    journal={Journal of Statistical Mechanics: Theory and Experiment},
+    volume={2005},
+    number={09},
+    pages={P09012},
+    year={2005},
+    doi={10.1088/1742-5468/2005/09/P09012}
+}
+@article{Whitfield2016,
+    title={Local spin operators for fermion simulations},
+    author={James D. Whitfield and Vojt{\v{e}}ch Havl{\'i}{\v{c}}ek and Matthias Troyer},
+    journal={Physical Review A},
+    volume={94},
+    number={3},
+    pages={030301},
+    year={2016},
+    doi={10.1103/PhysRevA.94.030301}
+}

--- a/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
+++ b/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
@@ -52,6 +52,11 @@ Symmetry-conserving Bravyi-Kitaev :cite:`Bravyi2017tapering`
 Bravyi-Kitaev tree :cite:`Havlicek2017`
    A tree-based variant of the Bravyi-Kitaev transformation that uses a different qubit indexing strategy.
 
+.. _encoding-verstraete-cirac:
+
+Verstraete-Cirac :cite:`Verstraete2005,Whitfield2016,Havlicek2017`
+   An auxiliary-fermion encoding for 2D lattice models. Places one auxiliary qubit on each lattice edge (plus phantom boundary edges) so that all nearest-neighbour interaction terms have constant Pauli weight independent of system size. Uses more qubits than Jordan-Wigner but avoids the long Z-strings that make JW costly on 2D problems. **Note:** the encoding enlarges the Hilbert space; physical states live in the +1 sector of per-edge stabilisers. Algorithms must prepare or project into this codespace (e.g. via stabiliser penalties or post-selection). Construct via :func:`~qdk_chemistry.algorithms.qubit_mapper.verstraete_cirac.verstraete_cirac`.
+
 
 Using the QubitMapper
 ---------------------
@@ -188,7 +193,7 @@ This is a **table-driven** backend: it reads the Pauli-string table from the :cl
 Any valid ``MajoranaMapping`` works — factory-produced or custom user-defined tables.
 The mapping's ``name`` and ``base_encoding`` are used only for metadata on the output, not to select a transform.
 
-Supported encodings: :ref:`Jordan-Wigner <encoding-jordan-wigner>`, :ref:`Bravyi-Kitaev <encoding-bravyi-kitaev>`, :ref:`Bravyi-Kitaev tree <encoding-bk-tree>`, :ref:`Parity <encoding-parity>`, :ref:`SCBK <encoding-scbk>`, and any custom encoding
+Supported encodings: :ref:`Jordan-Wigner <encoding-jordan-wigner>`, :ref:`Bravyi-Kitaev <encoding-bravyi-kitaev>`, :ref:`Bravyi-Kitaev tree <encoding-bk-tree>`, :ref:`Parity <encoding-parity>`, :ref:`SCBK <encoding-scbk>`, :ref:`Verstraete-Cirac <encoding-verstraete-cirac>`, and any custom encoding
 
 The native mapper uses blocked spin-orbital ordering internally (alpha orbitals first, then beta orbitals).
 Use ``QubitHamiltonian.to_interleaved()`` for alternative qubit orderings if needed.

--- a/python/src/qdk_chemistry/algorithms/qubit_mapper/__init__.py
+++ b/python/src/qdk_chemistry/algorithms/qubit_mapper/__init__.py
@@ -19,9 +19,13 @@ from qdk_chemistry.algorithms.qubit_mapper.qubit_mapper import (
     QubitMapperFactory,
     QubitMapperSettings,
 )
+from qdk_chemistry.algorithms.qubit_mapper.verstraete_cirac import (
+    verstraete_cirac,
+)
 
 __all__ = [
     "QdkQubitMapperSettings",
     "QubitMapperFactory",
     "QubitMapperSettings",
+    "verstraete_cirac",
 ]

--- a/python/src/qdk_chemistry/algorithms/qubit_mapper/verstraete_cirac.py
+++ b/python/src/qdk_chemistry/algorithms/qubit_mapper/verstraete_cirac.py
@@ -1,0 +1,432 @@
+"""Verstraete-Cirac fermion-to-qubit encoding for 2D lattices.
+
+This module provides a factory function that constructs a
+:class:`~qdk_chemistry.data.MajoranaMapping` using the Verstraete-Cirac (VC)
+auxiliary fermion method :cite:`Verstraete2005,Whitfield2016,Havlicek2017`.
+
+The VC encoding places one qubit on each lattice vertex and one auxiliary qubit
+on each edge (including "phantom" edges at open boundaries to ensure uniform
+vertex degree).  This produces bounded-weight Pauli strings for nearest-neighbor
+interactions, independent of system size — a key advantage over Jordan-Wigner
+and Bravyi-Kitaev for 2D lattice models.
+
+For *num_species* spin species (e.g. 2 for spin-1/2 Fermi-Hubbard), each
+species gets an independent copy of the lattice encoding on its own set of
+qubits.
+
+References
+----------
+.. [VC2005] Verstraete & Cirac, J. Stat. Mech. (2005) P09012.
+.. [Whitfield2016] Whitfield, Havlicek & Troyer, Phys. Rev. A 94, 030301 (2016).
+.. [Havlicek2017] Havlicek, Troyer & Whitfield, Phys. Rev. A 95, 032332 (2017).
+"""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    pass
+
+__all__ = [
+    "verstraete_cirac",
+    "codespace_effective_hamiltonian",
+]
+
+# Pauli type codes used by SparsePauliWord
+_X = 1
+_Y = 2
+_Z = 3
+
+
+# ---------------------------------------------------------------------------
+# Lattice + qubit layout helpers
+# ---------------------------------------------------------------------------
+
+
+class _VCLatticeLayout:
+    """Computes qubit assignments for the padded VC encoding on an R×C lattice.
+
+    Every vertex is padded to degree 4 using phantom edges at open boundaries,
+    ensuring that all Majorana operators have the same Pauli weight (5) and
+    all nearest-neighbour bilinears have the same weight (8).
+
+    Qubit numbering within a single-species block (starting at *offset*):
+        0 .. N_sites-1                          : vertex (site) qubits
+        N_sites .. N_sites+N_real_edges-1       : real edge qubits
+        N_sites+N_real_edges .. N_total_qubits-1: phantom edge qubits
+
+    Real edges are ordered: horizontal edges (row-major, left-to-right within
+    each row, rows bottom-to-top), then vertical edges (column-major,
+    bottom-to-top within each column, columns left-to-right).
+    """
+
+    def __init__(self, rows: int, cols: int, offset: int = 0) -> None:
+        if rows < 2 or cols < 2:
+            raise ValueError(f"Lattice must be at least 2×2, got {rows}×{cols}")
+        self.rows = rows
+        self.cols = cols
+        self.offset = offset
+        self.n_sites = rows * cols
+
+        # Real edges
+        self.n_h_edges = rows * (cols - 1)  # horizontal
+        self.n_v_edges = (rows - 1) * cols  # vertical
+        self.n_real_edges = self.n_h_edges + self.n_v_edges
+
+        # Phantom edges: each boundary site gets one per missing direction
+        self.n_phantom_left = rows       # x=0 sites missing left
+        self.n_phantom_right = rows      # x=cols-1 missing right
+        self.n_phantom_bottom = cols     # y=0 missing bottom
+        self.n_phantom_top = cols        # y=rows-1 missing top
+        self.n_phantom = (
+            self.n_phantom_left + self.n_phantom_right
+            + self.n_phantom_bottom + self.n_phantom_top
+        )
+
+        self.n_total_qubits = self.n_sites + self.n_real_edges + self.n_phantom
+
+    # -- qubit index helpers --------------------------------------------------
+
+    def site_qubit(self, x: int, y: int) -> int:
+        """Qubit index for the vertex at grid position (x, y)."""
+        return self.offset + y * self.cols + x
+
+    def _h_edge_qubit(self, x: int, y: int) -> int:
+        """Qubit for the real horizontal edge between (x,y) and (x+1,y)."""
+        return self.offset + self.n_sites + y * (self.cols - 1) + x
+
+    def _v_edge_qubit(self, x: int, y: int) -> int:
+        """Qubit for the real vertical edge between (x,y) and (x,y+1)."""
+        return self.offset + self.n_sites + self.n_h_edges + x * (self.rows - 1) + y
+
+    def _phantom_base(self) -> int:
+        return self.offset + self.n_sites + self.n_real_edges
+
+    def _phantom_left_qubit(self, y: int) -> int:
+        return self._phantom_base() + y
+
+    def _phantom_right_qubit(self, y: int) -> int:
+        return self._phantom_base() + self.n_phantom_left + y
+
+    def _phantom_bottom_qubit(self, x: int) -> int:
+        return self._phantom_base() + self.n_phantom_left + self.n_phantom_right + x
+
+    def _phantom_top_qubit(self, x: int) -> int:
+        return (
+            self._phantom_base()
+            + self.n_phantom_left
+            + self.n_phantom_right
+            + self.n_phantom_bottom
+            + x
+        )
+
+    def incident_edge_qubits(self, x: int, y: int) -> list[int]:
+        """Return the 4 auxiliary qubit indices for the 4 cardinal edges of (x, y).
+
+        Order: left, right, bottom, top.  Phantom qubits are used at boundaries.
+        """
+        left = self._h_edge_qubit(x - 1, y) if x > 0 else self._phantom_left_qubit(y)
+        right = self._h_edge_qubit(x, y) if x < self.cols - 1 else self._phantom_right_qubit(y)
+        bottom = self._v_edge_qubit(x, y - 1) if y > 0 else self._phantom_bottom_qubit(x)
+        top = self._v_edge_qubit(x, y) if y < self.rows - 1 else self._phantom_top_qubit(x)
+        return [left, right, bottom, top]
+
+    # -- stabiliser helpers ---------------------------------------------------
+
+    def real_edge_stabilizers(self) -> list[tuple[int, int, int]]:
+        """Return (site_u, site_v, edge_qubit) for each real edge."""
+        stabs = []
+        # Horizontal edges
+        for y in range(self.rows):
+            for x in range(self.cols - 1):
+                u = self.site_qubit(x, y)
+                v = self.site_qubit(x + 1, y)
+                e = self._h_edge_qubit(x, y)
+                stabs.append((u, v, e))
+        # Vertical edges
+        for x in range(self.cols):
+            for y in range(self.rows - 1):
+                u = self.site_qubit(x, y)
+                v = self.site_qubit(x, y + 1)
+                e = self._v_edge_qubit(x, y)
+                stabs.append((u, v, e))
+        return stabs
+
+    def phantom_qubit_indices(self) -> list[int]:
+        """Return all phantom qubit indices."""
+        base = self._phantom_base()
+        return list(range(base, base + self.n_phantom))
+
+
+# ---------------------------------------------------------------------------
+# Factory function
+# ---------------------------------------------------------------------------
+
+
+def verstraete_cirac(
+    rows: int,
+    cols: int,
+    num_species: int = 2,
+) -> "MajoranaMapping":
+    """Construct a Verstraete-Cirac MajoranaMapping for a 2D square lattice.
+
+    The encoding pads all vertices to degree 4 using phantom boundary edges
+    so that every nearest-neighbour hopping term has constant Pauli weight
+    regardless of lattice size.
+
+    For spin-1/2 models (``num_species=2``), each spin species gets an
+    independent VC copy on its own qubit register.  The modes follow blocked
+    spin-orbital ordering (all alpha first, then all beta), matching the
+    convention used by :class:`~qdk_chemistry.algorithms.qubit_mapper.QdkQubitMapper`.
+
+    Args:
+        rows: Number of lattice rows (≥ 2).
+        cols: Number of lattice columns (≥ 2).
+        num_species: Number of independent spin species (default 2 for
+            spin-1/2 Fermi-Hubbard; use 1 for spinless models).
+
+    Returns:
+        MajoranaMapping: A table-based mapping with
+            ``num_modes = num_species * rows * cols`` and
+            ``num_qubits = num_species * (rows*cols + 2*rows*cols + rows + cols)``.
+
+    Raises:
+        ValueError: If ``rows < 2``, ``cols < 2``, or ``num_species < 1``.
+
+    """
+    from qdk_chemistry.data import MajoranaMapping  # noqa: PLC0415
+
+    if num_species < 1:
+        raise ValueError(f"num_species must be >= 1, got {num_species}")
+
+    n_sites = rows * cols
+    n_modes = num_species * n_sites
+    table: list[list[tuple[int, int]]] = []
+
+    qubits_per_species = _VCLatticeLayout(rows, cols).n_total_qubits
+    for species in range(num_species):
+        layout = _VCLatticeLayout(rows, cols, offset=species * qubits_per_species)
+
+        for site_idx in range(n_sites):
+            x = site_idx % cols
+            y = site_idx // cols
+            sq = layout.site_qubit(x, y)
+            edge_qs = layout.incident_edge_qubits(x, y)
+
+            # γ_{2*mode} = X_site · Z_e1 · Z_e2 · Z_e3 · Z_e4
+            word_x: list[tuple[int, int]] = [(sq, _X)]
+            for eq in sorted(edge_qs):
+                word_x.append((eq, _Z))
+            table.append(sorted(word_x, key=lambda t: t[0]))
+
+            # γ_{2*mode+1} = Y_site · Z_e1 · Z_e2 · Z_e3 · Z_e4
+            word_y: list[tuple[int, int]] = [(sq, _Y)]
+            for eq in sorted(edge_qs):
+                word_y.append((eq, _Z))
+            table.append(sorted(word_y, key=lambda t: t[0]))
+
+    return MajoranaMapping.from_table(table, name="verstraete-cirac")
+
+
+# ---------------------------------------------------------------------------
+# Codespace projection utilities (for eigenvalue comparison tests)
+# ---------------------------------------------------------------------------
+
+
+def codespace_effective_hamiltonian(
+    qubit_hamiltonian: "QubitHamiltonian",
+    rows: int,
+    cols: int,
+    num_species: int = 2,
+) -> np.ndarray:
+    """Project a VC-encoded QubitHamiltonian onto its codespace.
+
+    Returns the effective Hamiltonian as a dense matrix of dimension
+    ``2**(num_species * rows * cols)``, suitable for exact diagonalisation.
+
+    The codespace is defined by the stabiliser constraints:
+
+    *  Real edge (u, v): ``Z_u · Z_v · X_e = +1``
+    *  Phantom edge: ``Z_phantom = +1``
+
+    Given a computational-basis state of the *site* qubits, each auxiliary
+    qubit is uniquely determined by the stabiliser it belongs to, so the
+    codespace dimension equals ``2**(num_sites_total)`` where
+    ``num_sites_total = num_species * rows * cols``.
+
+    The matrix is built *without* constructing the full ``2**num_qubits``
+    Hilbert-space matrix: for each Pauli string the matrix element between
+    every pair of codespace basis states is computed analytically.
+
+    Args:
+        qubit_hamiltonian: A VC-encoded qubit Hamiltonian.
+        rows: Lattice rows.
+        cols: Lattice columns.
+        num_species: Number of spin species.
+
+    Returns:
+        numpy.ndarray: Dense Hermitian matrix of shape
+            ``(2**n_site_qubits, 2**n_site_qubits)``.
+
+    """
+    n_sites = rows * cols
+    n_site_qubits = num_species * n_sites
+    dim = 2**n_site_qubits
+
+    # Guard against infeasible dense allocations.  A dim×dim complex128
+    # matrix requires dim² × 16 bytes; cap at ~4 GiB (n_site_qubits ≤ 14).
+    _MAX_SITE_QUBITS = 14
+    if n_site_qubits > _MAX_SITE_QUBITS:
+        raise ValueError(
+            f"codespace_effective_hamiltonian is a dense exact-diagonalisation "
+            f"utility intended for small systems only.  Received "
+            f"n_site_qubits={n_site_qubits} (dim={dim}), which would require "
+            f"~{dim * dim * 16 / 1e9:.1f} GB.  Maximum supported: "
+            f"n_site_qubits={_MAX_SITE_QUBITS}."
+        )
+
+    # Precompute layout info for each species
+    qubits_per_species = _VCLatticeLayout(rows, cols).n_total_qubits
+    layouts = []
+    for species in range(num_species):
+        lay = _VCLatticeLayout(rows, cols, offset=species * qubits_per_species)
+        real_stabs = list(lay.real_edge_stabilizers())
+        phantom_qs = lay.phantom_qubit_indices()
+        site_qs = [lay.site_qubit(x, y) for y in range(rows) for x in range(cols)]
+        layouts.append((lay, real_stabs, phantom_qs, site_qs))
+
+    # Build the set of all site qubit indices and auxiliary qubit indices
+    all_site_qs: list[int] = []
+    all_real_stabs: list[tuple[int, int, int]] = []  # (site_u, site_v, edge_qubit)
+    all_phantom_qs: list[int] = []
+    for _lay, real_stabs, phantom_qs, site_qs in layouts:
+        all_site_qs.extend(site_qs)
+        all_real_stabs.extend(real_stabs)
+        all_phantom_qs.extend(phantom_qs)
+
+    site_qubit_set = set(all_site_qs)
+
+    # Map global qubit index → site-qubit bit position (for computational basis)
+    site_q_to_bit = {q: i for i, q in enumerate(sorted(all_site_qs))}
+
+    H_eff = np.zeros((dim, dim), dtype=complex)  # noqa: N806
+
+    pauli_char_to_code = {"I": 0, "X": _X, "Y": _Y, "Z": _Z}
+
+    for term_idx in range(len(qubit_hamiltonian.pauli_strings)):
+        pauli_str = qubit_hamiltonian.pauli_strings[term_idx]
+        coeff = qubit_hamiltonian.coefficients[term_idx]
+        nq = len(pauli_str)
+
+        # Parse the Pauli string into per-qubit operators
+        # Label convention: label[nq - 1 - qubit] = operator on qubit
+        qubit_ops: dict[int, int] = {}
+        for pos, ch in enumerate(pauli_str):
+            qubit = nq - 1 - pos
+            code = pauli_char_to_code[ch]
+            if code != 0:
+                qubit_ops[qubit] = code
+
+        # Separate into site-qubit ops and auxiliary-qubit ops
+        site_ops: dict[int, int] = {}
+        aux_ops: dict[int, int] = {}
+        for q, op in qubit_ops.items():
+            if q in site_qubit_set:
+                site_ops[q] = op
+            else:
+                aux_ops[q] = op
+
+        # For each pair of codespace basis states |s⟩, |s'⟩, compute:
+        # ⟨ψ_{s'}|P|ψ_s⟩ = ⟨s'|P_site|s⟩ · ∏_aux ⟨aux(s')|P_aux|aux(s)⟩
+        #
+        # We iterate over |s⟩ and compute where P_site sends it, plus
+        # the auxiliary contribution.
+        for s in range(dim):
+            # Compute P_site|s⟩ = phase_site · |s'⟩
+            s_prime = s
+            phase_site = 1.0 + 0.0j
+            for q, op in site_ops.items():
+                bit = site_q_to_bit[q]
+                b = (s >> bit) & 1
+                if op == _Z:
+                    phase_site *= (-1) ** b
+                elif op == _X:
+                    s_prime ^= (1 << bit)
+                elif op == _Y:
+                    s_prime ^= (1 << bit)
+                    phase_site *= 1j * ((-1) ** b)  # Y|0⟩ = i|1⟩, Y|1⟩ = -i|0⟩
+
+            if abs(phase_site) < 1e-15:
+                continue
+
+            # Compute auxiliary contribution
+            aux_phase = 1.0 + 0.0j
+            valid = True
+
+            # Phantom qubits: in |0⟩, so ⟨0|P|0⟩ = 1 for I,Z; 0 for X,Y
+            for pq in all_phantom_qs:
+                op = aux_ops.get(pq, 0)
+                if op == _X or op == _Y:
+                    valid = False
+                    break
+                # I and Z both give 1 on |0⟩
+
+            if not valid:
+                continue
+
+            # Real edge qubits: in X eigenstate with eigenvalue λ = (-1)^(s_u⊕s_v)
+            for site_u, site_v, edge_q in all_real_stabs:
+                op = aux_ops.get(edge_q, 0)
+                if op == 0:
+                    # Identity: need λ_s == λ_{s'}
+                    bit_u = site_q_to_bit[site_u]
+                    bit_v = site_q_to_bit[site_v]
+                    lam_s = (-1) ** (((s >> bit_u) & 1) ^ ((s >> bit_v) & 1))
+                    lam_sp = (-1) ** (((s_prime >> bit_u) & 1) ^ ((s_prime >> bit_v) & 1))
+                    if lam_s != lam_sp:
+                        valid = False
+                        break
+                elif op == _X:
+                    # X eigenstate: ⟨λ'|X|λ⟩ = λ · δ(λ, λ')
+                    bit_u = site_q_to_bit[site_u]
+                    bit_v = site_q_to_bit[site_v]
+                    lam_s = (-1) ** (((s >> bit_u) & 1) ^ ((s >> bit_v) & 1))
+                    lam_sp = (-1) ** (((s_prime >> bit_u) & 1) ^ ((s_prime >> bit_v) & 1))
+                    if lam_s != lam_sp:
+                        valid = False
+                        break
+                    aux_phase *= lam_s
+                elif op == _Z:
+                    # Z flips X eigenvalue: ⟨λ'|Z|λ⟩ = δ(λ', -λ)
+                    bit_u = site_q_to_bit[site_u]
+                    bit_v = site_q_to_bit[site_v]
+                    lam_s = (-1) ** (((s >> bit_u) & 1) ^ ((s >> bit_v) & 1))
+                    lam_sp = (-1) ** (((s_prime >> bit_u) & 1) ^ ((s_prime >> bit_v) & 1))
+                    if lam_sp != -lam_s:
+                        valid = False
+                        break
+                elif op == _Y:
+                    # Y: ⟨λ'|Y|λ⟩ = -i·λ · δ(λ', -λ)
+                    bit_u = site_q_to_bit[site_u]
+                    bit_v = site_q_to_bit[site_v]
+                    lam_s = (-1) ** (((s >> bit_u) & 1) ^ ((s >> bit_v) & 1))
+                    lam_sp = (-1) ** (((s_prime >> bit_u) & 1) ^ ((s_prime >> bit_v) & 1))
+                    if lam_sp != -lam_s:
+                        valid = False
+                        break
+                    aux_phase *= -1j * lam_s
+
+            if not valid:
+                continue
+
+            H_eff[s_prime, s] += coeff * phase_site * aux_phase
+
+    return H_eff

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -1,0 +1,286 @@
+"""Tests for the Verstraete-Cirac fermion-to-qubit encoding.
+
+Tests cover:
+- Correctness: VC-encoded Fermi-Hubbard eigenvalues match Jordan-Wigner (2x2, t=1, U=4, half-filling)
+- Locality: max Pauli weight of nearest-neighbour hopping terms is constant across lattice sizes
+- Serialization: JSON and HDF5 round-trips produce identical QubitHamiltonian terms
+- Construction: factory works for 2x2, 2x3, 3x3, 4x4 and QubitMapper consumes them
+"""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import tempfile
+
+import h5py
+import numpy as np
+import pytest
+
+from qdk_chemistry.algorithms import create
+from qdk_chemistry.algorithms.qubit_mapper.verstraete_cirac import (
+    _VCLatticeLayout,
+    codespace_effective_hamiltonian,
+    verstraete_cirac,
+)
+from qdk_chemistry.data import LatticeGraph, MajoranaMapping, QubitHamiltonian
+
+
+# --- Helpers -----------------------------------------------------------------
+
+
+def _hubbard_hamiltonian(rows: int, cols: int, t: float, U: float):  # noqa: N803
+    """Create a Fermi-Hubbard Hamiltonian on an open-boundary square lattice."""
+    from qdk_chemistry.utils.model_hamiltonians import create_hubbard_hamiltonian  # noqa: PLC0415
+
+    lattice = LatticeGraph.square(cols, rows, periodic_x=False, periodic_y=False)
+    return create_hubbard_hamiltonian(lattice, epsilon=0.0, t=t, U=U)
+
+
+def _pauli_weight(pauli_str: str) -> int:
+    """Count the number of non-identity Paulis in a label string."""
+    return sum(1 for c in pauli_str if c != "I")
+
+
+def _qh_term_dict(qh: QubitHamiltonian) -> dict[str, complex]:
+    """Build a {pauli_string: coefficient} dict from a QubitHamiltonian."""
+    return dict(zip(qh.pauli_strings, qh.coefficients, strict=True))
+
+
+# --- Criterion 1: factory + QubitMapper consumption --------------------------
+
+
+class TestConstruction:
+    """VC factory produces valid MajoranaMappings that QubitMapper consumes."""
+
+    @pytest.mark.parametrize(
+        "rows,cols",
+        [(2, 2), (2, 3), (3, 3), (4, 4)],
+        ids=["2x2", "2x3", "3x3", "4x4"],
+    )
+    def test_factory_single_species(self, rows: int, cols: int) -> None:
+        """Factory produces correct MajoranaMapping dimensions (single species)."""
+        mapping = verstraete_cirac(rows, cols, num_species=1)
+        n_sites = rows * cols
+        assert mapping.num_modes == n_sites
+        assert mapping.name == "verstraete-cirac"
+        assert mapping.is_majorana_atomic
+        assert len(mapping.table) == 2 * n_sites
+
+    @pytest.mark.parametrize(
+        "rows,cols",
+        [(2, 2), (2, 3), (3, 3), (4, 4)],
+        ids=["2x2", "2x3", "3x3", "4x4"],
+    )
+    def test_qubit_mapper_consumes_without_error(self, rows: int, cols: int) -> None:
+        """QubitMapper.run() succeeds with the VC mapping for each lattice size."""
+        ham = _hubbard_hamiltonian(rows, cols, t=1.0, U=4.0)
+        mapping = verstraete_cirac(rows, cols, num_species=2)
+        mapper = create("qubit_mapper", "qdk")
+        qh = mapper.run(ham, mapping)
+        assert isinstance(qh, QubitHamiltonian)
+        assert len(qh.pauli_strings) > 0
+        assert qh.num_qubits == mapping.num_qubits
+
+    def test_two_species_qubit_count(self) -> None:
+        """Two-species mapping uses 2x the single-species qubit count."""
+        for rows, cols in [(2, 2), (3, 3)]:
+            m1 = verstraete_cirac(rows, cols, num_species=1)
+            m2 = verstraete_cirac(rows, cols, num_species=2)
+            assert m2.num_qubits == 2 * m1.num_qubits
+
+    def test_invalid_lattice_rejected(self) -> None:
+        """Lattice smaller than 2x2 is rejected."""
+        with pytest.raises(ValueError, match="at least 2"):
+            verstraete_cirac(1, 3)
+        with pytest.raises(ValueError, match="at least 2"):
+            verstraete_cirac(2, 1)
+
+    def test_invalid_species_rejected(self) -> None:
+        """num_species < 1 is rejected."""
+        with pytest.raises(ValueError, match="num_species"):
+            verstraete_cirac(2, 2, num_species=0)
+
+
+# --- Criterion 2: eigenvalue correctness ------------------------------------
+
+
+class TestEigenvalueCorrectness:
+    """VC codespace eigenvalues match JW for 2x2 Fermi-Hubbard."""
+
+    def test_2x2_hubbard_eigenvalues(self) -> None:
+        """Four lowest eigenvalues match JW to within 1e-10 (2x2, t=1, U=4)."""
+        rows, cols = 2, 2
+        n_modes = 2 * rows * cols  # two spin species
+
+        ham = _hubbard_hamiltonian(rows, cols, t=1.0, U=4.0)
+        mapper = create("qubit_mapper", "qdk")
+
+        # Jordan-Wigner reference
+        jw_mapping = MajoranaMapping.jordan_wigner(num_modes=n_modes)
+        qh_jw = mapper.run(ham, jw_mapping)
+        eigs_jw = np.sort(np.real(np.linalg.eigvalsh(qh_jw.to_matrix())))
+
+        # Verstraete-Cirac: map then project onto codespace
+        vc_mapping = verstraete_cirac(rows, cols, num_species=2)
+        qh_vc = mapper.run(ham, vc_mapping)
+        H_eff = codespace_effective_hamiltonian(qh_vc, rows, cols, num_species=2)  # noqa: N806
+        eigs_vc = np.sort(np.real(np.linalg.eigvalsh(H_eff)))
+
+        # Both omit core energy, so compare directly
+        np.testing.assert_allclose(
+            eigs_vc[:4],
+            eigs_jw[:4],
+            atol=1e-10,
+            err_msg="VC lowest 4 eigenvalues do not match JW",
+        )
+
+    def test_codespace_dimension(self) -> None:
+        """Codespace has the expected dimension 2^(num_modes)."""
+        rows, cols = 2, 2
+        ham = _hubbard_hamiltonian(rows, cols, t=1.0, U=4.0)
+        mapping = verstraete_cirac(rows, cols, num_species=2)
+        mapper = create("qubit_mapper", "qdk")
+        qh_vc = mapper.run(ham, mapping)
+
+        H_eff = codespace_effective_hamiltonian(qh_vc, rows, cols, num_species=2)  # noqa: N806
+        expected_dim = 2 ** (2 * rows * cols)
+        assert H_eff.shape == (expected_dim, expected_dim)
+
+
+# --- Criterion 3: locality --------------------------------------------------
+
+
+class TestLocality:
+    """Max nearest-neighbour hopping Pauli weight is constant across sizes."""
+
+    @staticmethod
+    def _max_hopping_weight(rows: int, cols: int) -> int:
+        """Max Pauli weight of hopping terms for a pure-hopping Hamiltonian."""
+        lattice = LatticeGraph.square(cols, rows, periodic_x=False, periodic_y=False)
+        from qdk_chemistry.utils.model_hamiltonians import create_hubbard_hamiltonian  # noqa: PLC0415
+
+        ham = create_hubbard_hamiltonian(lattice, epsilon=0.0, t=1.0, U=0.0)
+        mapping = verstraete_cirac(rows, cols, num_species=2)
+        mapper = create("qubit_mapper", "qdk")
+        qh = mapper.run(ham, mapping)
+        return max(_pauli_weight(ps) for ps in qh.pauli_strings)
+
+    def test_constant_pauli_weight(self) -> None:
+        """Max nearest-neighbour hopping weight is identical for L=2, 3, 4."""
+        weights = {L: self._max_hopping_weight(L, L) for L in (2, 3, 4)}
+        assert weights[2] == weights[3] == weights[4], (
+            f"Pauli weights differ across lattice sizes: {weights}"
+        )
+        assert weights[2] > 0
+
+
+# --- Criterion 4: serialization round-trips ----------------------------------
+
+
+class TestSerialization:
+    """VC mapping survives JSON/HDF5 round-trips with identical QubitHamiltonian."""
+
+    @pytest.mark.parametrize("rows,cols", [(2, 2), (2, 3)], ids=["2x2", "2x3"])
+    def test_json_mapping_roundtrip(self, rows: int, cols: int) -> None:
+        """MajoranaMapping Majorana table survives JSON round-trip."""
+        mapping = verstraete_cirac(rows, cols, num_species=1)
+        loaded = MajoranaMapping.from_json(mapping.to_json())
+
+        assert loaded.num_modes == mapping.num_modes
+        assert loaded.num_qubits == mapping.num_qubits
+        assert loaded.name == mapping.name
+        for k in range(2 * mapping.num_modes):
+            assert list(loaded.majorana(k)) == list(mapping.majorana(k))
+
+    @pytest.mark.parametrize("rows,cols", [(2, 2), (2, 3)], ids=["2x2", "2x3"])
+    def test_hdf5_mapping_roundtrip(self, rows: int, cols: int) -> None:
+        """MajoranaMapping Majorana table survives HDF5 round-trip."""
+        mapping = verstraete_cirac(rows, cols, num_species=1)
+        with tempfile.NamedTemporaryFile(suffix=".h5") as f:
+            with h5py.File(f.name, "w") as hf:
+                mapping.to_hdf5(hf)
+            with h5py.File(f.name, "r") as hf:
+                loaded = MajoranaMapping.from_hdf5(hf)
+
+        assert loaded.num_modes == mapping.num_modes
+        assert loaded.num_qubits == mapping.num_qubits
+        for k in range(2 * mapping.num_modes):
+            assert list(loaded.majorana(k)) == list(mapping.majorana(k))
+
+    def test_json_roundtrip_produces_identical_hamiltonian(self) -> None:
+        """JSON round-tripped mapping yields term-by-term identical QubitHamiltonian."""
+        mapping = verstraete_cirac(2, 2, num_species=2)
+        loaded = MajoranaMapping.from_json(mapping.to_json())
+
+        ham = _hubbard_hamiltonian(2, 2, t=1.0, U=4.0)
+        mapper = create("qubit_mapper", "qdk")
+        qh_orig = mapper.run(ham, mapping)
+        qh_loaded = mapper.run(ham, loaded)
+
+        d_orig = _qh_term_dict(qh_orig)
+        d_loaded = _qh_term_dict(qh_loaded)
+        assert len(d_orig) == len(d_loaded)
+        for ps, coeff in d_orig.items():
+            assert ps in d_loaded, f"Missing Pauli string after JSON round-trip: {ps}"
+            np.testing.assert_allclose(d_loaded[ps], coeff, atol=1e-14)
+
+    def test_hdf5_roundtrip_produces_identical_hamiltonian(self) -> None:
+        """HDF5 round-tripped mapping yields term-by-term identical QubitHamiltonian."""
+        mapping = verstraete_cirac(2, 2, num_species=2)
+        with tempfile.NamedTemporaryFile(suffix=".h5") as f:
+            with h5py.File(f.name, "w") as hf:
+                mapping.to_hdf5(hf)
+            with h5py.File(f.name, "r") as hf:
+                loaded = MajoranaMapping.from_hdf5(hf)
+
+        ham = _hubbard_hamiltonian(2, 2, t=1.0, U=4.0)
+        mapper = create("qubit_mapper", "qdk")
+        qh_orig = mapper.run(ham, mapping)
+        qh_loaded = mapper.run(ham, loaded)
+
+        d_orig = _qh_term_dict(qh_orig)
+        d_loaded = _qh_term_dict(qh_loaded)
+        assert len(d_orig) == len(d_loaded)
+        for ps, coeff in d_orig.items():
+            assert ps in d_loaded, f"Missing Pauli string after HDF5 round-trip: {ps}"
+            np.testing.assert_allclose(d_loaded[ps], coeff, atol=1e-14)
+
+
+# --- Lattice layout unit tests -----------------------------------------------
+
+
+class TestLatticeLayout:
+    """Unit tests for _VCLatticeLayout internals."""
+
+    def test_uniform_degree(self) -> None:
+        """Every site has exactly 4 incident edge qubits (padded with phantoms)."""
+        for rows, cols in [(2, 2), (2, 3), (3, 3), (4, 4)]:
+            layout = _VCLatticeLayout(rows, cols)
+            for y in range(rows):
+                for x in range(cols):
+                    edges = layout.incident_edge_qubits(x, y)
+                    assert len(edges) == 4, f"({x},{y}) on {rows}x{cols}: {len(edges)} edges"
+                    assert len(set(edges)) == 4, f"({x},{y}) has duplicate edge qubits"
+
+    def test_shared_edge_between_neighbours(self) -> None:
+        """Adjacent sites share exactly one real edge qubit."""
+        layout = _VCLatticeLayout(3, 3)
+        # Horizontal neighbour (0,0)-(1,0)
+        shared_h = set(layout.incident_edge_qubits(0, 0)) & set(layout.incident_edge_qubits(1, 0))
+        assert len(shared_h) == 1
+        # Vertical neighbour (0,0)-(0,1)
+        shared_v = set(layout.incident_edge_qubits(0, 0)) & set(layout.incident_edge_qubits(0, 1))
+        assert len(shared_v) == 1
+
+    def test_no_qubit_index_overlap(self) -> None:
+        """Site qubits and auxiliary qubits never share indices."""
+        for rows, cols in [(2, 2), (3, 3)]:
+            layout = _VCLatticeLayout(rows, cols)
+            site_qs = {layout.site_qubit(x, y) for y in range(rows) for x in range(cols)}
+            aux_qs = set()
+            for y in range(rows):
+                for x in range(cols):
+                    aux_qs.update(layout.incident_edge_qubits(x, y))
+            assert site_qs.isdisjoint(aux_qs)


### PR DESCRIPTION
Closes #482

Adds the Verstraete-Cirac auxiliary-fermion encoding as a new `MajoranaMapping` factory for 2D square lattices.

## What's included

- **`verstraete_cirac.py`** — Factory function that builds the VC Majorana table via `MajoranaMapping.from_table()`. Pads all boundary sites to degree 4 with phantom edges so nearest-neighbour hopping terms have constant Pauli weight (independent of lattice size). Supports single or multi-species (spin-1/2 Fermi-Hubbard).

- **`codespace_effective_hamiltonian()`** — Projects the VC-encoded QubitHamiltonian onto the physical codespace analytically (no full 2^n matrix), for eigenvalue verification.

- **`test_verstraete_cirac.py`** — Covers all acceptance criteria:
  - Factory works for 2×2, 2×3, 3×3, 4×4; QubitMapper consumes without error
  - 2×2 Fermi-Hubbard (t=1, U=4) lowest 4 eigenvalues match JW to 1e-10
  - Max hopping Pauli weight is identical for L=2,3,4
  - JSON and HDF5 round-trips produce term-by-term identical QubitHamiltonians

- **Docs** — VC added to supported encodings in `qubit_mapper.rst`; Verstraete2005 and Whitfield2016 added to `references.bib`.