### PR TITLE
Add Zassenhaus-expansion time-evolution builder

### DIFF
--- a/docs/source/_static/examples/python/hamiltonian_unitary_builder.py
+++ b/docs/source/_static/examples/python/hamiltonian_unitary_builder.py
@@ -47,6 +47,16 @@ pr.settings().set("seed", 42)
 ################################################################################
 
 ################################################################################
+# start-cell-configure-zassenhaus
+# Configure a Zassenhaus-expansion builder: higher order cancels successively
+# higher commutator corrections, giving error O(t^(order+1)) at fixed step count.
+zassenhaus = create("hamiltonian_unitary_builder", "zassenhaus")
+zassenhaus.settings().set("order", 4)
+zassenhaus.settings().set("num_divisions", 1)
+# end-cell-configure-zassenhaus
+################################################################################
+
+################################################################################
 # start-cell-run
 import numpy as np
 from qdk_chemistry.algorithms import create
@@ -92,6 +102,6 @@ from qdk_chemistry.algorithms import registry
 
 # List all registered time evolution builder implementations
 implementations = registry.available("hamiltonian_unitary_builder")
-print(implementations)  # e.g. ['trotter', 'qdrift', 'partially_randomized']
+print(implementations)  # e.g. ['trotter', 'qdrift', 'partially_randomized', 'zassenhaus']
 # end-cell-list-implementations
 ################################################################################

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -611,3 +611,24 @@
     year={1992},
     doi={10.1016/0375-9601(92)90335-J}
 }
+@article{Wilcox1967,
+    title={Exponential Operators and Parameter Differentiation in Quantum Physics},
+    author={R. M. Wilcox},
+    journal={Journal of Mathematical Physics},
+    volume={8},
+    number={4},
+    pages={962--982},
+    year={1967},
+    doi={10.1063/1.1705306}
+}
+@article{Casas2012,
+    title={Efficient computation of the {Zassenhaus} formula},
+    author={Fernando Casas and Ander Murua and Mladen Nadinic},
+    journal={Computer Physics Communications},
+    volume={183},
+    number={11},
+    pages={2386--2391},
+    year={2012},
+    doi={10.1016/j.cpc.2012.06.006},
+    url={https://arxiv.org/abs/1204.0389}
+}

--- a/docs/source/user/comprehensive/algorithms/hamiltonian_unitary_builder.rst
+++ b/docs/source/user/comprehensive/algorithms/hamiltonian_unitary_builder.rst
@@ -196,6 +196,9 @@ At :math:`p = 1` the construction reduces to the first-order Trotter product.
    * - ``num_divisions``
      - int
      - Number of time divisions :math:`N` (each evolves for ``time / N`` and the step repeats :math:`N` times). Default is 1.
+   * - ``target_accuracy``
+     - float
+     - Target accuracy :math:`\epsilon` for automatic division count. When set, :math:`N` is estimated from the commutator error bound :math:`N = \lceil(\alpha\,t^{p+1}/\epsilon)^{1/p}\rceil` (same infrastructure as the Trotter ``"commutator"`` bound) and the larger of it and ``num_divisions`` is used. When ``0.0`` (default), automatic estimation is disabled.
    * - ``weight_threshold``
      - float
      - Coefficient threshold below which Pauli terms are discarded. Default is 1e-12.
@@ -211,6 +214,8 @@ When the input :class:`~qdk_chemistry.data.QubitHamiltonian` carries a populated
 
 In both cases groups are sorted by ascending layer count so that the smallest groups sit on the outside of the Strang/Suzuki splitting, which maximises merging at recursion boundaries.
 This typically reduces the number of distinct exponentials per Trotter step and the saving compounds through the recursion at higher orders.
+
+The Zassenhaus builder also consumes the partition: its bare first-order product orders the Hamiltonian terms by group so that commuting terms within a group are adjacent (matching the Trotter term ordering), which is the starting point for its commutator corrections.
 
 When ``term_partition is None`` each Pauli term is exponentiated as its own group.
 Pre-populate the partition using the :ref:`term_grouper algorithm <algorithms-term-grouper>` or one of the :ref:`spin model Hamiltonian builders <model-term-partition>` to enable group-aware scheduling.

--- a/docs/source/user/comprehensive/algorithms/hamiltonian_unitary_builder.rst
+++ b/docs/source/user/comprehensive/algorithms/hamiltonian_unitary_builder.rst
@@ -142,6 +142,55 @@ When both ``num_divisions`` and ``target_accuracy`` are specified, the builder u
      - float
      - Coefficient threshold below which Pauli terms are discarded. Default is 1e-12.
 
+.. _zassenhaus-builder:
+
+Zassenhaus expansion
+~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Factory name: ``"zassenhaus"``
+
+The Zassenhaus formula is the dual of the Baker-Campbell-Hausdorff formula :cite:`Wilcox1967`: it writes the time-evolution operator as an *ordered product* of exponentials in which the low-order commutator corrections appear as **explicit factors**, rather than being absorbed implicitly into a Trotter step count.
+
+For a Hamiltonian :math:`H = \sum_j \alpha_j P_j`, starting from the bare first-order product :math:`\prod_j e^{-i\alpha_j P_j t}`, the builder appends commutator corrections order by order:
+
+.. math::
+
+   e^{-iHt} \approx \Bigl[\prod_j e^{-i\alpha_j P_j t/N}\Bigr] \, e^{-iC_2} \, e^{-iC_3} \cdots e^{-iC_p}
+
+where each :math:`C_n` collects the degree-:math:`n` nested-commutator corrections needed to make the product exact through order :math:`n`.
+Because every nested commutator of Pauli strings is itself a scalar multiple of a single Pauli string, each :math:`C_n` decomposes into ordinary Pauli rotations :math:`e^{-i\theta P}`, so the output remains a ``PauliProductFormulaContainer``.
+
+For expansion order :math:`p` the operator-norm error at fixed step count obeys :cite:`Casas2012,Childs2021`
+
+.. math::
+
+   \bigl\lVert e^{-iHt} - U_{\text{Zassenhaus}} \bigr\rVert = O\!\left(t^{\,p+1}\right),
+
+so Hamiltonians whose dominant commutators are sparse or analytically tractable (lattice models with limited geometric coupling, chemistry Hamiltonians under term partitions with small inter-group commutators) are simulated with fewer steps than Trotter-Suzuki would require.
+At :math:`p = 1` the construction reduces to the first-order Trotter product.
+
+.. note::
+   The number of correction factors grows with the expansion order, since successively higher nested commutators must be cancelled.
+   The expansion is most economical when those commutators are sparse.
+
+.. rubric:: Settings
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Setting
+     - Type
+     - Description
+   * - ``order``
+     - int
+     - Zassenhaus expansion order :math:`p \ge 1`. ``1`` reproduces first-order Trotter; higher orders cancel successively higher commutator corrections. Default is 2.
+   * - ``num_divisions``
+     - int
+     - Number of time divisions :math:`N` (each evolves for ``time / N`` and the step repeats :math:`N` times). Default is 1.
+   * - ``weight_threshold``
+     - float
+     - Coefficient threshold below which Pauli terms are discarded. Default is 1e-12.
+
 
 Consuming term partitions
 -------------------------

--- a/docs/source/user/comprehensive/algorithms/hamiltonian_unitary_builder.rst
+++ b/docs/source/user/comprehensive/algorithms/hamiltonian_unitary_builder.rst
@@ -172,6 +172,15 @@ At :math:`p = 1` the construction reduces to the first-order Trotter product.
    The number of correction factors grows with the expansion order, since successively higher nested commutators must be cancelled.
    The expansion is most economical when those commutators are sparse.
 
+.. rubric:: Configuring settings
+
+.. tab:: Python API
+
+   .. literalinclude:: ../../../_static/examples/python/hamiltonian_unitary_builder.py
+      :language: python
+      :start-after: # start-cell-configure-zassenhaus
+      :end-before: # end-cell-configure-zassenhaus
+
 .. rubric:: Settings
 
 .. list-table::

--- a/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
+++ b/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
@@ -28,14 +28,17 @@ References:
 
 from __future__ import annotations
 
+import math
+
 from qdk_chemistry.algorithms.hamiltonian_unitary_builder.base import TimeEvolutionBuilder, TimeEvolutionSettings
 from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus_expansion import zassenhaus_factors
-from qdk_chemistry.data import QubitHamiltonian, UnitaryRepresentation
+from qdk_chemistry.data import FlatPartition, LayeredPartition, QubitHamiltonian, UnitaryRepresentation
 from qdk_chemistry.data.unitary_representation.containers.pauli_product_formula import (
     ExponentiatedPauliTerm,
     PauliProductFormulaContainer,
 )
 from qdk_chemistry.utils import Logger
+from qdk_chemistry.utils.pauli_commutation import commutator_bound_higher_order
 
 __all__: list[str] = ["Zassenhaus", "ZassenhausSettings"]
 
@@ -52,6 +55,9 @@ class ZassenhausSettings(TimeEvolutionSettings):
                 higher commutator corrections, giving error ``O(t**(p+1))``.
             num_divisions: Number of time divisions ``N``.  Each division evolves
                 for ``time / N`` and the step is repeated ``N`` times.
+            target_accuracy: Target accuracy for automatic time-division count
+                (0.0 means disabled).  When set, ``N`` is estimated from a
+                commutator error bound and the larger of it and ``num_divisions`` is used.
             weight_threshold: The absolute threshold for filtering small coefficients.
 
         """
@@ -62,6 +68,12 @@ class ZassenhausSettings(TimeEvolutionSettings):
             "int",
             1,
             "Explicit number of time divisions (each evolves for time / num_divisions).",
+        )
+        self._set_default(
+            "target_accuracy",
+            "double",
+            0.0,
+            "Target accuracy for automatic time-division count (0.0 means disabled).",
         )
         self._set_default(
             "weight_threshold", "float", 1e-12, "The absolute threshold for filtering small coefficients."
@@ -106,6 +118,7 @@ class Zassenhaus(TimeEvolutionBuilder):
         *,
         time: float = 0.0,
         num_divisions: int = 1,
+        target_accuracy: float = 0.0,
         weight_threshold: float = 1e-12,
         power: int = 1,
         power_strategy: str = "repeat",
@@ -117,6 +130,9 @@ class Zassenhaus(TimeEvolutionBuilder):
             time: The evolution time. Defaults to 0.0.
             num_divisions: Number of time divisions ``N`` (each evolves for
                 ``time / N`` and the step repeats ``N`` times). Defaults to 1.
+            target_accuracy: Target accuracy for automatic division count. When > 0,
+                ``N`` is estimated from a commutator error bound and the larger of it
+                and ``num_divisions`` is used. Use 0.0 (default) to disable.
             weight_threshold: Threshold for filtering small coefficients. Defaults to 1e-12.
             power: The power to raise the unitary to. Defaults to 1.
             power_strategy: Strategy for U^power: ``"rescale"`` or ``"repeat"`` (default).
@@ -129,6 +145,7 @@ class Zassenhaus(TimeEvolutionBuilder):
         self._settings.set("power_strategy", power_strategy)
         self._settings.set("order", order)
         self._settings.set("num_divisions", num_divisions)
+        self._settings.set("target_accuracy", target_accuracy)
         self._settings.set("weight_threshold", weight_threshold)
 
     def _run_impl(self, qubit_hamiltonian: QubitHamiltonian) -> UnitaryRepresentation:
@@ -148,17 +165,17 @@ class Zassenhaus(TimeEvolutionBuilder):
         if order < 1:
             raise ValueError(f"Zassenhaus expansion order must be >= 1, got {order}.")
 
-        num_divisions = self._settings.get("num_divisions")
-        if num_divisions < 1:
-            raise ValueError(f"num_divisions must be a positive integer, got {num_divisions}.")
+        if self._settings.get("num_divisions") < 1:
+            raise ValueError(f"num_divisions must be a positive integer, got {self._settings.get('num_divisions')}.")
 
         if not qubit_hamiltonian.is_hermitian(tolerance=weight_threshold):
             raise ValueError("Non-Hermitian Hamiltonian: coefficients have nonzero imaginary parts.")
 
+        num_divisions = self._resolve_num_divisions(qubit_hamiltonian, effective_time)
         num_qubits = qubit_hamiltonian.num_qubits
         delta = effective_time / num_divisions
 
-        terms = qubit_hamiltonian.get_real_coefficients(tolerance=weight_threshold)
+        terms = self._ordered_terms(qubit_hamiltonian, weight_threshold)
         step_terms = self._build_step_terms(terms, order=order, delta=delta, atol=weight_threshold)
 
         container = PauliProductFormulaContainer(
@@ -167,6 +184,64 @@ class Zassenhaus(TimeEvolutionBuilder):
             num_qubits=num_qubits,
         )
         return UnitaryRepresentation(container=container)
+
+    def _resolve_num_divisions(self, qubit_hamiltonian: QubitHamiltonian, time: float) -> int:
+        r"""Determine the number of time divisions ``N``.
+
+        Without *target_accuracy* this is just the ``num_divisions`` setting.  When
+        *target_accuracy* :math:`\epsilon` is set, ``N`` is estimated from the
+        commutator error bound: the order-:math:`p` remainder scales as
+        :math:`\alpha\,t^{p+1}/N^{p}`, where :math:`\alpha` is the sum of degree-:math:`(p+1)`
+        nested-commutator norms (:func:`~qdk_chemistry.utils.pauli_commutation.commutator_bound_higher_order`,
+        the same infrastructure the Trotter builder uses).  Setting that
+        :math:`\le \epsilon` gives :math:`N = \lceil (\alpha t^{p+1}/\epsilon)^{1/p} \rceil`.
+        The larger of the manual and estimated value is returned.
+        """
+        manual = self._settings.get("num_divisions")
+        target_accuracy = self._settings.get("target_accuracy")
+        if target_accuracy <= 0.0 or time == 0.0:
+            return manual
+
+        order = self._settings.get("order")
+        weight_threshold = self._settings.get("weight_threshold")
+        alpha = commutator_bound_higher_order(qubit_hamiltonian, order, weight_threshold=weight_threshold)
+        if alpha <= 0.0:
+            return manual
+        auto = math.ceil((alpha * abs(time) ** (order + 1) / target_accuracy) ** (1.0 / order))
+        return max(manual, auto, 1)
+
+    @staticmethod
+    def _ordered_terms(qubit_hamiltonian: QubitHamiltonian, weight_threshold: float) -> list[tuple[str, float]]:
+        """Return ``(pauli_label, real_coeff)`` pairs, ordered by ``term_partition`` if present.
+
+        When the Hamiltonian carries a :class:`~qdk_chemistry.data.TermPartition`, the bare
+        first-order product consumes it so that commuting terms within a group are adjacent
+        (consistent with the Trotter builder); otherwise terms keep their natural order.
+        Terms whose real coefficient is below *weight_threshold* are dropped.
+        """
+        partition = qubit_hamiltonian.term_partition
+        labels = qubit_hamiltonian.pauli_strings
+        coefficients = qubit_hamiltonian.coefficients
+
+        if partition is None:
+            indices: list[int] = list(range(len(labels)))
+        else:
+            indices = []
+            for group in partition.groups:
+                if isinstance(partition, LayeredPartition):
+                    for layer in group:
+                        indices.extend(layer)
+                elif isinstance(partition, FlatPartition):
+                    indices.extend(group)
+                else:
+                    raise TypeError(f"Unsupported TermPartition subtype: {type(partition).__name__}.")
+
+        ordered: list[tuple[str, float]] = []
+        for index in indices:
+            real = complex(coefficients[index]).real
+            if abs(real) > weight_threshold:
+                ordered.append((labels[index], real))
+        return ordered
 
     @staticmethod
     def _build_step_terms(

--- a/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
+++ b/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
@@ -1,0 +1,226 @@
+r"""QDK/Chemistry implementation of the Zassenhaus-expansion Builder.
+
+The Zassenhaus formula is the dual of the Baker-Campbell-Hausdorff formula: it
+writes :math:`\exp(-iHt)` as an *ordered product* of exponentials in which the
+low-order commutator corrections appear as explicit factors, rather than being
+absorbed implicitly into a Trotter step count.  For a configured expansion order
+:math:`p` the operator-norm error scales as :math:`O(t^{\,p+1})` at fixed step
+count, so Hamiltonians whose dominant commutators are sparse or analytically
+tractable are simulated with fewer steps than Trotter-Suzuki would require.
+
+References:
+    Wilcox, R. M. "Exponential operators and parameter differentiation in quantum
+    physics." *Journal of Mathematical Physics* 8.4 (1967): 962-982.
+
+    Casas, F., Murua, A., and Nadinic, M. "Efficient computation of the Zassenhaus
+    formula." *Computer Physics Communications* 183.11 (2012): 2386-2391.
+    https://arxiv.org/abs/1204.0389
+
+    Childs, A. M., et al. "Theory of Trotter Error with Commutator Scaling."
+    *Physical Review X* 11.1 (2021): 011020. https://arxiv.org/abs/1912.08854
+
+"""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from qdk_chemistry.algorithms.hamiltonian_unitary_builder.base import TimeEvolutionBuilder, TimeEvolutionSettings
+from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus_expansion import zassenhaus_factors
+from qdk_chemistry.data import QubitHamiltonian, UnitaryRepresentation
+from qdk_chemistry.data.unitary_representation.containers.pauli_product_formula import (
+    ExponentiatedPauliTerm,
+    PauliProductFormulaContainer,
+)
+from qdk_chemistry.utils import Logger
+
+__all__: list[str] = ["Zassenhaus", "ZassenhausSettings"]
+
+
+class ZassenhausSettings(TimeEvolutionSettings):
+    """Settings for the Zassenhaus-expansion builder."""
+
+    def __init__(self):
+        """Initialize ZassenhausSettings with default values.
+
+        Attributes:
+            order: The Zassenhaus expansion order ``p``.  ``p = 1`` reproduces the
+                first-order Trotter product; higher orders cancel successively
+                higher commutator corrections, giving error ``O(t**(p+1))``.
+            num_divisions: Number of time divisions ``N``.  Each division evolves
+                for ``time / N`` and the step is repeated ``N`` times.
+            weight_threshold: The absolute threshold for filtering small coefficients.
+
+        """
+        super().__init__()
+        self._set_default("order", "int", 2, "The order of the Zassenhaus expansion.")
+        self._set_default(
+            "num_divisions",
+            "int",
+            1,
+            "Explicit number of time divisions (each evolves for time / num_divisions).",
+        )
+        self._set_default(
+            "weight_threshold", "float", 1e-12, "The absolute threshold for filtering small coefficients."
+        )
+
+
+class Zassenhaus(TimeEvolutionBuilder):
+    r"""Zassenhaus-expansion time-evolution builder.
+
+    Approximates the time-evolution operator :math:`e^{-iHt}` for a Hermitian
+    Hamiltonian :math:`H = \sum_j \alpha_j P_j` (Pauli strings :math:`P_j`) as an
+    ordered product of single-Pauli exponentials.  Starting from the bare
+    first-order Lie-Trotter product, the builder appends explicit commutator
+    corrections order by order so that, for expansion order :math:`p`,
+
+    .. math::
+
+        \bigl\lVert e^{-iHt} - U_{\text{Zassenhaus}} \bigr\rVert = O\!\left(t^{\,p+1}\right).
+
+    Because every nested commutator of Pauli strings is itself a scalar multiple
+    of a single Pauli string, each correction factor is again an exponential
+    :math:`e^{-i\theta P}` and the output is a
+    :class:`~qdk_chemistry.data.unitary_representation.containers.pauli_product_formula.PauliProductFormulaContainer`,
+    consumable by the same downstream algorithms (e.g. ``PhaseEstimation``) as the
+    Trotter builder.
+
+    The order-by-order commutator-cancellation construction is implemented by the
+    ``zassenhaus_factors`` function in the ``zassenhaus_expansion`` module.
+
+    Examples:
+        >>> from qdk_chemistry.algorithms import registry
+        >>> builder = registry.create(
+        ...     "hamiltonian_unitary_builder", "zassenhaus", order=3, time=1.0
+        ... )
+        >>> unitary = builder.run(qubit_hamiltonian)
+
+    """
+
+    def __init__(
+        self,
+        order: int = 2,
+        *,
+        time: float = 0.0,
+        num_divisions: int = 1,
+        weight_threshold: float = 1e-12,
+        power: int = 1,
+        power_strategy: str = "repeat",
+    ):
+        """Initialize the Zassenhaus builder with the specified settings.
+
+        Args:
+            order: Zassenhaus expansion order ``p >= 1``. Defaults to 2.
+            time: The evolution time. Defaults to 0.0.
+            num_divisions: Number of time divisions ``N`` (each evolves for
+                ``time / N`` and the step repeats ``N`` times). Defaults to 1.
+            weight_threshold: Threshold for filtering small coefficients. Defaults to 1e-12.
+            power: The power to raise the unitary to. Defaults to 1.
+            power_strategy: Strategy for U^power: ``"rescale"`` or ``"repeat"`` (default).
+
+        """
+        super().__init__()
+        self._settings = ZassenhausSettings()
+        self._settings.set("time", time)
+        self._settings.set("power", power)
+        self._settings.set("power_strategy", power_strategy)
+        self._settings.set("order", order)
+        self._settings.set("num_divisions", num_divisions)
+        self._settings.set("weight_threshold", weight_threshold)
+
+    def _run_impl(self, qubit_hamiltonian: QubitHamiltonian) -> UnitaryRepresentation:
+        """Construct the unitary representation using the Zassenhaus expansion.
+
+        Args:
+            qubit_hamiltonian: The qubit Hamiltonian to be used in the construction.
+
+        Returns:
+            UnitaryRepresentation: The unitary representation built by the Zassenhaus expansion.
+
+        """
+        effective_time, power_repetitions = self._resolve_power()
+        order = self._settings.get("order")
+        weight_threshold = self._settings.get("weight_threshold")
+
+        if order < 1:
+            raise ValueError(f"Zassenhaus expansion order must be >= 1, got {order}.")
+
+        num_divisions = self._settings.get("num_divisions")
+        if num_divisions < 1:
+            raise ValueError(f"num_divisions must be a positive integer, got {num_divisions}.")
+
+        if not qubit_hamiltonian.is_hermitian(tolerance=weight_threshold):
+            raise ValueError("Non-Hermitian Hamiltonian: coefficients have nonzero imaginary parts.")
+
+        num_qubits = qubit_hamiltonian.num_qubits
+        delta = effective_time / num_divisions
+
+        terms = qubit_hamiltonian.get_real_coefficients(tolerance=weight_threshold)
+        step_terms = self._build_step_terms(terms, order=order, delta=delta, atol=weight_threshold)
+
+        container = PauliProductFormulaContainer(
+            step_terms=step_terms,
+            step_reps=num_divisions * power_repetitions,
+            num_qubits=num_qubits,
+        )
+        return UnitaryRepresentation(container=container)
+
+    @staticmethod
+    def _build_step_terms(
+        terms: list[tuple[str, float]],
+        *,
+        order: int,
+        delta: float,
+        atol: float,
+    ) -> list[ExponentiatedPauliTerm]:
+        r"""Build the exponentiated-Pauli terms for a single time division of length ``delta``.
+
+        The symbolic Zassenhaus factors (rotation-angle prefactor + power of ``t``)
+        are evaluated at ``t = delta``: factor ``f`` contributes the rotation
+        :math:`e^{-i\,\theta\,P}` with ``theta = f.angle_coefficient * delta**f.degree``.
+
+        Args:
+            terms: ``(pauli_label, coefficient)`` pairs of the Hermitian Hamiltonian.
+            order: Zassenhaus expansion order.
+            delta: Evolution time of a single division.
+            atol: Absolute tolerance for dropping negligible rotations.
+
+        Returns:
+            Ordered list of :class:`ExponentiatedPauliTerm` for one division.
+
+        """
+        if not terms:
+            Logger.warn("No coefficients above the tolerance; returning empty term list.")
+            return []
+
+        # ``zassenhaus_factors`` returns factors f_0, f_1, ... defining the product
+        # U = exp(f_0) exp(f_1) ... with f_0 *leftmost*.  Downstream consumers
+        # (``PauliSequenceMapper`` and the container's matrix reconstruction) apply
+        # ``step_terms[0]`` *first* (i.e. rightmost in the matrix product), so the
+        # factor list is reversed here to preserve the intended ordering.
+        #
+        # Structurally negligible factors are already pruned inside
+        # ``zassenhaus_factors`` (via the ``t``-independent coefficient threshold);
+        # the angle is *not* re-thresholded here, since ``angle = coeff * delta**degree``
+        # shrinks with the time step and would otherwise drop high-order corrections at
+        # small ``t``, spoiling the O(t**(order+1)) error scaling.
+        factors = zassenhaus_factors(terms, order, tol=atol)
+
+        return [
+            ExponentiatedPauliTerm(
+                pauli_term=dict(factor.pauli_term),
+                angle=factor.angle_coefficient * (delta**factor.degree),
+            )
+            for factor in reversed(factors)
+        ]
+
+    def name(self) -> str:
+        """Return the name of the unitary builder."""
+        return "zassenhaus"
+
+    def type_name(self) -> str:
+        """Return hamiltonian_unitary_builder as the algorithm type name."""
+        return "hamiltonian_unitary_builder"

--- a/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus_expansion.py
+++ b/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus_expansion.py
@@ -109,68 +109,154 @@ def _poly_clean(poly: GradedPoly, tol: float = 1e-14) -> GradedPoly:
     return cleaned
 
 
-def _poly_multiply(left: GradedPoly, right: GradedPoly, max_degree: int) -> GradedPoly:
-    """Multiply two graded Pauli polynomials, truncating contributions above ``max_degree``."""
+# ----------------------------------------------------------------------------------
+# Commutator-based log of a product (avoids materialising the dense product)
+# ----------------------------------------------------------------------------------
+
+# Dexpinv coefficients c_k = (-1)**k * B_k / k!  (B_k = Bernoulli numbers), from
+#   log(e^Z e^f) = Z + integral_0^1  sum_k c_k ad_{Omega(s)}^k (f)  ds.
+# Odd k > 1 vanish.  Tabulated through k = 8 (covers expansion orders well past use).
+_DEXPINV_COEFFS: dict[int, float] = {
+    0: 1.0,
+    1: 0.5,
+    2: 1.0 / 12.0,
+    4: -1.0 / 720.0,
+    6: 1.0 / 30240.0,
+    8: -1.0 / 1209600.0,
+}
+
+# An operator carrying an explicit power of the BCH integration variable ``s``:
+# s_power -> graded Pauli polynomial.
+SPoly = dict[int, GradedPoly]
+
+
+def _word_commutator(word_a: PauliWord, word_b: PauliWord) -> tuple[complex, PauliWord] | None:
+    r"""Commutator of two Pauli words: ``(coeff, word)`` for :math:`[P_a, P_b]`, or ``None`` if they commute.
+
+    For Pauli strings, :math:`P_a P_b = \phi_{ab} Q` and :math:`P_b P_a = \phi_{ba} Q`
+    (the same word :math:`Q`), so :math:`[P_a, P_b] = (\phi_{ab} - \phi_{ba}) Q`, which
+    vanishes exactly when the two strings commute.  This is what keeps the corrections
+    sparse: every commutator is a single Pauli word, and commuting pairs cost nothing.
+    """
+    list_a, list_b = list(word_a), list(word_b)
+    phase_ab, product = PauliTermAccumulator.multiply_uncached(list_a, list_b)
+    phase_ba, _ = PauliTermAccumulator.multiply_uncached(list_b, list_a)
+    coeff = phase_ab - phase_ba
+    if abs(coeff) < 1e-15:
+        return None
+    return coeff, _canonical_word(product)
+
+
+def _poly_commutator(left: GradedPoly, right: GradedPoly, max_degree: int, tol: float = 1e-14) -> GradedPoly:
+    """Graded commutator ``[left, right]``, computed term by term.
+
+    Only anticommuting word pairs contribute; commuting pairs are skipped, so the
+    result stays as sparse as the generated Lie algebra allows (no dense intermediate).
+    """
     out: GradedPoly = {}
     for word_a, deg_a in left.items():
-        list_a = list(word_a)
         for word_b, deg_b in right.items():
-            phase, product = PauliTermAccumulator.multiply_uncached(list_a, list(word_b))
-            result_word = _canonical_word(product)
-            bucket = out.setdefault(result_word, {})
+            commuted = _word_commutator(word_a, word_b)
+            if commuted is None:
+                continue
+            comm_coeff, word = commuted
+            bucket = out.setdefault(word, {})
             for da, ca in deg_a.items():
                 for db, cb in deg_b.items():
                     degree = da + db
                     if degree > max_degree:
                         continue
-                    bucket[degree] = bucket.get(degree, 0j) + phase * ca * cb
+                    bucket[degree] = bucket.get(degree, 0j) + comm_coeff * ca * cb
+    return _poly_clean(out, tol)
+
+
+def _sop_add_inplace(target: SPoly, other: SPoly, scale: complex = 1.0) -> SPoly:
+    """Accumulate ``scale * other`` into an s-power-indexed operator ``target`` (in place)."""
+    for s_power, poly in other.items():
+        _poly_add_inplace(target.setdefault(s_power, {}), poly, scale)
+    return target
+
+
+def _sop_to_poly(sop: SPoly) -> GradedPoly:
+    """Evaluate an s-power operator at ``s = 1`` by summing over its s-powers."""
+    total: GradedPoly = {}
+    for poly in sop.values():
+        _poly_add_inplace(total, poly)
+    return total
+
+
+def _sop_ad(omega: SPoly, term: SPoly, max_degree: int) -> SPoly:
+    """Apply the adjoint action ``[Omega, .]`` to an s-power operator (s-powers add)."""
+    out: SPoly = {}
+    for i, op_i in omega.items():
+        for j, op_j in term.items():
+            comm = _poly_commutator(op_i, op_j, max_degree)
+            if comm:
+                _poly_add_inplace(out.setdefault(i + j, {}), comm)
     return out
 
 
-def _poly_identity() -> GradedPoly:
-    """Return the identity element of the graded Pauli algebra."""
-    return {(): {0: 1 + 0j}}
+def _polys_close(a: GradedPoly, b: GradedPoly, tol: float) -> bool:
+    """Whether two graded polynomials agree to within ``tol`` on every coefficient."""
+    for word in set(a) | set(b):
+        da, db = a.get(word, {}), b.get(word, {})
+        for degree in set(da) | set(db):
+            if abs(da.get(degree, 0j) - db.get(degree, 0j)) > tol:
+                return False
+    return True
 
 
-def _poly_exp(generator: GradedPoly, max_degree: int) -> GradedPoly:
-    r"""Return the truncated series :math:`\exp(generator)`.
+def _bch_merge(z_poly: GradedPoly, f_poly: GradedPoly, max_degree: int, tol: float = 1e-14) -> GradedPoly:
+    r"""Return ``log(e^Z e^f)`` truncated to t-degree ``max_degree`` using commutators only.
 
-    ``generator`` must have minimum degree :math:`\ge 1` so the Taylor series
-    truncates: the :math:`k`-th power has minimum degree :math:`k`.
+    Solves the dexpinv ODE :math:`\Omega'(s) = \sum_k c_k\,\mathrm{ad}_{\Omega(s)}^k(f)`
+    with :math:`\Omega(0)=Z` for :math:`\Omega(1)`, by Picard iteration that tracks the
+    integration variable ``s`` as an explicit polynomial degree.  ``e^Z`` (the dense
+    product) is never formed; the only non-sparse object is the log itself.
     """
-    result = _poly_identity()
-    term = _poly_identity()
-    for k in range(1, max_degree + 1):
-        term = _poly_multiply(term, generator, max_degree)
-        if not term:
+    seed = {w: dict(dm) for w, dm in z_poly.items()}
+    omega: SPoly = {0: {w: dict(dm) for w, dm in seed.items()}}
+    previous = _poly_clean(_sop_to_poly(omega), tol)
+    for _ in range(max_degree + 3):
+        # integrand(s) = sum_k c_k ad_{Omega(s)}^k (f)
+        integrand: SPoly = {}
+        term: SPoly = {0: {w: dict(dm) for w, dm in f_poly.items()}}
+        _sop_add_inplace(integrand, term, _DEXPINV_COEFFS[0])
+        for k in range(1, max_degree + 1):
+            term = _sop_ad(omega, term, max_degree)
+            if not term:
+                break
+            ck = _DEXPINV_COEFFS.get(k, 0.0)
+            if ck != 0.0:
+                _sop_add_inplace(integrand, term, ck)
+        # Omega(s) = Z + integral_0^s integrand d(sigma):  s_power j -> j+1, divide by j+1
+        new_omega: SPoly = {0: {w: dict(dm) for w, dm in seed.items()}}
+        for s_power, poly in integrand.items():
+            integrated = {word: {deg: c / (s_power + 1) for deg, c in dm.items()} for word, dm in poly.items()}
+            _poly_add_inplace(new_omega.setdefault(s_power + 1, {}), integrated)
+        omega = {sp: cleaned for sp, p in new_omega.items() if (cleaned := _poly_clean(p, tol))}
+        current = _poly_clean(_sop_to_poly(omega), tol)
+        converged = _polys_close(current, previous, tol)
+        previous = current
+        if converged:
             break
-        term = {word: {degree: coeff / k for degree, coeff in degree_map.items()} for word, degree_map in term.items()}
-        _poly_add_inplace(result, term)
-    return _poly_clean(result)
+    return previous
 
 
-def _poly_log(unitary: GradedPoly, max_degree: int) -> GradedPoly:
-    r"""Return the truncated series :math:`\log(unitary)` for ``unitary = I + M``.
+def _log_of_product(
+    factors: list[tuple[PauliWord, int, complex]], max_degree: int, tol: float = 1e-14
+) -> GradedPoly:
+    r"""Compute ``log(prod_m exp(f_m))`` to t-degree ``max_degree`` via incremental BCH merges.
 
-    Uses :math:`\log(I + M) = \sum_{k \ge 1} (-1)^{k+1} M^{k}/k`, where
-    :math:`M` has minimum degree :math:`\ge 1`.
+    Each ``f_m`` is a single Pauli term ``(word, degree, coeff)``.  The factors are
+    folded left to right, merging each into the running log with :func:`_bch_merge`,
+    so the dense product is never materialised and commuting pairs are skipped.
     """
-    residual = _poly_add_inplace({word: dict(dm) for word, dm in unitary.items()}, {(): {0: -1 + 0j}})
-    residual = _poly_clean(residual)
-
-    result: GradedPoly = {}
-    power = _poly_identity()
-    for k in range(1, max_degree + 1):
-        power = _poly_multiply(power, residual, max_degree)
-        if not power:
-            break
-        sign = 1.0 if k % 2 == 1 else -1.0
-        scaled = {
-            word: {degree: sign * coeff / k for degree, coeff in degree_map.items()}
-            for word, degree_map in power.items()
-        }
-        _poly_add_inplace(result, scaled)
-    return _poly_clean(result)
+    running: GradedPoly = {}
+    for word, degree, coeff in factors:
+        f_poly: GradedPoly = {word: {degree: coeff}}
+        running = f_poly if not running else _bch_merge(running, f_poly, max_degree, tol)
+    return _poly_clean(running, tol)
 
 
 # ----------------------------------------------------------------------------------
@@ -194,16 +280,20 @@ def zassenhaus_factors(
     The factors are built order by order.  Starting from the bare first-order
     Lie-Trotter product :math:`\prod_k \exp(-i\alpha_k t P_k)`, the routine repeatedly
 
-    1. forms the truncated unitary series :math:`U = \prod_m \exp(f_m)`,
-    2. computes its logarithm :math:`L = \log U` as a graded Pauli polynomial,
-    3. extracts the degree-:math:`n` residual :math:`R_n` of :math:`L - (-iHt)`, and
-    4. appends single-Pauli factors realising :math:`-R_n`.
+    1. computes :math:`L = \log\bigl(\prod_m \exp(f_m)\bigr)` as a graded Pauli polynomial,
+    2. extracts the degree-:math:`n` residual :math:`R_n` of :math:`L - (-iHt)`, and
+    3. appends single-Pauli factors realising :math:`-R_n`.
 
     Appending degree-:math:`n` factors cancels the order-:math:`n` term of
     :math:`\log U` exactly (their mutual cross terms are of degree :math:`\ge n+1`),
     and recomputing :math:`L` at every step folds all splitting errors into later
     corrections.  After processing :math:`n = 2, \dots, \text{order}` the logarithm
     equals :math:`-iHt + O(t^{\,\text{order}+1})`.
+
+    The logarithm :math:`L = \log\prod_m \exp(f_m)` is computed directly via nested
+    commutators (the BCH/dexpinv recursion in :func:`_log_of_product`) -- each commutator
+    of Pauli words is a single word and commuting pairs are skipped, so the dense
+    :math:`4^n` product is never materialised.
 
     Args:
         terms: ``(pauli_label, coefficient)`` pairs for the Hermitian Hamiltonian.
@@ -235,10 +325,7 @@ def zassenhaus_factors(
     target = _poly_clean(target, tol)
 
     for degree in range(2, order + 1):
-        unitary = _poly_identity()
-        for word, factor_degree, coeff in factors:
-            unitary = _poly_multiply(unitary, _poly_exp({word: {factor_degree: coeff}}, order), order)
-        log_unitary = _poly_log(_poly_clean(unitary, tol), order)
+        log_unitary = _log_of_product(factors, order, tol)
 
         difference = _poly_add_inplace({w: dict(dm) for w, dm in log_unitary.items()}, target, scale=-1.0)
         residual = _poly_clean(difference, tol)

--- a/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus_expansion.py
+++ b/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus_expansion.py
@@ -1,0 +1,274 @@
+r"""Graded Pauli-polynomial algebra and the Zassenhaus factor construction.
+
+This module implements the order-by-order Zassenhaus expansion used by the
+:class:`~qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus.Zassenhaus`
+builder.  It is kept separate from the builder so the (purely algebraic) factor
+construction can be unit-tested without constructing
+:class:`~qdk_chemistry.data.UnitaryRepresentation` objects.
+
+The key observation is that for a Pauli Hamiltonian every nested commutator of the
+summands is again a scalar multiple of a *single* Pauli string, so the whole
+construction stays inside the Pauli algebra -- no matrix logarithms are required.
+
+Operators are represented as **graded Pauli polynomials**: a mapping
+
+    ``word -> {degree: complex_coefficient}``
+
+where ``word`` is a canonical sparse Pauli word (a sorted tuple of
+``(qubit_index, pauli_axis)`` pairs, ``pauli_axis`` in ``{1: X, 2: Y, 3: Z}``) and
+``degree`` tracks the power of the evolution time :math:`t`.  Pauli-string products
+(with their phases) are delegated to
+:meth:`~qdk_chemistry.data.PauliTermAccumulator.multiply_uncached`, the same tested
+routine used by :func:`~qdk_chemistry.utils.pauli_commutation.commutator`.
+
+References:
+    R. M. Wilcox, *Exponential operators and parameter differentiation in quantum
+    physics*, J. Math. Phys. **8**, 962 (1967).
+
+    F. Casas, A. Murua, and M. Nadinic, *Efficient computation of the Zassenhaus
+    formula*, Comput. Phys. Commun. **183**, 2386 (2012). arXiv:1204.0389.
+
+    A. M. Childs, Y. Su, M. C. Tran, N. Wiebe, and S. Zhu, *Theory of Trotter error
+    with commutator scaling*, Phys. Rev. X **11**, 011020 (2021). arXiv:1912.08854.
+
+"""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from qdk_chemistry.data import PauliTermAccumulator
+
+__all__: list[str] = ["ZassenhausFactor", "zassenhaus_factors"]
+
+# A canonical sparse Pauli word: sorted tuple of (qubit_index, pauli_axis),
+# pauli_axis in {1: X, 2: Y, 3: Z}.  The empty tuple is the identity.
+PauliWord = tuple[tuple[int, int], ...]
+
+# A graded Pauli polynomial: word -> {degree: coefficient}.
+GradedPoly = dict[PauliWord, dict[int, complex]]
+
+_AXIS_TO_CHAR = {1: "X", 2: "Y", 3: "Z"}
+
+
+@dataclass(frozen=True)
+class ZassenhausFactor:
+    r"""A single exponential factor :math:`\exp(-i\,\theta\,t^{d}\,P)` of the Zassenhaus product.
+
+    The rotation angle for a concrete per-step time :math:`t` is
+    ``angle_coefficient * t**degree``; keeping ``degree`` explicit lets the builder
+    evaluate the same symbolic factor list at any time step.
+    """
+
+    pauli_term: dict[int, str]
+    """Mapping ``qubit_index -> {'X', 'Y', 'Z'}`` describing the Pauli string :math:`P`."""
+
+    angle_coefficient: float
+    """Real prefactor of the rotation angle; the angle is ``angle_coefficient * t**degree``."""
+
+    degree: int
+    """Power of the evolution time :math:`t` carried by this factor."""
+
+
+# ----------------------------------------------------------------------------------
+# Graded Pauli-polynomial algebra
+# ----------------------------------------------------------------------------------
+
+
+def _word_to_term_map(word: PauliWord) -> dict[int, str]:
+    """Convert a canonical sparse Pauli word to a ``{qubit: axis_char}`` mapping."""
+    return {qubit: _AXIS_TO_CHAR[axis] for qubit, axis in word}
+
+
+def _canonical_word(word: list[tuple[int, int]]) -> PauliWord:
+    """Return a sorted tuple form of a sparse Pauli word, dropping identity entries."""
+    return tuple(sorted((q, a) for q, a in word if a != 0))
+
+
+def _poly_add_inplace(target: GradedPoly, other: GradedPoly, scale: complex = 1.0) -> GradedPoly:
+    """Accumulate ``scale * other`` into ``target`` (modified in place) and return it."""
+    for word, degree_map in other.items():
+        bucket = target.setdefault(word, {})
+        for degree, coeff in degree_map.items():
+            bucket[degree] = bucket.get(degree, 0j) + scale * coeff
+    return target
+
+
+def _poly_clean(poly: GradedPoly, tol: float = 1e-14) -> GradedPoly:
+    """Drop coefficients (and emptied words) whose magnitude is below ``tol``."""
+    cleaned: GradedPoly = {}
+    for word, degree_map in poly.items():
+        kept = {degree: coeff for degree, coeff in degree_map.items() if abs(coeff) > tol}
+        if kept:
+            cleaned[word] = kept
+    return cleaned
+
+
+def _poly_multiply(left: GradedPoly, right: GradedPoly, max_degree: int) -> GradedPoly:
+    """Multiply two graded Pauli polynomials, truncating contributions above ``max_degree``."""
+    out: GradedPoly = {}
+    for word_a, deg_a in left.items():
+        list_a = list(word_a)
+        for word_b, deg_b in right.items():
+            phase, product = PauliTermAccumulator.multiply_uncached(list_a, list(word_b))
+            result_word = _canonical_word(product)
+            bucket = out.setdefault(result_word, {})
+            for da, ca in deg_a.items():
+                for db, cb in deg_b.items():
+                    degree = da + db
+                    if degree > max_degree:
+                        continue
+                    bucket[degree] = bucket.get(degree, 0j) + phase * ca * cb
+    return out
+
+
+def _poly_identity() -> GradedPoly:
+    """Return the identity element of the graded Pauli algebra."""
+    return {(): {0: 1 + 0j}}
+
+
+def _poly_exp(generator: GradedPoly, max_degree: int) -> GradedPoly:
+    r"""Return the truncated series :math:`\exp(generator)`.
+
+    ``generator`` must have minimum degree :math:`\ge 1` so the Taylor series
+    truncates: the :math:`k`-th power has minimum degree :math:`k`.
+    """
+    result = _poly_identity()
+    term = _poly_identity()
+    for k in range(1, max_degree + 1):
+        term = _poly_multiply(term, generator, max_degree)
+        if not term:
+            break
+        term = {word: {degree: coeff / k for degree, coeff in degree_map.items()} for word, degree_map in term.items()}
+        _poly_add_inplace(result, term)
+    return _poly_clean(result)
+
+
+def _poly_log(unitary: GradedPoly, max_degree: int) -> GradedPoly:
+    r"""Return the truncated series :math:`\log(unitary)` for ``unitary = I + M``.
+
+    Uses :math:`\log(I + M) = \sum_{k \ge 1} (-1)^{k+1} M^{k}/k`, where
+    :math:`M` has minimum degree :math:`\ge 1`.
+    """
+    residual = _poly_add_inplace({word: dict(dm) for word, dm in unitary.items()}, {(): {0: -1 + 0j}})
+    residual = _poly_clean(residual)
+
+    result: GradedPoly = {}
+    power = _poly_identity()
+    for k in range(1, max_degree + 1):
+        power = _poly_multiply(power, residual, max_degree)
+        if not power:
+            break
+        sign = 1.0 if k % 2 == 1 else -1.0
+        scaled = {
+            word: {degree: sign * coeff / k for degree, coeff in degree_map.items()}
+            for word, degree_map in power.items()
+        }
+        _poly_add_inplace(result, scaled)
+    return _poly_clean(result)
+
+
+# ----------------------------------------------------------------------------------
+# Zassenhaus factor construction
+# ----------------------------------------------------------------------------------
+
+
+def zassenhaus_factors(
+    terms: list[tuple[str, float]],
+    order: int,
+    *,
+    tol: float = 1e-14,
+) -> list[ZassenhausFactor]:
+    r"""Construct the Zassenhaus product factorisation of :math:`\exp(-iHt)`.
+
+    Given the real Pauli expansion :math:`H = \sum_k \alpha_k P_k` (passed as
+    ``terms`` of ``(pauli_label, alpha_k)`` pairs), this returns an ordered list of
+    single-Pauli exponential factors whose product approximates :math:`\exp(-iHt)`
+    with operator-norm error :math:`O(t^{\,\text{order}+1})`.
+
+    The factors are built order by order.  Starting from the bare first-order
+    Lie-Trotter product :math:`\prod_k \exp(-i\alpha_k t P_k)`, the routine repeatedly
+
+    1. forms the truncated unitary series :math:`U = \prod_m \exp(f_m)`,
+    2. computes its logarithm :math:`L = \log U` as a graded Pauli polynomial,
+    3. extracts the degree-:math:`n` residual :math:`R_n` of :math:`L - (-iHt)`, and
+    4. appends single-Pauli factors realising :math:`-R_n`.
+
+    Appending degree-:math:`n` factors cancels the order-:math:`n` term of
+    :math:`\log U` exactly (their mutual cross terms are of degree :math:`\ge n+1`),
+    and recomputing :math:`L` at every step folds all splitting errors into later
+    corrections.  After processing :math:`n = 2, \dots, \text{order}` the logarithm
+    equals :math:`-iHt + O(t^{\,\text{order}+1})`.
+
+    Args:
+        terms: ``(pauli_label, coefficient)`` pairs for the Hermitian Hamiltonian.
+            Labels use the little-endian convention (rightmost character is qubit 0).
+        order: The Zassenhaus expansion order :math:`p \ge 1`.  ``order = 1`` reproduces
+            the first-order Trotter product.
+        tol: Magnitude below which graded coefficients are discarded.
+
+    Returns:
+        Ordered list of :class:`ZassenhausFactor`.  The rotation angle of factor
+        ``f`` at per-step time ``t`` is ``f.angle_coefficient * t**f.degree``.
+
+    Raises:
+        ValueError: If ``order < 1``.
+
+    """
+    if order < 1:
+        raise ValueError(f"Zassenhaus expansion order must be >= 1, got {order}.")
+
+    # Seed: a_k = -i * alpha_k * P_k, carrying one power of t (degree 1).
+    factors: list[tuple[PauliWord, int, complex]] = []
+    target: GradedPoly = {}  # A = -i t H, the exact generator we are matching.
+    for label, alpha in terms:
+        word = _canonical_word(_label_to_word(label))
+        coeff = -1j * alpha
+        factors.append((word, 1, coeff))
+        bucket = target.setdefault(word, {})
+        bucket[1] = bucket.get(1, 0j) + coeff
+    target = _poly_clean(target, tol)
+
+    for degree in range(2, order + 1):
+        unitary = _poly_identity()
+        for word, factor_degree, coeff in factors:
+            unitary = _poly_multiply(unitary, _poly_exp({word: {factor_degree: coeff}}, order), order)
+        log_unitary = _poly_log(_poly_clean(unitary, tol), order)
+
+        difference = _poly_add_inplace({w: dict(dm) for w, dm in log_unitary.items()}, target, scale=-1.0)
+        residual = _poly_clean(difference, tol)
+
+        # Append -R_n: the degree-`degree` part of the residual, in canonical order.
+        for word in sorted(residual.keys()):
+            coeff = residual[word].get(degree, 0j)
+            if abs(coeff) > tol:
+                factors.append((word, degree, -coeff))
+
+    return [_to_factor(word, degree, coeff) for word, degree, coeff in factors]
+
+
+def _to_factor(word: PauliWord, degree: int, coeff: complex) -> ZassenhausFactor:
+    r"""Convert an internal ``(word, degree, antihermitian coeff)`` triple to a :class:`ZassenhausFactor`.
+
+    The internal coefficient ``coeff`` is the antihermitian prefactor of
+    :math:`\exp(\text{coeff}\, t^{d} P)`.  For a Hermitian Hamiltonian it is purely
+    imaginary, so the rotation angle ``theta`` with :math:`\exp(-i\,\theta\,t^{d}P)`
+    is ``theta = i * coeff`` (real).
+    """
+    angle_coefficient = (1j * coeff).real
+    return ZassenhausFactor(pauli_term=_word_to_term_map(word), angle_coefficient=angle_coefficient, degree=degree)
+
+
+def _label_to_word(label: str) -> list[tuple[int, int]]:
+    """Convert a little-endian Pauli label to a sparse word (qubit-0-first, axis ints)."""
+    axis = {"X": 1, "Y": 2, "Z": 3}
+    word: list[tuple[int, int]] = []
+    for index, char in enumerate(reversed(label)):
+        if char != "I":
+            word.append((index, axis[char]))
+    return word

--- a/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus_expansion.py
+++ b/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus_expansion.py
@@ -130,21 +130,33 @@ _DEXPINV_COEFFS: dict[int, float] = {
 SPoly = dict[int, GradedPoly]
 
 
+def _words_commute(word_a: PauliWord, word_b: PauliWord) -> bool:
+    """Whether two Pauli words commute.
+
+    Two Pauli strings commute iff the number of qubits where both act with
+    *different* (non-identity) single-qubit operators is even.  This mirrors the
+    label-based check in :func:`qdk_chemistry.utils.pauli_commutation.commutator`,
+    on sparse words instead of full strings.
+    """
+    axes_b = dict(word_b)
+    anticommuting = sum(1 for qubit, axis_a in word_a if axes_b.get(qubit, axis_a) != axis_a)
+    return anticommuting % 2 == 0
+
+
 def _word_commutator(word_a: PauliWord, word_b: PauliWord) -> tuple[complex, PauliWord] | None:
     r"""Commutator of two Pauli words: ``(coeff, word)`` for :math:`[P_a, P_b]`, or ``None`` if they commute.
 
-    For Pauli strings, :math:`P_a P_b = \phi_{ab} Q` and :math:`P_b P_a = \phi_{ba} Q`
-    (the same word :math:`Q`), so :math:`[P_a, P_b] = (\phi_{ab} - \phi_{ba}) Q`, which
-    vanishes exactly when the two strings commute.  This is what keeps the corrections
-    sparse: every commutator is a single Pauli word, and commuting pairs cost nothing.
+    When the two strings anticommute, :math:`P_b P_a = -P_a P_b`, so
+    :math:`[P_a, P_b] = P_a P_b - P_b P_a = 2\,P_a P_b`.  We therefore short-circuit on
+    the cheap commutativity pre-check (skipping commuting pairs entirely) and evaluate a
+    single product :math:`P_a P_b` -- the :math:`P_b P_a` phase is fixed by the
+    anticommutation relation and never computed.  Every commutator is a single Pauli
+    word, which is what keeps the corrections sparse.
     """
-    list_a, list_b = list(word_a), list(word_b)
-    phase_ab, product = PauliTermAccumulator.multiply_uncached(list_a, list_b)
-    phase_ba, _ = PauliTermAccumulator.multiply_uncached(list_b, list_a)
-    coeff = phase_ab - phase_ba
-    if abs(coeff) < 1e-15:
+    if _words_commute(word_a, word_b):
         return None
-    return coeff, _canonical_word(product)
+    phase_ab, product = PauliTermAccumulator.multiply_uncached(list(word_a), list(word_b))
+    return 2.0 * phase_ab, _canonical_word(product)
 
 
 def _poly_commutator(left: GradedPoly, right: GradedPoly, max_degree: int, tol: float = 1e-14) -> GradedPoly:
@@ -217,6 +229,7 @@ def _bch_merge(z_poly: GradedPoly, f_poly: GradedPoly, max_degree: int, tol: flo
     seed = {w: dict(dm) for w, dm in z_poly.items()}
     omega: SPoly = {0: {w: dict(dm) for w, dm in seed.items()}}
     previous = _poly_clean(_sop_to_poly(omega), tol)
+    converged = False
     for _ in range(max_degree + 3):
         # integrand(s) = sum_k c_k ad_{Omega(s)}^k (f)
         integrand: SPoly = {}
@@ -240,6 +253,11 @@ def _bch_merge(z_poly: GradedPoly, f_poly: GradedPoly, max_degree: int, tol: flo
         previous = current
         if converged:
             break
+    if not converged:
+        raise RuntimeError(
+            f"BCH merge (dexpinv Picard iteration) did not converge within {max_degree + 3} iterations "
+            f"at max_degree={max_degree}."
+        )
     return previous
 
 
@@ -324,29 +342,54 @@ def zassenhaus_factors(
         bucket[1] = bucket.get(1, 0j) + coeff
     target = _poly_clean(target, tol)
 
-    for degree in range(2, order + 1):
-        log_unitary = _log_of_product(factors, order, tol)
+    # Maintain the running log incrementally: start from the seed product, then fold in
+    # each batch of corrections as they are appended -- rather than recomputing the full
+    # product log every order (the corrections from earlier orders are already baked in).
+    running_log = _log_of_product(factors, order, tol)
 
-        difference = _poly_add_inplace({w: dict(dm) for w, dm in log_unitary.items()}, target, scale=-1.0)
+    for degree in range(2, order + 1):
+        difference = _poly_add_inplace({w: dict(dm) for w, dm in running_log.items()}, target, scale=-1.0)
         residual = _poly_clean(difference, tol)
 
         # Append -R_n: the degree-`degree` part of the residual, in canonical order.
+        new_factors: list[tuple[PauliWord, int, complex]] = []
         for word in sorted(residual.keys()):
             coeff = residual[word].get(degree, 0j)
             if abs(coeff) > tol:
-                factors.append((word, degree, -coeff))
+                new_factors.append((word, degree, -coeff))
+        factors.extend(new_factors)
+
+        # Fold the newly appended factors into the running log for the next order
+        # (skipped on the final order: the log is not needed again).
+        if degree < order:
+            for word, factor_degree, coeff in new_factors:
+                running_log = _bch_merge(running_log, {word: {factor_degree: coeff}}, order, tol)
 
     return [_to_factor(word, degree, coeff) for word, degree, coeff in factors]
 
 
-def _to_factor(word: PauliWord, degree: int, coeff: complex) -> ZassenhausFactor:
+def _to_factor(word: PauliWord, degree: int, coeff: complex, hermiticity_tol: float = 1e-9) -> ZassenhausFactor:
     r"""Convert an internal ``(word, degree, antihermitian coeff)`` triple to a :class:`ZassenhausFactor`.
 
     The internal coefficient ``coeff`` is the antihermitian prefactor of
     :math:`\exp(\text{coeff}\, t^{d} P)`.  For a Hermitian Hamiltonian it is purely
     imaginary, so the rotation angle ``theta`` with :math:`\exp(-i\,\theta\,t^{d}P)`
-    is ``theta = i * coeff`` (real).
+    is ``theta = i * coeff`` (real); the rotation angle keeps ``Im(coeff)`` and the
+    real part is discarded.
+
+    A non-negligible real part signals non-Hermitian drift (an upstream non-Hermitian
+    input or an arithmetic bug), so it is rejected rather than silently dropped.
+
+    Raises:
+        ValueError: If ``abs(coeff.real) > hermiticity_tol``.
     """
+    if abs(coeff.real) > hermiticity_tol:
+        axes = {1: "X", 2: "Y", 3: "Z"}
+        label = " ".join(f"{axes[a]}{q}" for q, a in word) or "I"
+        raise ValueError(
+            f"Non-Hermitian drift: factor on [{label}] (degree {degree}) has "
+            f"|Re(coeff)| = {abs(coeff.real):.2e} > {hermiticity_tol:.1e}."
+        )
     angle_coefficient = (1j * coeff).real
     return ZassenhausFactor(pauli_term=_word_to_term_map(word), angle_coefficient=angle_coefficient, degree=degree)
 

--- a/python/src/qdk_chemistry/algorithms/registry.py
+++ b/python/src/qdk_chemistry/algorithms/registry.py
@@ -596,6 +596,7 @@ def _register_python_algorithms():
     )
     from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.qdrift import QDrift  # noqa: PLC0415
     from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.trotter import Trotter  # noqa: PLC0415
+    from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus import Zassenhaus  # noqa: PLC0415
     from qdk_chemistry.algorithms.phase_estimation.circuit_builder.iterative_builder import (  # noqa: PLC0415
         QdkIterativeQpeCircuitBuilder,
     )
@@ -626,6 +627,7 @@ def _register_python_algorithms():
     register(lambda: IdentityTermGrouper())
     register(lambda: Trotter())
     register(lambda: QDrift())
+    register(lambda: Zassenhaus())
     register(lambda: PartiallyRandomized())
     register(lambda: PauliSequenceMapper())
     register(lambda: ControlledPauliSequenceMapper())

--- a/python/tests/test_time_evolution_zassenhaus.py
+++ b/python/tests/test_time_evolution_zassenhaus.py
@@ -210,8 +210,9 @@ def _fit_error_slope(hamiltonian: QubitHamiltonian, order: int) -> float:
 
     For high orders on small-coefficient Hamiltonians the error at the smallest
     times reaches the floating-point floor (``~1e-15``), where the log-log slope is
-    meaningless.  Such points are dropped before the fit; the remaining points still
-    lie within the specified ``[1e-3, 1e-1]`` window.
+    meaningless.  Points within ~2 orders of that floor (``< 1e-13``) are dropped
+    before the fit; every remaining point still follows the power law and lies within
+    the specified ``[1e-3, 1e-1]`` window.
     """
     hamiltonian_matrix = hamiltonian.to_matrix()
     times = np.logspace(-3, -1, 12)
@@ -224,7 +225,7 @@ def _fit_error_slope(hamiltonian: QubitHamiltonian, order: int) -> float:
         errors.append(np.linalg.norm(u_exact - u_builder, 2))
     errors = np.asarray(errors)
 
-    mask = errors > 1e-10
+    mask = errors > 1e-13
     if int(mask.sum()) < 4:
         # Too few points above the floor: keep the six largest-t points.
         mask = np.zeros_like(errors, dtype=bool)
@@ -380,4 +381,9 @@ def test_h2_ground_state_chemical_accuracy():
         shots_per_bit=1,
     )
     resolved = _resolve_energy(phase_fraction, evolution_time, expected_energy=ground_energy)
-    assert abs(resolved - ground_energy) < 1.6e-3
+    error = abs(resolved - ground_energy)
+    print(
+        f"\n[H2/STO-3G QPE] estimated = {resolved:.6f} Ha | exact (FCI) = {ground_energy:.6f} Ha "
+        f"| |error| = {error:.2e} Ha (chemical accuracy = 1.6e-3 Ha)"
+    )
+    assert error < 1.6e-3

--- a/python/tests/test_time_evolution_zassenhaus.py
+++ b/python/tests/test_time_evolution_zassenhaus.py
@@ -1,0 +1,383 @@
+"""Tests for the Zassenhaus-expansion Hamiltonian unitary builder in QDK/Chemistry."""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import scipy.linalg
+
+from qdk_chemistry.algorithms import registry
+from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus import Zassenhaus
+from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus_expansion import (
+    zassenhaus_factors,
+)
+from qdk_chemistry.data import QubitHamiltonian, UnitaryRepresentation
+from qdk_chemistry.data.unitary_representation.containers.pauli_product_formula import (
+    PauliProductFormulaContainer,
+)
+from qdk_chemistry.utils.model_hamiltonians import create_heisenberg_hamiltonian
+
+try:
+    from qdk_chemistry.data import LatticeGraph
+
+    _HAS_LATTICE = True
+except ImportError:  # pragma: no cover - LatticeGraph should be available
+    _HAS_LATTICE = False
+
+
+# ----------------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------------
+
+_PAULI = {
+    "I": np.eye(2, dtype=complex),
+    "X": np.array([[0, 1], [1, 0]], dtype=complex),
+    "Y": np.array([[0, -1j], [1j, 0]], dtype=complex),
+    "Z": np.array([[1, 0], [0, -1]], dtype=complex),
+}
+
+
+def _pauli_matrix(label: str) -> np.ndarray:
+    """Dense matrix of a little-endian Pauli label (leftmost char = highest qubit)."""
+    matrix = np.array([[1]], dtype=complex)
+    for char in label:
+        matrix = np.kron(matrix, _PAULI[char])
+    return matrix
+
+
+def _container_unitary(container: PauliProductFormulaContainer) -> np.ndarray:
+    r"""Reconstruct the dense unitary of a :class:`PauliProductFormulaContainer`.
+
+    Follows the same convention as downstream consumers (``PauliSequenceMapper``)
+    and the Trotter tests: ``step_terms[0]`` is applied *first* (rightmost in the
+    matrix product), and the single-step product is repeated ``step_reps`` times.
+    """
+    dim = 2**container.num_qubits
+    step = np.eye(dim, dtype=complex)
+    for term in container.step_terms:
+        label = ["I"] * container.num_qubits
+        for qubit, pauli in term.pauli_term.items():
+            label[container.num_qubits - 1 - qubit] = pauli
+        step = scipy.linalg.expm(-1j * term.angle * _pauli_matrix("".join(label))) @ step
+    return np.linalg.matrix_power(step, container.step_reps)
+
+
+def _terms_to_label(terms: dict[int, str], num_qubits: int) -> str:
+    """Convert a ``{qubit: axis}`` mapping to a little-endian Pauli label."""
+    chars = ["I"] * num_qubits
+    for qubit, axis in terms.items():
+        chars[num_qubits - 1 - qubit] = axis
+    return "".join(chars)
+
+
+def _heisenberg_chain_4() -> QubitHamiltonian:
+    """4-site open Heisenberg chain with J=1 (XX + YY + ZZ on each bond)."""
+    if _HAS_LATTICE:
+        graph = LatticeGraph.chain(4, periodic=False)
+        return create_heisenberg_hamiltonian(graph, jx=1.0, jy=1.0, jz=1.0, include_term_groups=False)
+    # Fallback: build the chain directly.
+    labels: list[str] = []
+    for bond in range(3):
+        for axis in "XYZ":
+            mapping = {bond: axis, bond + 1: axis}
+            labels.append(_terms_to_label(mapping, 4))
+    return QubitHamiltonian(pauli_strings=labels, coefficients=np.ones(len(labels)))
+
+
+def _h2_sto3g_jw() -> QubitHamiltonian:
+    """Canonical H2/STO-3G qubit Hamiltonian (Jordan-Wigner, 4 qubits, R=0.7414 A).
+
+    Coefficients are the widely reproduced OpenFermion values; the absolute
+    constant is irrelevant to the tests, which compute the reference ground-state
+    energy from the operator itself.
+    """
+    # (coefficient, {qubit_index: pauli_axis})
+    raw: list[tuple[float, dict[int, str]]] = [
+        (-0.09706626816762854, {}),
+        (0.17141282644776915, {0: "Z"}),
+        (0.17141282644776912, {1: "Z"}),
+        (-0.22343153690813466, {2: "Z"}),
+        (-0.22343153690813466, {3: "Z"}),
+        (0.16868898170361207, {0: "Z", 1: "Z"}),
+        (0.12062523483390411, {0: "Z", 2: "Z"}),
+        (0.16592785033770345, {0: "Z", 3: "Z"}),
+        (0.16592785033770345, {1: "Z", 2: "Z"}),
+        (0.12062523483390411, {1: "Z", 3: "Z"}),
+        (0.17441287612261588, {2: "Z", 3: "Z"}),
+        (-0.04530261550379932, {0: "X", 1: "X", 2: "Y", 3: "Y"}),
+        (0.04530261550379932, {0: "X", 1: "Y", 2: "Y", 3: "X"}),
+        (0.04530261550379932, {0: "Y", 1: "X", 2: "X", 3: "Y"}),
+        (-0.04530261550379932, {0: "Y", 1: "Y", 2: "X", 3: "X"}),
+    ]
+    labels = [_terms_to_label(mapping, 4) for _, mapping in raw]
+    coeffs = np.array([c for c, _ in raw])
+    return QubitHamiltonian(pauli_strings=labels, coefficients=coeffs, encoding="jordan-wigner")
+
+
+# ----------------------------------------------------------------------------------
+# Basic builder behaviour
+# ----------------------------------------------------------------------------------
+
+
+class TestZassenhausBuilder:
+    """Smoke tests for the Zassenhaus builder."""
+
+    def test_name_and_type(self):
+        """The builder advertises the expected algorithm name and type."""
+        builder = Zassenhaus()
+        assert builder.name() == "zassenhaus"
+        assert builder.type_name() == "hamiltonian_unitary_builder"
+
+    def test_registered_in_factory(self):
+        """The builder is discoverable through the standard registry mechanism."""
+        assert "zassenhaus" in registry.available("hamiltonian_unitary_builder")
+        builder = registry.create("hamiltonian_unitary_builder", "zassenhaus", order=3, time=0.5)
+        assert isinstance(builder, Zassenhaus)
+        assert builder.settings().get("order") == 3
+
+    def test_returns_pauli_product_formula_container(self):
+        """Running the builder yields a PauliProductFormulaContainer of the right shape."""
+        hamiltonian = QubitHamiltonian(pauli_strings=["XI", "ZZ"], coefficients=np.array([1.0, 0.5]))
+        builder = Zassenhaus(order=2, time=0.3)
+        unitary = builder.run(hamiltonian)
+
+        assert isinstance(unitary, UnitaryRepresentation)
+        container = unitary.get_container()
+        assert isinstance(container, PauliProductFormulaContainer)
+        assert container.num_qubits == 2
+        assert container.step_reps == 1
+        assert len(container.step_terms) >= 2  # first-order terms plus corrections
+
+    def test_num_divisions_sets_step_reps(self):
+        """``num_divisions`` controls the repetition count, like the Trotter builder."""
+        hamiltonian = QubitHamiltonian(pauli_strings=["XI", "ZZ"], coefficients=np.array([1.0, 0.5]))
+        builder = Zassenhaus(order=2, time=0.4, num_divisions=5)
+        container = builder.run(hamiltonian).get_container()
+        assert container.step_reps == 5
+
+    def test_non_hermitian_raises(self):
+        """A non-Hermitian Hamiltonian is rejected."""
+        hamiltonian = QubitHamiltonian(pauli_strings=["XI"], coefficients=np.array([1.0 + 1.0j]))
+        builder = Zassenhaus(order=2, time=0.1)
+        with pytest.raises(ValueError, match="Non-Hermitian"):
+            builder.run(hamiltonian)
+
+    def test_invalid_order_raises(self):
+        """Expansion orders below 1 are rejected."""
+        hamiltonian = QubitHamiltonian(pauli_strings=["XI"], coefficients=np.array([1.0]))
+        builder = Zassenhaus(order=0, time=0.1)
+        with pytest.raises(ValueError, match="order must be >= 1"):
+            builder.run(hamiltonian)
+
+    def test_first_order_is_bare_trotter_product(self):
+        """At order 1 the Zassenhaus product is the bare first-order Trotter product.
+
+        The product *ordering* differs (Zassenhaus emits its factors reversed), but
+        for a first-order product only the multiset of single-term exponentials
+        matters; it must coincide with the Trotter builder's.
+        """
+        hamiltonian = QubitHamiltonian(pauli_strings=["XI", "ZZ", "IZ"], coefficients=np.array([1.0, 0.5, 0.25]))
+        time = 0.2
+
+        zassenhaus = Zassenhaus(order=1, time=time).run(hamiltonian).get_container()
+        trotter = registry.create("hamiltonian_unitary_builder", "trotter", order=1, time=time, num_divisions=1)
+        trotter_container = trotter.run(hamiltonian).get_container()
+
+        def _multiset(container: PauliProductFormulaContainer) -> set:
+            return {
+                (frozenset(term.pauli_term.items()), round(term.angle, 12)) for term in container.step_terms
+            }
+
+        assert len(zassenhaus.step_terms) == len(hamiltonian.pauli_strings)
+        assert _multiset(zassenhaus) == _multiset(trotter_container)
+
+
+# ----------------------------------------------------------------------------------
+# Error-scaling acceptance criterion
+# ----------------------------------------------------------------------------------
+
+
+def _fit_error_slope(hamiltonian: QubitHamiltonian, order: int) -> float:
+    r"""Fit the slope of ``log || U_exact - U_builder ||`` vs ``log t``.
+
+    Evaluated at a single time division over ``t in [1e-3, 1e-1]``; for a correct
+    order-``p`` expansion the slope equals ``p + 1``.
+
+    For high orders on small-coefficient Hamiltonians the error at the smallest
+    times reaches the floating-point floor (``~1e-15``), where the log-log slope is
+    meaningless.  Such points are dropped before the fit; the remaining points still
+    lie within the specified ``[1e-3, 1e-1]`` window.
+    """
+    hamiltonian_matrix = hamiltonian.to_matrix()
+    times = np.logspace(-3, -1, 12)
+    errors = []
+    for time in times:
+        builder = Zassenhaus(order=order, time=float(time), num_divisions=1)
+        container = builder.run(hamiltonian).get_container()
+        u_builder = _container_unitary(container)
+        u_exact = scipy.linalg.expm(-1j * hamiltonian_matrix * time)
+        errors.append(np.linalg.norm(u_exact - u_builder, 2))
+    errors = np.asarray(errors)
+
+    mask = errors > 1e-10
+    if int(mask.sum()) < 4:
+        # Too few points above the floor: keep the six largest-t points.
+        mask = np.zeros_like(errors, dtype=bool)
+        mask[-6:] = True
+
+    slope, _ = np.polyfit(np.log(times[mask]), np.log(errors[mask]), 1)
+    return float(slope)
+
+
+@pytest.mark.parametrize("order", [2, 3, 4])
+def test_error_scaling_heisenberg_chain(order: int):
+    """4-site Heisenberg chain: operator-norm error scales as O(t^(p+1))."""
+    slope = _fit_error_slope(_heisenberg_chain_4(), order)
+    assert abs(slope - (order + 1)) < 0.1
+
+
+@pytest.mark.parametrize("order", [2, 3, 4])
+def test_error_scaling_h2_sto3g(order: int):
+    """H2/STO-3G (Jordan-Wigner): operator-norm error scales as O(t^(p+1))."""
+    slope = _fit_error_slope(_h2_sto3g_jw(), order)
+    assert abs(slope - (order + 1)) < 0.1
+
+
+def test_factor_count_grows_with_order():
+    """Higher expansion orders append additional correction factors."""
+    terms = [("XI", 1.0), ("ZZ", 0.5), ("IY", 0.25)]
+    counts = [len(zassenhaus_factors(terms, order)) for order in (1, 2, 3, 4)]
+    assert counts == sorted(counts)
+    assert counts[0] == len(terms)  # order 1 == bare Trotter product
+    assert counts[-1] > counts[0]
+
+
+# ----------------------------------------------------------------------------------
+# Phase-estimation consumability
+# ----------------------------------------------------------------------------------
+
+# The phase-estimation stack relies on the Q#/QDK simulator utilities, mirrored
+# from ``test_phase_estimation_iterative.py``.
+from qdk_chemistry.data import AlgorithmRef, Circuit  # noqa: E402
+from qdk_chemistry.data.circuit import QsharpFactoryData  # noqa: E402
+from qdk_chemistry.algorithms.phase_estimation.iterative_phase_estimation import (  # noqa: E402
+    IterativePhaseEstimation,
+)
+from qdk_chemistry.utils.phase import energy_from_phase  # noqa: E402
+from qdk_chemistry.utils.qsharp import QSHARP_UTILS  # noqa: E402
+
+_SEED = 42
+
+
+def _resolve_energy(phase_fraction: float, evolution_time: float, expected_energy: float) -> float:
+    """Resolve QPE phase periodicity by selecting the energy closest to ``expected_energy``."""
+    candidates = [phase_fraction % 1.0, (1.0 - phase_fraction) % 1.0]
+    energies = [energy_from_phase(c, evolution_time=evolution_time) for c in candidates]
+    index = int(np.argmin([abs(e - expected_energy) for e in energies]))
+    return energies[index]
+
+
+def _run_iterative_zassenhaus(
+    hamiltonian: QubitHamiltonian,
+    state_vector: np.ndarray,
+    *,
+    evolution_time: float,
+    num_bits: int,
+    order: int,
+    num_divisions: int,
+    shots_per_bit: int = 1,
+) -> float:
+    """Run iterative QPE using the Zassenhaus builder and return the raw phase fraction."""
+    num_qubits = int(np.log2(len(state_vector)))
+    state_prep_params = {
+        "rowMap": list(range(num_qubits - 1, -1, -1)),
+        "stateVector": np.asarray(state_vector, dtype=float).tolist(),
+        "expansionOps": [],
+        "numQubits": num_qubits,
+    }
+    qsharp_op = QSHARP_UTILS.StatePreparation.MakeStatePreparationOp(state_prep_params)
+    qsharp_factories = QsharpFactoryData(
+        program=QSHARP_UTILS.StatePreparation.MakeStatePreparationCircuit, parameter=state_prep_params
+    )
+
+    iqpe = IterativePhaseEstimation(num_bits=num_bits, shots_per_bit=shots_per_bit)
+    iqpe.settings().set("circuit_executor", AlgorithmRef("circuit_executor", "qdk_full_state_simulator", seed=_SEED))
+    iqpe.settings().set("circuit_mapper", AlgorithmRef("controlled_circuit_mapper", "pauli_sequence"))
+    iqpe.settings().set(
+        "unitary_builder",
+        AlgorithmRef(
+            "hamiltonian_unitary_builder",
+            "zassenhaus",
+            time=evolution_time,
+            order=order,
+            num_divisions=num_divisions,
+        ),
+    )
+
+    result = iqpe.run(
+        qubit_hamiltonian=hamiltonian,
+        state_preparation=Circuit(qsharp_factory=qsharp_factories, qsharp_op=qsharp_op),
+    )
+    return result.phase_fraction
+
+
+def test_phase_estimation_consumable():
+    """The builder is consumable by IterativePhaseEstimation end-to-end (toy 2-qubit case).
+
+    Uses the exact top eigenstate ``(|00> + |11>)/sqrt(2)`` of ``H = 0.25 XX + 0.5 ZZ``
+    (eigenvalue 0.75) so the recovered energy is deterministic.  Several divisions keep
+    the Zassenhaus unitary accurate at ``t = pi/2``.
+    """
+    hamiltonian = QubitHamiltonian(pauli_strings=["XX", "ZZ"], coefficients=np.array([0.25, 0.5]))
+    state_vector = np.array([1.0, 0.0, 0.0, 1.0]) / np.sqrt(2.0)
+    evolution_time = float(np.pi / 2.0)
+
+    phase_fraction = _run_iterative_zassenhaus(
+        hamiltonian,
+        state_vector,
+        evolution_time=evolution_time,
+        num_bits=4,
+        order=3,
+        num_divisions=20,
+        shots_per_bit=1,
+    )
+    resolved = _resolve_energy(phase_fraction, evolution_time, expected_energy=0.75)
+    assert abs(resolved - 0.75) < 1e-2
+
+
+@pytest.mark.slow
+def test_h2_ground_state_chemical_accuracy():
+    """Estimate the H2/STO-3G ground-state energy to chemical accuracy via QPE + Zassenhaus.
+
+    The exact ground eigenvector is used as the input state, so the result is
+    deterministic.  ``num_bits = 12`` gives an energy resolution of
+    ``2*pi / 2**12 ~ 1.5e-3`` (max rounding error ~7.7e-4 at ``t = 1``), and the
+    builder's product-formula error at the most-significant bit (power ``2**11``) is
+    ``~2**11 * t**(p+1) / N**p``; the high expansion ``order = 6`` makes this converge
+    quickly, so ``num_divisions = 16`` keeps it well below chemical accuracy while
+    keeping the circuit depth tractable.  This test is still compute-heavy (hence
+    ``slow``); the bit/division/order counts may need adjustment on different simulators.
+    """
+    hamiltonian = _h2_sto3g_jw()
+    matrix = hamiltonian.to_matrix()
+    eigenvalues, eigenvectors = np.linalg.eigh(matrix)
+    ground_energy = float(eigenvalues[0])
+    ground_state = np.real(eigenvectors[:, 0])
+
+    evolution_time = 1.0
+    phase_fraction = _run_iterative_zassenhaus(
+        hamiltonian,
+        ground_state,
+        evolution_time=evolution_time,
+        num_bits=12,
+        order=6,
+        num_divisions=16,
+        shots_per_bit=1,
+    )
+    resolved = _resolve_energy(phase_fraction, evolution_time, expected_energy=ground_energy)
+    assert abs(resolved - ground_energy) < 1.6e-3

--- a/python/tests/test_time_evolution_zassenhaus.py
+++ b/python/tests/test_time_evolution_zassenhaus.py
@@ -7,16 +7,18 @@
 
 from __future__ import annotations
 
+import functools
+
 import numpy as np
 import pytest
 import scipy.linalg
 
-from qdk_chemistry.algorithms import registry
+from qdk_chemistry.algorithms import create, registry
 from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus import Zassenhaus
 from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus_expansion import (
     zassenhaus_factors,
 )
-from qdk_chemistry.data import QubitHamiltonian, UnitaryRepresentation
+from qdk_chemistry.data import MajoranaMapping, QubitHamiltonian, Structure, UnitaryRepresentation
 from qdk_chemistry.data.unitary_representation.containers.pauli_product_formula import (
     PauliProductFormulaContainer,
 )
@@ -89,34 +91,24 @@ def _heisenberg_chain_4() -> QubitHamiltonian:
     return QubitHamiltonian(pauli_strings=labels, coefficients=np.ones(len(labels)))
 
 
+@functools.lru_cache(maxsize=1)
 def _h2_sto3g_jw() -> QubitHamiltonian:
-    """Canonical H2/STO-3G qubit Hamiltonian (Jordan-Wigner, 4 qubits, R=0.7414 A).
+    """H2/STO-3G qubit Hamiltonian (Jordan-Wigner, 4 qubits) built via the QDK pipeline.
 
-    Coefficients are the widely reproduced OpenFermion values; the absolute
-    constant is irrelevant to the tests, which compute the reference ground-state
-    energy from the operator itself.
+    Produced the same way the rest of the library does (SCF -> Hamiltonian constructor
+    -> Jordan-Wigner qubit mapping), rather than hardcoding coefficients, at the H2
+    equilibrium bond length (1.4 Bohr ~ 0.74 A; ``Structure`` coordinates are in Bohr).
+    Cached so the SCF runs only once across the test module.
     """
-    # (coefficient, {qubit_index: pauli_axis})
-    raw: list[tuple[float, dict[int, str]]] = [
-        (-0.09706626816762854, {}),
-        (0.17141282644776915, {0: "Z"}),
-        (0.17141282644776912, {1: "Z"}),
-        (-0.22343153690813466, {2: "Z"}),
-        (-0.22343153690813466, {3: "Z"}),
-        (0.16868898170361207, {0: "Z", 1: "Z"}),
-        (0.12062523483390411, {0: "Z", 2: "Z"}),
-        (0.16592785033770345, {0: "Z", 3: "Z"}),
-        (0.16592785033770345, {1: "Z", 2: "Z"}),
-        (0.12062523483390411, {1: "Z", 3: "Z"}),
-        (0.17441287612261588, {2: "Z", 3: "Z"}),
-        (-0.04530261550379932, {0: "X", 1: "X", 2: "Y", 3: "Y"}),
-        (0.04530261550379932, {0: "X", 1: "Y", 2: "Y", 3: "X"}),
-        (0.04530261550379932, {0: "Y", 1: "X", 2: "X", 3: "Y"}),
-        (-0.04530261550379932, {0: "Y", 1: "Y", 2: "X", 3: "X"}),
-    ]
-    labels = [_terms_to_label(mapping, 4) for _, mapping in raw]
-    coeffs = np.array([c for c, _ in raw])
-    return QubitHamiltonian(pauli_strings=labels, coefficients=coeffs, encoding="jordan-wigner")
+    coords = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4]])
+    structure = Structure(coords, symbols=["H", "H"])
+
+    scf_solver = create("scf_solver")
+    _, wavefunction = scf_solver.run(structure, charge=0, spin_multiplicity=1, basis_or_guess="sto-3g")
+
+    hamiltonian = create("hamiltonian_constructor").run(wavefunction.get_orbitals())
+    n_spin_orbitals = 2 * hamiltonian.get_orbitals().get_num_molecular_orbitals()
+    return create("qubit_mapper").run(hamiltonian, MajoranaMapping.jordan_wigner(n_spin_orbitals))
 
 
 # ----------------------------------------------------------------------------------
@@ -256,6 +248,39 @@ def test_factor_count_grows_with_order():
     assert counts == sorted(counts)
     assert counts[0] == len(terms)  # order 1 == bare Trotter product
     assert counts[-1] > counts[0]
+
+
+def test_target_accuracy_increases_divisions():
+    """A tighter ``target_accuracy`` raises the automatic time-division count."""
+    hamiltonian = QubitHamiltonian(pauli_strings=["XI", "ZZ", "IY"], coefficients=np.array([1.0, 0.6, 0.4]))
+
+    baseline = Zassenhaus(order=3, time=1.0).run(hamiltonian).get_container().step_reps
+    loose = Zassenhaus(order=3, time=1.0, target_accuracy=1e-2).run(hamiltonian).get_container().step_reps
+    tight = Zassenhaus(order=3, time=1.0, target_accuracy=1e-4).run(hamiltonian).get_container().step_reps
+
+    assert baseline == 1  # target_accuracy disabled by default
+    assert tight > loose > baseline
+
+
+def test_term_partition_is_consumed():
+    """A populated ``term_partition`` orders the seed terms by group; result stays O(t^(p+1))."""
+    hamiltonian = create_heisenberg_hamiltonian(
+        LatticeGraph.chain(4, periodic=False), jx=1.0, jy=1.0, jz=1.0, include_term_groups=True
+    )
+    assert hamiltonian.term_partition is not None
+
+    # _ordered_terms must reproduce the partition's grouped index order.
+    ordered = Zassenhaus._ordered_terms(hamiltonian, weight_threshold=1e-12)
+    expected_indices: list[int] = []
+    for group in hamiltonian.term_partition.groups:
+        for layer in group:  # LayeredPartition: group -> layers -> indices
+            expected_indices.extend(layer)
+    expected_labels = [hamiltonian.pauli_strings[i] for i in expected_indices]
+    assert [label for label, _ in ordered] == expected_labels
+
+    # Consuming the partition must not break the error scaling.
+    slope = _fit_error_slope(hamiltonian, order=3)
+    assert abs(slope - 4) < 0.1
 
 
 # ----------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #483 

* Register a new factory Zassenhaus() under keyword "zassenhaus"
*  The error scaling is tested in `test_error_scaling_heisenberg_chain` and `test_error_scaling_h2_sto3g`. See more discussion below.
* Accuracy whe running in `PhaseEstimation` is tested in `test_h2_ground_state_chemical_accuracy` in `test_time_evolution_zassenhaus.py`. Heavy test marked with `@pytest.mark.slow`. See more discussion below.
* tests are under python/tests/test_time_evolution_zassenhaus.py
* added docs in hamiltonian_unitary_builder.rst under "Available implementations"

## Error scaling
 
The error scaling is tested

Operator-norm error `‖U_exact − U_builder‖` vs evolution time `t` (single time division), for the two acceptance Hamiltonians — the 4-site open Heisenberg chain (J=1) and H2/STO-3G (Jordan–Wigner) — at expansion orders p = 2, 3, 4 (solid, with the fitted slope in the legend). Each grey dashed line is the ideal `O(t^(p+1))` reference (offset ×6 for visibility); every measured curve runs
parallel to its reference, i.e. the error decreases as `t^(p+1)` exactly as expected. The fitted slopes match `p+1` to within ±0.005.

For H2 at p=4 the smallest-`t` points flatten onto the red line: that is the double-precision floor (~2.2e-16), where the error is below what 64-bit `expm` can resolve — those points (drawn hollow) are excluded from the slope fit.

<img width="1560" height="650" alt="_zassenhaus_error_scaling" src="https://github.com/user-attachments/assets/d7d9d0f0-b863-4647-8a56-597f1c2a3a8b" />


**Underlying operator-norm error ‖U_exact − U_builder‖ vs t for each p**

4-site Heisenberg (J=1)
| t | p=2 | p=3 | p=4 |
|---|---|---|---|
| 1.0e-03 | 1.40e-08 | 2.82e-11 | 8.13e-14 |
| 3.2e-03 | 4.43e-07 | 2.82e-09 | 2.57e-11 |
| 1.0e-02 | 1.40e-05 | 2.82e-07 | 8.13e-09 |
| 3.2e-02 | 4.42e-04 | 2.83e-05 | 2.57e-06 |
| 1.0e-01 | 1.39e-02 | 2.86e-03 | 8.28e-04 |

H2/STO-3G (JW)
| t | p=2 | p=3 | p=4 |
|---|---|---|---|
| 1.0e-03 | 8.29e-11 | 3.47e-14 | 6.66e-16 † |
| 3.2e-03 | 2.62e-09 | 3.44e-12 | 5.01e-15 † |
| 1.0e-02 | 8.29e-08 | 3.44e-10 | 1.58e-12 |
| 3.2e-02 | 2.62e-06 | 3.44e-08 | 5.00e-10 |
| 1.0e-01 | 8.28e-05 | 3.44e-06 | 1.58e-07 |

† double-precision floor (~2.2e-16); excluded from the slope fit (`< 1e-13`).

## Phase-estimation consumability (chemical accuracy)

`test_h2_ground_state_chemical_accuracy` runs the existing IterativePhaseEstimation harness (Q# full-state simulator + `pauli_sequence` controlled mapper) with the new `"zassenhaus"` builder as the only changed component, and recovers the FCI ground-state energy of H2/STO-3G (Jordan–Wigner):

    estimated = -1.138214 Ha | exact (FCI) = -1.137284 Ha | |error| = 9.30e-04 Ha

i.e. within chemical accuracy (1.6e-3 Ha). Marked `@pytest.mark.slow` (a test on 12-bit QPE uses ~20 GB of memory and takes ~30 min). 
The fast `test_phase_estimation_consumable` covers the same end-to-end path on a 2-qubit system.

Disclamer: Used Claude Code