### PR TITLE
Add Zassenhaus recursion HamiltonianUnitaryBuilder

### DIFF
--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -611,3 +611,24 @@
     year={1992},
     doi={10.1016/0375-9601(92)90335-J}
 }
+@article{Wilcox1967,
+    title={Exponential Operators and Parameter Differentiation in Quantum Physics},
+    author={R. M. Wilcox},
+    journal={Journal of Mathematical Physics},
+    volume={8},
+    number={4},
+    pages={962--982},
+    year={1967},
+    doi={10.1063/1.1705306}
+}
+@article{Casas2012,
+    title={Efficient computation of the {Zassenhaus} formula},
+    author={Fernando Casas and Ander Murua and Mladen Nadinic},
+    journal={Computer Physics Communications},
+    volume={183},
+    number={11},
+    pages={2386--2391},
+    year={2012},
+    doi={10.1016/j.cpc.2012.06.006},
+    url={https://arxiv.org/abs/1204.0389}
+}

--- a/docs/source/user/comprehensive/algorithms/hamiltonian_unitary_builder.rst
+++ b/docs/source/user/comprehensive/algorithms/hamiltonian_unitary_builder.rst
@@ -10,7 +10,7 @@ Overview
 Building unitary from Hamiltonian — such as the Hamiltonian simulation unitary :math:`U(t) = e^{-iHt}` or block encoding unitary :math:`U = \frac{H}{\|H\|}` — is a central subroutine in many quantum algorithms.
 The :class:`~qdk_chemistry.algorithms.HamiltonianUnitaryBuilder` provides a unified interface for methods that construct this operator from a :class:`~qdk_chemistry.data.QubitHamiltonian`.
 
-QDK/Chemistry currently provides two product-formula methods for this task: Trotter-Suzuki and the Zassenhaus recursion.
+QDK/Chemistry currently provides two product-formula methods for this task: Trotter-Suzuki and the Zassenhaus expansion.
 Both decompose :math:`e^{-iHt}` into a sequence of elementary Pauli rotations :math:`e^{-i\theta P}` that can be directly implemented as quantum gates, with controllable approximation error via the expansion order and number of time divisions :cite:`Suzuki1992,Casas2012`.
 The resulting :class:`~qdk_chemistry.data.UnitaryRepresentation` objects wrap a ``PauliProductFormulaContainer`` — a list of exponentiated Pauli terms with a repetition count.
 
@@ -144,7 +144,7 @@ When both ``num_divisions`` and ``target_accuracy`` are specified, the builder u
 
 .. _zassenhaus-builder:
 
-Zassenhaus recursion
+Zassenhaus expansion
 ~~~~~~~~~~~~~~~~~~~~~
 .. rubric:: Factory name: ``"zassenhaus"``
 
@@ -155,24 +155,28 @@ For two anti-Hermitian generators :math:`X = -i t A` and :math:`Y = -i t B`:
 
    e^{X + Y} = e^{X}\, e^{Y}\, e^{C_2}\, e^{C_3}\, e^{C_4}\cdots
 
-where the corrections are nested commutators :cite:`Casas2012`:
+where the lowest corrections are the nested commutators :cite:`Casas2012`
 
 .. math::
 
    C_2 &= -\tfrac{1}{2}[X, Y] \\
    C_3 &= \tfrac{1}{3}[Y, [X, Y]] + \tfrac{1}{6}[X, [X, Y]] \\
-   C_4 &= -\tfrac{1}{24}[X, [X, [X, Y]]] - \tfrac{1}{8}[Y, [X, [X, Y]]] - \tfrac{1}{8}[Y, [Y, [X, Y]]]
+   C_4 &= -\tfrac{1}{24}[X, [X, [X, Y]]] - \tfrac{1}{8}[Y, [X, [X, Y]]] - \tfrac{1}{8}[Y, [Y, [X, Y]]].
 
 Truncating after :math:`C_p` yields an operator-norm error of :math:`O(t^{p+1})` at a single time division.
 Unlike Trotter-Suzuki, where the commutator structure is absorbed into the step count, here it is cancelled directly :cite:`Childs2021` — an advantage when the dominant commutators are sparse (lattice models with limited geometric coupling, or chemistry Hamiltonians under term partitions with small inter-group commutators).
 
-To handle a Hamiltonian with more than two non-commuting parts, the builder first partitions :math:`H` into internally-commuting groups :math:`G_1, \ldots, G_K` (each :math:`e^{-i t G_i}` is then exact) and applies the expansion recursively:
+**Multi-operator form.** A Hamiltonian generally has more than two non-commuting parts, so the builder partitions :math:`H` into internally-commuting groups :math:`G_0, \ldots, G_{K-1}` (each :math:`e^{-i t G_i}` is then exact) and uses the multi-operator Zassenhaus formula directly,
 
 .. math::
 
-   Z_p(G_1, \ldots, G_K) = e^{-i t G_1}\; Z_p(G_2, \ldots, G_K)\; e^{C_2} \cdots e^{C_p}
+   e^{-i t H} = e^{X_0} \cdots e^{X_{K-1}}\; e^{C_2}\, e^{C_3} \cdots e^{C_p}, \qquad X_i = -i t G_i,
 
-with the corrections evaluated against the exact remaining block :math:`-i t (G_2 + \cdots + G_K)`.
+with a single genuine :math:`K`-operator exponent :math:`C_n` per degree (the two-operator formulae above are the :math:`K = 2` instances).
+The :math:`C_n` are **not hard-coded**: for the requested order they are generated once as exact rational coefficients of a free-Lie-algebra word series, then evaluated on the group operators through nested commutators (the Dynkin map) using the QDK-native ``commutator``.
+The expansion therefore extends to any order; orders **2-6** are validated.
+Each correction :math:`e^{C_n}` is in turn realised by a Trotter-Suzuki product of just-high-enough order, so its splitting error never dominates the :math:`O(t^{p+1})` truncation.
+
 Groups are taken from the Hamiltonian's :attr:`~qdk_chemistry.data.QubitHamiltonian.term_partition` when it is present and internally commuting; otherwise the builder groups terms greedily with the :ref:`commuting term grouper <algorithms-term-grouper>`.
 The output is a ``PauliProductFormulaContainer`` of the same shape as the :ref:`Trotter builder <trotter-builder>`, so it is consumable by downstream algorithms such as :doc:`PhaseEstimation <phase_estimation>` without changes.
 
@@ -187,10 +191,13 @@ The output is a ``PauliProductFormulaContainer`` of the same shape as the :ref:`
      - Description
    * - ``order``
      - int
-     - Zassenhaus expansion order :math:`p`. Supported values are 2, 3, and 4; order 1 (no commutator corrections) falls back to the first-order Trotter builder. Default is 2.
+     - Zassenhaus expansion order :math:`p` (supported values 2-6); order 1 (no commutator corrections) falls back to the first-order Trotter builder; order 0 selects the smallest order meeting ``target_accuracy`` automatically. Default is 2.
    * - ``num_divisions``
      - int
-     - Number of time divisions :math:`N`. The Zassenhaus product approximates :math:`e^{-iHt/N}` and is repeated :math:`N` times. Default is 1.
+     - Number of time divisions :math:`N` (:math:`\ge 1`). The Zassenhaus product approximates :math:`e^{-iHt/N}` and is repeated :math:`N` times. Default is 1.
+   * - ``target_accuracy``
+     - float
+     - Target operator-norm accuracy. When positive, :math:`N` is raised automatically so the leading error :math:`\lVert C_{p+1}\rVert\, t^{p+1}/N^{p}` falls below it (the larger of this estimate and ``num_divisions`` is used). ``0.0`` (default) disables it.
    * - ``weight_threshold``
      - float
      - Coefficient threshold below which Pauli terms are discarded. Default is 1e-12.

--- a/docs/source/user/comprehensive/algorithms/hamiltonian_unitary_builder.rst
+++ b/docs/source/user/comprehensive/algorithms/hamiltonian_unitary_builder.rst
@@ -191,7 +191,7 @@ The output is a ``PauliProductFormulaContainer`` of the same shape as the :ref:`
      - Description
    * - ``order``
      - int
-     - Zassenhaus expansion order :math:`p` (supported values 2-6); order 1 (no commutator corrections) falls back to the first-order Trotter builder; order 0 selects the smallest order meeting ``target_accuracy`` automatically. Default is 2.
+     - Zassenhaus expansion order :math:`p` (:math:`\ge 2`; validated for 2-6); order 1 (no commutator corrections) falls back to the first-order Trotter builder. Default is 2.
    * - ``num_divisions``
      - int
      - Number of time divisions :math:`N` (:math:`\ge 1`). The Zassenhaus product approximates :math:`e^{-iHt/N}` and is repeated :math:`N` times. Default is 1.

--- a/docs/source/user/comprehensive/algorithms/hamiltonian_unitary_builder.rst
+++ b/docs/source/user/comprehensive/algorithms/hamiltonian_unitary_builder.rst
@@ -10,8 +10,8 @@ Overview
 Building unitary from Hamiltonian — such as the Hamiltonian simulation unitary :math:`U(t) = e^{-iHt}` or block encoding unitary :math:`U = \frac{H}{\|H\|}` — is a central subroutine in many quantum algorithms.
 The :class:`~qdk_chemistry.algorithms.HamiltonianUnitaryBuilder` provides a unified interface for methods that construct this operator from a :class:`~qdk_chemistry.data.QubitHamiltonian`.
 
-QDK/Chemistry currently provides Trotter-Suzuki product formulas for this task.
-These decompose :math:`e^{-iHt}` into a sequence of elementary Pauli rotations :math:`e^{-i\theta P}` that can be directly implemented as quantum gates, with controllable approximation error via the Trotter order and number of time divisions :cite:`Suzuki1992`.
+QDK/Chemistry currently provides two product-formula methods for this task: Trotter-Suzuki and the Zassenhaus recursion.
+Both decompose :math:`e^{-iHt}` into a sequence of elementary Pauli rotations :math:`e^{-i\theta P}` that can be directly implemented as quantum gates, with controllable approximation error via the expansion order and number of time divisions :cite:`Suzuki1992,Casas2012`.
 The resulting :class:`~qdk_chemistry.data.UnitaryRepresentation` objects wrap a ``PauliProductFormulaContainer`` — a list of exponentiated Pauli terms with a repetition count.
 
 
@@ -138,6 +138,59 @@ When both ``num_divisions`` and ``target_accuracy`` are specified, the builder u
    * - ``error_bound``
      - str
      - Error bound strategy: ``"commutator"`` (default, tighter) or ``"naive"`` (simpler).
+   * - ``weight_threshold``
+     - float
+     - Coefficient threshold below which Pauli terms are discarded. Default is 1e-12.
+
+.. _zassenhaus-builder:
+
+Zassenhaus recursion
+~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Factory name: ``"zassenhaus"``
+
+The Zassenhaus expansion is the dual of the Baker-Campbell-Hausdorff formula :cite:`Wilcox1967`: it factorises a single exponential of a sum into an ordered product of exponentials in which low-order nested-commutator corrections appear as **explicit** factors, rather than being suppressed implicitly by the step count.
+For two anti-Hermitian generators :math:`X = -i t A` and :math:`Y = -i t B`:
+
+.. math::
+
+   e^{X + Y} = e^{X}\, e^{Y}\, e^{C_2}\, e^{C_3}\, e^{C_4}\cdots
+
+where the corrections are nested commutators :cite:`Casas2012`:
+
+.. math::
+
+   C_2 &= -\tfrac{1}{2}[X, Y] \\
+   C_3 &= \tfrac{1}{3}[Y, [X, Y]] + \tfrac{1}{6}[X, [X, Y]] \\
+   C_4 &= -\tfrac{1}{24}[X, [X, [X, Y]]] - \tfrac{1}{8}[Y, [X, [X, Y]]] - \tfrac{1}{8}[Y, [Y, [X, Y]]]
+
+Truncating after :math:`C_p` yields an operator-norm error of :math:`O(t^{p+1})` at a single time division.
+Unlike Trotter-Suzuki, where the commutator structure is absorbed into the step count, here it is cancelled directly :cite:`Childs2021` — an advantage when the dominant commutators are sparse (lattice models with limited geometric coupling, or chemistry Hamiltonians under term partitions with small inter-group commutators).
+
+To handle a Hamiltonian with more than two non-commuting parts, the builder first partitions :math:`H` into internally-commuting groups :math:`G_1, \ldots, G_K` (each :math:`e^{-i t G_i}` is then exact) and applies the expansion recursively:
+
+.. math::
+
+   Z_p(G_1, \ldots, G_K) = e^{-i t G_1}\; Z_p(G_2, \ldots, G_K)\; e^{C_2} \cdots e^{C_p}
+
+with the corrections evaluated against the exact remaining block :math:`-i t (G_2 + \cdots + G_K)`.
+Groups are taken from the Hamiltonian's :attr:`~qdk_chemistry.data.QubitHamiltonian.term_partition` when it is present and internally commuting; otherwise the builder groups terms greedily with the :ref:`commuting term grouper <algorithms-term-grouper>`.
+The output is a ``PauliProductFormulaContainer`` of the same shape as the :ref:`Trotter builder <trotter-builder>`, so it is consumable by downstream algorithms such as :doc:`PhaseEstimation <phase_estimation>` without changes.
+
+.. rubric:: Settings
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Setting
+     - Type
+     - Description
+   * - ``order``
+     - int
+     - Zassenhaus expansion order :math:`p`. Supported values are 2, 3, and 4; order 1 (no commutator corrections) falls back to the first-order Trotter builder. Default is 2.
+   * - ``num_divisions``
+     - int
+     - Number of time divisions :math:`N`. The Zassenhaus product approximates :math:`e^{-iHt/N}` and is repeated :math:`N` times. Default is 1.
    * - ``weight_threshold``
      - float
      - Coefficient threshold below which Pauli terms are discarded. Default is 1e-12.

--- a/docs/source/user/comprehensive/algorithms/hamiltonian_unitary_builder.rst
+++ b/docs/source/user/comprehensive/algorithms/hamiltonian_unitary_builder.rst
@@ -174,7 +174,7 @@ Unlike Trotter-Suzuki, where the commutator structure is absorbed into the step 
 
 with a single genuine :math:`K`-operator exponent :math:`C_n` per degree (the two-operator formulae above are the :math:`K = 2` instances).
 The :math:`C_n` are **not hard-coded**: for the requested order they are generated once as exact rational coefficients of a free-Lie-algebra word series, then evaluated on the group operators through nested commutators (the Dynkin map) using the QDK-native ``commutator``.
-The expansion therefore extends to any order; orders **2-6** are validated.
+The expansion therefore extends to any order; orders **2-4** are covered by the test suite.
 Each correction :math:`e^{C_n}` is in turn realised by a Trotter-Suzuki product of just-high-enough order, so its splitting error never dominates the :math:`O(t^{p+1})` truncation.
 
 Groups are taken from the Hamiltonian's :attr:`~qdk_chemistry.data.QubitHamiltonian.term_partition` when it is present and internally commuting; otherwise the builder groups terms greedily with the :ref:`commuting term grouper <algorithms-term-grouper>`.
@@ -191,7 +191,7 @@ The output is a ``PauliProductFormulaContainer`` of the same shape as the :ref:`
      - Description
    * - ``order``
      - int
-     - Zassenhaus expansion order :math:`p` (:math:`\ge 2`; validated for 2-6); order 1 (no commutator corrections) falls back to the first-order Trotter builder. Default is 2.
+     - Zassenhaus expansion order :math:`p` (:math:`\ge 2`; tested for 2-4); order 1 (no commutator corrections) falls back to the first-order Trotter builder. Default is 2.
    * - ``num_divisions``
      - int
      - Number of time divisions :math:`N` (:math:`\ge 1`). The Zassenhaus product approximates :math:`e^{-iHt/N}` and is repeated :math:`N` times. Default is 1.

--- a/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
+++ b/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
@@ -1,0 +1,414 @@
+r"""QDK/Chemistry implementation of the Zassenhaus product-formula Builder.
+
+The Zassenhaus formula is the dual of Baker-Campbell-Hausdorff: it expands a
+single exponential of a sum into an ordered product of exponentials in which
+low-order nested-commutator corrections appear as *explicit* factors, rather
+than being controlled implicitly by a step count (as in Trotter-Suzuki):
+
+    exp(X + Y) = exp(X) exp(Y) exp(C2) exp(C3) exp(C4) ...
+
+with, in terms of X = -i t A and Y = -i t B (A, B Hermitian Hamiltonian groups),
+
+    C2 = -1/2 [X, Y]
+    C3 =  1/3 [Y, [X, Y]] + 1/6 [X, [X, Y]]
+    C4 = -1/24 [X, [X, [X, Y]]] - 1/8 [Y, [X, [X, Y]]] - 1/8 [Y, [Y, [X, Y]]]
+
+Truncating after C_p yields an operator-norm error of O(t^{p+1}).
+
+References:
+    Wilcox, R. M. "Exponential operators and parameter differentiation in
+    quantum physics." J. Math. Phys. 8, 962 (1967).
+
+    Casas, F., Murua, A., Nadinic, M. "Efficient computation of the Zassenhaus
+    formula." Comput. Phys. Commun. 183, 2386 (2012). arXiv:1204.0389.
+
+    Childs, A. M., et al. "Theory of Trotter Error with Commutator Scaling."
+    Phys. Rev. X 11, 011020 (2021). arXiv:1912.08854.
+
+"""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import numpy as np
+
+from qdk_chemistry.algorithms.hamiltonian_unitary_builder.base import TimeEvolutionBuilder, TimeEvolutionSettings
+from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.trotter import Trotter
+from qdk_chemistry.data import (
+    FlatPartition,
+    LayeredPartition,
+    QubitHamiltonian,
+    TermPartition,
+    UnitaryRepresentation,
+)
+from qdk_chemistry.data.unitary_representation.containers.pauli_product_formula import (
+    ExponentiatedPauliTerm,
+    PauliProductFormulaContainer,
+)
+from qdk_chemistry.utils import Logger
+from qdk_chemistry.utils.pauli_commutation import commutator, do_pauli_labels_commute
+
+__all__: list[str] = ["Zassenhaus", "ZassenhausSettings"]
+
+# Supported expansion orders (matches acceptance criteria p in {2, 3, 4}).
+_MIN_ORDER = 2
+_MAX_ORDER = 4
+
+
+class ZassenhausSettings(TimeEvolutionSettings):
+    """Settings for the Zassenhaus product-formula builder."""
+
+    def __init__(self):
+        """Initialize ZassenhausSettings with default values.
+
+        Attributes:
+            order: Expansion order p; corrections C_2..C_p are included so the
+                truncation error scales as O(t^{p+1}). Supported: 2, 3, 4.
+                Order 1 (no corrections) falls back to the first-order Trotter builder.
+            num_divisions: Number of time divisions N. The full Zassenhaus
+                product approximates exp(-iH t/N) and is repeated N times.
+            weight_threshold: Absolute threshold for filtering small coefficients.
+
+        """
+        super().__init__()
+        self._set_default("order", "int", 2, "The Zassenhaus expansion order p (2, 3, or 4; 1 falls back to Trotter).")
+        self._set_default("num_divisions", "int", 1, "Number of time divisions N (>= 1).")
+        self._set_default(
+            "weight_threshold", "float", 1e-12, "The absolute threshold for filtering small coefficients."
+        )
+
+
+class Zassenhaus(TimeEvolutionBuilder):
+    """Zassenhaus product-formula time-evolution builder.
+
+    Note:
+        Unlike the Trotter builder, automatic step-count estimation from a
+        ``target_accuracy`` (Zassenhaus error scales as
+        ``||C_{p+1}|| t^{p+1} / N^p``) is not yet provided; ``num_divisions``
+        is set explicitly (default 1). Such an estimator is left as future work.
+
+        Remaining gate-count optimisations are also left as future work:
+        ordering the recursion groups, exploiting disjoint-support (layer)
+        parallelism instead of flattening layers, and merging redundant terms
+        at division / Suzuki-copy boundaries.
+
+    """
+
+    def __init__(
+        self,
+        order: int = 2,
+        *,
+        time: float = 0.0,
+        num_divisions: int = 1,
+        weight_threshold: float = 1e-12,
+        power: int = 1,
+        power_strategy: str = "repeat",
+    ):
+        r"""Initialize the Zassenhaus builder.
+
+        Args:
+            order: Expansion order p in {2, 3, 4}; order 1 falls back to first-order Trotter. Defaults to 2.
+            time: The evolution time. Defaults to 0.0.
+            num_divisions: Number of time divisions N (>= 1). Defaults to 1.
+            weight_threshold: Threshold for filtering small coefficients. Defaults to 1e-12.
+            power: The power to raise the unitary to. Defaults to 1.
+            power_strategy: Strategy for U^power: ``"rescale"`` or ``"repeat"`` (default).
+
+        """
+        super().__init__()
+        self._settings = ZassenhausSettings()
+        self._settings.set("time", time)
+        self._settings.set("power", power)
+        self._settings.set("power_strategy", power_strategy)
+        self._settings.set("order", order)
+        self._settings.set("num_divisions", num_divisions)
+        self._settings.set("weight_threshold", weight_threshold)
+
+    # ------------------------------------------------------------------ #
+    # Entry point (mirrors Trotter._run_impl -> _trotter)
+    # ------------------------------------------------------------------ #
+    def _run_impl(self, qubit_hamiltonian: QubitHamiltonian) -> UnitaryRepresentation:
+        """Construct the unitary representation using the Zassenhaus expansion."""
+        order = self._settings.get("order")
+        if order == 1:
+            # Order 1 carries no commutator corrections (e^X e^Y), which is
+            # exactly the first-order Trotter product -- delegate to it.
+            return self._trotter_fallback(qubit_hamiltonian)
+        if not (_MIN_ORDER <= order <= _MAX_ORDER):
+            raise NotImplementedError(
+                f"Zassenhaus order must be 1 (Trotter fallback) or in [{_MIN_ORDER}, {_MAX_ORDER}], got {order}."
+            )
+
+        effective_time, power_repetitions = self._resolve_power()
+        weight_threshold = self._settings.get("weight_threshold")
+
+        if not qubit_hamiltonian.is_hermitian(tolerance=weight_threshold):
+            raise ValueError("Non-Hermitian Hamiltonian: coefficients have nonzero imaginary parts.")
+
+        num_divisions = max(1, self._settings.get("num_divisions"))
+        delta = effective_time / num_divisions
+
+        # One Zassenhaus product approximating exp(-i H delta).
+        step_terms = self._decompose_zassenhaus_step(qubit_hamiltonian, time=delta, order=order, atol=weight_threshold)
+
+        container = PauliProductFormulaContainer(
+            step_terms=step_terms,
+            step_reps=num_divisions * power_repetitions,
+            num_qubits=qubit_hamiltonian.num_qubits,
+        )
+        return UnitaryRepresentation(container=container)
+
+    def _trotter_fallback(self, qubit_hamiltonian: QubitHamiltonian) -> UnitaryRepresentation:
+        """Delegate order 1 to the first-order Trotter builder.
+
+        The Zassenhaus product at order 1 is just ``e^X e^Y`` with no commutator
+        corrections, identical to the first-order Trotter formula. The current
+        settings (time, divisions, power, threshold) are forwarded.
+        """
+        trotter = Trotter(
+            order=1,
+            time=self._settings.get("time"),
+            num_divisions=self._settings.get("num_divisions"),
+            weight_threshold=self._settings.get("weight_threshold"),
+            power=self._settings.get("power"),
+            power_strategy=self._settings.get("power_strategy"),
+        )
+        return trotter.run(qubit_hamiltonian)
+
+    # ------------------------------------------------------------------ #
+    # Core approximation logic (this is the Trotter-analogue swap point)
+    # ------------------------------------------------------------------ #
+    def _decompose_zassenhaus_step(
+        self,
+        qubit_hamiltonian: QubitHamiltonian,
+        time: float,
+        order: int,
+        *,
+        atol: float = 1e-12,
+    ) -> list[ExponentiatedPauliTerm]:
+        r"""Decompose a single Zassenhaus step into exponentiated Pauli terms.
+
+        Partitions H into internally-commuting groups G_1, ..., G_K and builds
+        the recursive K-group Zassenhaus product (see :meth:`_zassenhaus_factors`),
+        then flattens each anti-Hermitian factor into ``ExponentiatedPauliTerm``s.
+        """
+        groups = self._commuting_groups(qubit_hamiltonian)
+        if not groups:
+            Logger.warn("No Pauli terms above the tolerance; returning empty term list.")
+            return []
+
+        # Ordered (leftmost-first) list of (factor, is_correction) pairs.
+        factors = self._zassenhaus_factors(groups, time, order)
+
+        # Flatten each factor in operator order exp(G_1) ... exp(C_n). Group
+        # factors are exact (internally commuting), so a plain product suffices.
+        # A degree-n correction flattens with error O(t^{2n}) (plain) or O(t^{3n})
+        # (symmetric/Strang). The lowest correction C_2 (n=2) gives O(t^4) plain,
+        # which is < O(t^{p+1}) only for p >= 4 -- so symmetric flattening is needed
+        # for order 4 but redundant (extra gates) for orders 2 and 3.
+        flatten_correction = self._exponentiate_factor_symmetric if order > 3 else self._exponentiate_factor
+        terms: list[ExponentiatedPauliTerm] = []
+        for factor, is_correction in factors:
+            flatten = flatten_correction if is_correction else self._exponentiate_factor
+            terms.extend(flatten(factor, atol=atol))
+
+        # The mapper applies step_terms[0] first (rightmost operator), so reverse
+        # to realize the product above: the leftmost factor is applied last.
+        terms.reverse()
+        return terms
+
+    def _zassenhaus_factors(
+        self, groups: list[QubitHamiltonian], time: float, order: int
+    ) -> list[tuple[QubitHamiltonian, bool]]:
+        r"""Recursive K-group Zassenhaus product.
+
+        For groups (G_1, ..., G_K), each internally commuting, with
+        X_1 = -i t G_1 and X_R = -i t (G_2 + ... + G_K):
+
+            Z_p(G_1, ..., G_K) = e^{X_1} . Z_p(G_2, ..., G_K) . e^{C_2} ... e^{C_p}
+
+        where the corrections C_n = C_n(X_1, X_R) use the *exact* rest block X_R.
+        Returned as an ordered (leftmost-first) list of ``(factor, is_correction)``
+        pairs; each e^{X_i} group factor is exact because G_i is internally
+        commuting.
+        """
+        x_first = (-1j * time) * groups[0]
+        if len(groups) == 1:
+            return [(x_first, False)]
+
+        rest = groups[1]
+        for group in groups[2:]:
+            rest = rest + group
+        x_rest = (-1j * time) * rest
+
+        inner = self._zassenhaus_factors(groups[1:], time, order)
+        corrections = [(c, True) for c in self._correction_factors(x_first, x_rest, order=order)]
+        return [(x_first, False), *inner, *corrections]
+
+    def _correction_factors(self, x: QubitHamiltonian, y: QubitHamiltonian, order: int) -> list[QubitHamiltonian]:
+        r"""Return the commutator-correction factors C_2 .. C_order for blocks X, Y.
+
+        Uses the native ``commutator`` (QDK-native, Qiskit-free) recursively.
+        Each returned factor is an anti-Hermitian ``QubitHamiltonian``.
+        """
+        k = commutator(x, y)  # [X, Y] -- shared building block
+
+        factors: list[QubitHamiltonian] = []
+
+        # Order 2: -1/2 [X, Y]
+        factors.append((-0.5) * k)
+        if order == 2:
+            return factors
+
+        # Order 3: 1/3 [Y, [X, Y]] + 1/6 [X, [X, Y]]
+        c3 = (1.0 / 3.0) * commutator(y, k) + (1.0 / 6.0) * commutator(x, k)
+        factors.append(c3)
+        if order == 3:
+            return factors
+
+        # Order 4: -1/24 [X,[X,[X,Y]]] - 1/8 [Y,[X,[X,Y]]] - 1/8 [Y,[Y,[X,Y]]].
+        # Coefficients verified two ways: (i) roots-of-unity extraction of the
+        # degree-4 term, and (ii) the operator-norm slope test gives p+1 = 5.
+        xk = commutator(x, k)  # [X, [X, Y]]
+        yk = commutator(y, k)  # [Y, [X, Y]]
+        c4 = (-1.0 / 24.0) * commutator(x, xk) + (-1.0 / 8.0) * commutator(y, xk) + (-1.0 / 8.0) * commutator(y, yk)
+        factors.append(c4)
+        return factors
+
+    # ------------------------------------------------------------------ #
+    # Helpers
+    # ------------------------------------------------------------------ #
+    def _commuting_groups(self, qubit_hamiltonian: QubitHamiltonian) -> list[QubitHamiltonian]:
+        r"""Partition H into internally-commuting Hermitian groups.
+
+        A correct Zassenhaus expansion requires each ``exp(-i t G_i)`` to be
+        exact, i.e. every group must be a set of mutually-commuting Pauli terms.
+
+        Strategy: consume ``qubit_hamiltonian.term_partition`` when it is present
+        *and* every group is internally commuting (exploits user-provided sparse
+        structure, e.g. even/odd lattice bonds). Otherwise group greedily with
+        :class:`FullCommutingTermGrouper`.
+        """
+        partition = qubit_hamiltonian.term_partition
+        if partition is not None:
+            groups = self._materialize_groups(qubit_hamiltonian, partition)
+            if all(self._is_internally_commuting(g) for g in groups):
+                return groups
+            Logger.debug("Zassenhaus: provided term_partition is not internally commuting; re-grouping.")
+
+        # Lazy import avoids a module-load cycle (registry imports this builder).
+        from qdk_chemistry.algorithms.term_grouper.commuting import FullCommutingTermGrouper  # noqa: PLC0415
+
+        grouped = FullCommutingTermGrouper().run(qubit_hamiltonian)
+        return self._materialize_groups(grouped, grouped.term_partition)
+
+    def _materialize_groups(
+        self, qubit_hamiltonian: QubitHamiltonian, partition: TermPartition
+    ) -> list[QubitHamiltonian]:
+        """Materialise an index-based ``TermPartition`` into sub-Hamiltonians.
+
+        ``FlatPartition`` groups are used directly; ``LayeredPartition`` groups
+        are flattened across layers into a single commuting set per group.
+        """
+        labels = qubit_hamiltonian.pauli_strings
+        coeffs = np.asarray(qubit_hamiltonian.coefficients)
+        encoding = qubit_hamiltonian.encoding
+        fmo = qubit_hamiltonian.fermion_mode_order
+
+        if isinstance(partition, LayeredPartition):
+            index_groups = [tuple(i for layer in group for i in layer) for group in partition.groups]
+        elif isinstance(partition, FlatPartition):
+            index_groups = [tuple(group) for group in partition.groups]
+        else:
+            raise TypeError(
+                f"Unsupported TermPartition subtype: {type(partition).__name__}. "
+                "Expected FlatPartition or LayeredPartition."
+            )
+
+        groups: list[QubitHamiltonian] = []
+        for indices in index_groups:
+            if not indices:
+                continue
+            groups.append(
+                QubitHamiltonian(
+                    pauli_strings=[labels[i] for i in indices],
+                    coefficients=np.asarray([coeffs[i] for i in indices]),
+                    encoding=encoding,
+                    fermion_mode_order=fmo,
+                )
+            )
+        return groups
+
+    @staticmethod
+    def _is_internally_commuting(group: QubitHamiltonian) -> bool:
+        """Return ``True`` if every pair of Pauli terms in *group* commutes."""
+        labels = group.pauli_strings
+        return all(
+            do_pauli_labels_commute(labels[i], labels[j]) for i in range(len(labels)) for j in range(i + 1, len(labels))
+        )
+
+    def _exponentiate_factor(self, factor: QubitHamiltonian, *, atol: float = 1e-12) -> list[ExponentiatedPauliTerm]:
+        r"""Flatten an anti-Hermitian factor F = sum f_j P_j into exp terms.
+
+        Since F is anti-Hermitian, f_j is purely imaginary, and
+        exp(F) = prod_j exp(f_j P_j) = prod_j exp(-i (-Im f_j) P_j),
+        i.e. the ``ExponentiatedPauliTerm`` angle is ``-Im(f_j)``.
+
+        Identity terms are kept as global-phase rotations (empty Pauli map),
+        matching the Trotter builder: dropping them corrupts controlled-U
+        phases in PhaseEstimation (a leading ``I...I`` term, as in H2/STO-3G,
+        carries a real physical phase).
+
+        Note: a factor's terms generally do NOT commute, so this first-order
+        flattening introduces an O(t^{2n}) error for an O(t^n) factor -- which
+        is >= O(t^{p+1}) for n >= 2, p <= 4, hence harmless to the target order.
+        """
+        terms: list[ExponentiatedPauliTerm] = []
+        for label, coeff in zip(factor.pauli_strings, factor.coefficients, strict=True):
+            c = complex(coeff)
+            if abs(c) < atol:
+                continue
+            if abs(c.real) > atol:
+                # Anti-Hermitian factor should have ~zero real part. Surface
+                # violations instead of silently dropping them (Copilot review
+                # flagged this exact failure mode on PR #508).
+                raise ValueError(f"Expected anti-Hermitian factor; term {label!r} has real coeff {c.real}.")
+            angle = -c.imag
+            mapping = self._pauli_label_to_map(label)  # empty for identity -> global phase
+            terms.append(ExponentiatedPauliTerm(pauli_term=mapping, angle=angle))
+        return terms
+
+    def _exponentiate_factor_symmetric(
+        self, factor: QubitHamiltonian, *, atol: float = 1e-12
+    ) -> list[ExponentiatedPauliTerm]:
+        r"""Symmetric (Strang) flattening of an anti-Hermitian factor.
+
+        Emits half-angle terms forward then in reverse:
+        ``exp(f_1/2) ... exp(f_m/2) exp(f_m/2) ... exp(f_1/2)``, whose error
+        versus ``exp(F)`` is O(||F||^3). For a degree-n factor (||F|| ~ t^n)
+        this is O(t^{3n}), one symmetric order tighter than the plain product.
+        The emitted block is a palindrome, so the outer ``terms.reverse()`` in
+        :meth:`_decompose_zassenhaus_step` leaves its internal order intact.
+
+        The two identical centre terms ``exp(f_m/2) exp(f_m/2) = exp(f_m)`` are
+        merged into a single full-angle rotation, saving one gate per factor
+        (and collapsing a single-term factor to one rotation).
+        """
+        half = self._exponentiate_factor((0.5) * factor, atol=atol)
+        if not half:
+            return []
+        *body, last = half
+        centre = ExponentiatedPauliTerm(pauli_term=last.pauli_term, angle=2.0 * last.angle)
+        return [*body, centre, *body[::-1]]
+
+    def name(self) -> str:
+        """Return the name of the unitary builder."""
+        return "zassenhaus"
+
+    def type_name(self) -> str:
+        """Return hamiltonian_unitary_builder as the algorithm type name."""
+        return "hamiltonian_unitary_builder"

--- a/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
+++ b/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
@@ -15,6 +15,13 @@ with, in terms of X = -i t A and Y = -i t B (A, B Hermitian Hamiltonian groups),
 
 Truncating after C_p yields an operator-norm error of O(t^{p+1}).
 
+The Hamiltonian is split into K internally-commuting groups and the builder uses
+the *multi-operator* Zassenhaus formula directly --
+``exp(sum_i X_i) = exp(X_0) ... exp(X_{K-1}) exp(C_2) ... exp(C_p)`` with one
+genuine K-operator exponent C_n per degree. The C_n are generated symbolically for
+any order (rather than hard-coded), so the two-operator C2/C3/C4 above are just the
+familiar low-order instances; see :func:`_zassenhaus_word_exponents`.
+
 References:
     Wilcox, R. M. "Exponential operators and parameter differentiation in
     quantum physics." J. Math. Phys. 8, 962 (1967).
@@ -33,6 +40,9 @@ References:
 # --------------------------------------------------------------------------------------------
 
 from __future__ import annotations
+
+from fractions import Fraction
+from functools import cache
 
 import numpy as np
 
@@ -54,9 +64,103 @@ from qdk_chemistry.utils.pauli_commutation import commutator, do_pauli_labels_co
 
 __all__: list[str] = ["Zassenhaus", "ZassenhausSettings"]
 
-# Supported expansion orders (matches acceptance criteria p in {2, 3, 4}).
+# Supported expansion orders. Corrections C_2..C_order are generated symbolically
+# (see below) for any order, and each is flattened with a Trotter-Suzuki product of
+# just-high-enough order (see Zassenhaus._correction_trotter_order), so the method
+# generalises to any order. The upper bound is a practical/tested cap, not a
+# fundamental one -- raise it as needed (cost grows ~K^order in the generator).
 _MIN_ORDER = 2
-_MAX_ORDER = 4
+_MAX_ORDER = 6
+
+
+# ----------------------------------------------------------------------------------- #
+# Universal Zassenhaus exponents (symbolic, operator-independent, cached)
+#
+# The multi-operator Zassenhaus formula factorises the exponential of a sum of K
+# operators X_0, ..., X_{K-1} as
+#
+#     exp(X_0 + ... + X_{K-1}) = exp(X_0) ... exp(X_{K-1}) exp(C_2) exp(C_3) ...
+#
+# where each C_n is a homogeneous degree-n element of the free Lie algebra on the
+# generators. C_n is computed once per (K, order) as a truncated noncommutative
+# word series with exact rational coefficients, then turned into nested commutators
+# of the actual operators via the Dynkin map (see Zassenhaus._evaluate_exponent).
+# This generalises the recursive two-operator scheme to a single correction block
+# per degree (textbook form: fewer, non-redundant factors) at any order.
+# ----------------------------------------------------------------------------------- #
+
+
+def _series_mul(a: dict, b: dict, max_degree: int) -> dict:
+    """Multiply two truncated word series (words = tuples of generator indices)."""
+    out: dict = {}
+    for w1, c1 in a.items():
+        for w2, c2 in b.items():
+            if len(w1) + len(w2) > max_degree:
+                continue
+            w = w1 + w2
+            out[w] = out.get(w, Fraction(0)) + c1 * c2
+    return {w: c for w, c in out.items() if c}
+
+
+def _series_exp(generator: dict, max_degree: int) -> dict:
+    """Exponential of a word series with no degree-0 term, truncated to ``max_degree``."""
+    result = {(): Fraction(1)}
+    term = {(): Fraction(1)}
+    for k in range(1, max_degree + 1):
+        term = {w: c * Fraction(1, k) for w, c in _series_mul(term, generator, max_degree).items()}
+        if not term:
+            break
+        for w, c in term.items():
+            result[w] = result.get(w, Fraction(0)) + c
+    return {w: c for w, c in result.items() if c}
+
+
+def _series_log(series: dict, max_degree: int) -> dict:
+    """Logarithm of ``1 + r`` (r the non-constant part), truncated to ``max_degree``."""
+    remainder = {w: c for w, c in series.items() if w != ()}
+    result: dict = {}
+    power = {(): Fraction(1)}
+    for k in range(1, max_degree + 1):
+        power = _series_mul(power, remainder, max_degree)
+        if not power:
+            break
+        sign = Fraction((-1) ** (k + 1), k)
+        for w, c in power.items():
+            result[w] = result.get(w, Fraction(0)) + sign * c
+    return {w: c for w, c in result.items() if c}
+
+
+@cache
+def _zassenhaus_word_exponents(num_generators: int, order: int) -> tuple:
+    """Return the Zassenhaus exponents C_2..C_order over ``num_generators`` symbols.
+
+    The result is a tuple whose entry ``n - 2`` is the word expansion of C_n as a
+    tuple of ``(word, Fraction)`` pairs, where ``word`` is a tuple of generator
+    indices. Depends only on ``(num_generators, order)`` so it is cached.
+
+    Peeling: with X_i the i-th generator and S their sum,
+    ``R = exp(-X_{K-1}) ... exp(-X_0) exp(S)`` has lowest degree 2, and
+    ``C_n`` is the degree-n part of ``log(exp(-C_{n-1}) ... exp(-C_2) R)``.
+    """
+    generators = [{(i,): Fraction(1)} for i in range(num_generators)]
+    total: dict = {}
+    for gen in generators:
+        for w, c in gen.items():
+            total[w] = total.get(w, Fraction(0)) + c
+
+    remainder = _series_exp(total, order)
+    for gen in generators:
+        neg = {w: -c for w, c in gen.items()}
+        remainder = _series_mul(_series_exp(neg, order), remainder, order)
+
+    exponents: list = []
+    for n in range(2, order + 1):
+        log_remainder = _series_log(remainder, order)
+        c_n = {w: c for w, c in log_remainder.items() if len(w) == n}
+        exponents.append(tuple(sorted(c_n.items())))
+        neg_c_n = {w: -c for w, c in c_n.items()}
+        remainder = _series_mul(_series_exp(neg_c_n, order), remainder, order)
+    return tuple(exponents)
 
 
 class ZassenhausSettings(TimeEvolutionSettings):
@@ -67,16 +171,28 @@ class ZassenhausSettings(TimeEvolutionSettings):
 
         Attributes:
             order: Expansion order p; corrections C_2..C_p are included so the
-                truncation error scales as O(t^{p+1}). Supported: 2, 3, 4.
-                Order 1 (no corrections) falls back to the first-order Trotter builder.
+                truncation error scales as O(t^{p+1}). Supported: 2, 3, 4, 5, 6.
+                Order 1 (no corrections) falls back to the first-order Trotter builder;
+                order 0 selects the order automatically from ``target_accuracy``.
             num_divisions: Number of time divisions N. The full Zassenhaus
                 product approximates exp(-iH t/N) and is repeated N times.
+            target_accuracy: Target operator-norm accuracy for automatic N
+                (0.0 disables it). When set, N is raised so the leading
+                truncation error ``||C_{p+1}|| t^{p+1} / N^p`` is below it.
             weight_threshold: Absolute threshold for filtering small coefficients.
 
         """
         super().__init__()
-        self._set_default("order", "int", 2, "The Zassenhaus expansion order p (2, 3, or 4; 1 falls back to Trotter).")
+        self._set_default(
+            "order", "int", 2, "The Zassenhaus expansion order p (2-6; 1 falls back to Trotter; 0 = auto)."
+        )
         self._set_default("num_divisions", "int", 1, "Number of time divisions N (>= 1).")
+        self._set_default(
+            "target_accuracy",
+            "double",
+            0.0,
+            "Target accuracy for automatic division-count estimation (0.0 means disabled).",
+        )
         self._set_default(
             "weight_threshold", "float", 1e-12, "The absolute threshold for filtering small coefficients."
         )
@@ -86,15 +202,15 @@ class Zassenhaus(TimeEvolutionBuilder):
     """Zassenhaus product-formula time-evolution builder.
 
     Note:
-        Unlike the Trotter builder, automatic step-count estimation from a
-        ``target_accuracy`` (Zassenhaus error scales as
-        ``||C_{p+1}|| t^{p+1} / N^p``) is not yet provided; ``num_divisions``
-        is set explicitly (default 1). Such an estimator is left as future work.
+        ``num_divisions`` N may be set explicitly (default 1) or estimated
+        automatically from ``target_accuracy`` (Zassenhaus error scales as
+        ``||C_{p+1}|| t^{p+1} / N^p``); when both are given the larger N wins.
+        With ``order=0`` the expansion order itself is chosen from
+        ``target_accuracy`` (the smallest order meeting the single-division bound).
 
-        Remaining gate-count optimisations are also left as future work:
-        ordering the recursion groups, exploiting disjoint-support (layer)
-        parallelism instead of flattening layers, and merging redundant terms
-        at division / Suzuki-copy boundaries.
+        Remaining gate-count optimisations are left as future work: exploiting
+        disjoint-support (layer) parallelism instead of flattening layers, and
+        merging redundant terms at division / Suzuki-copy boundaries.
 
     """
 
@@ -104,6 +220,7 @@ class Zassenhaus(TimeEvolutionBuilder):
         *,
         time: float = 0.0,
         num_divisions: int = 1,
+        target_accuracy: float = 0.0,
         weight_threshold: float = 1e-12,
         power: int = 1,
         power_strategy: str = "repeat",
@@ -111,21 +228,29 @@ class Zassenhaus(TimeEvolutionBuilder):
         r"""Initialize the Zassenhaus builder.
 
         Args:
-            order: Expansion order p in {2, 3, 4}; order 1 falls back to first-order Trotter. Defaults to 2.
+            order: Expansion order p in {2, 3, 4, 5, 6}; order 1 falls back to first-order Trotter; order 0
+                selects the order automatically from ``target_accuracy``. Defaults to 2.
             time: The evolution time. Defaults to 0.0.
             num_divisions: Number of time divisions N (>= 1). Defaults to 1.
+            target_accuracy: Target accuracy for automatic N estimation. Use 0.0 (default) to disable.
             weight_threshold: Threshold for filtering small coefficients. Defaults to 1e-12.
             power: The power to raise the unitary to. Defaults to 1.
             power_strategy: Strategy for U^power: ``"rescale"`` or ``"repeat"`` (default).
 
+        Raises:
+            ValueError: If ``num_divisions`` is less than 1.
+
         """
         super().__init__()
+        if num_divisions < 1:
+            raise ValueError(f"num_divisions must be >= 1, got {num_divisions}.")
         self._settings = ZassenhausSettings()
         self._settings.set("time", time)
         self._settings.set("power", power)
         self._settings.set("power_strategy", power_strategy)
         self._settings.set("order", order)
         self._settings.set("num_divisions", num_divisions)
+        self._settings.set("target_accuracy", target_accuracy)
         self._settings.set("weight_threshold", weight_threshold)
 
     # ------------------------------------------------------------------ #
@@ -138,10 +263,6 @@ class Zassenhaus(TimeEvolutionBuilder):
             # Order 1 carries no commutator corrections (e^X e^Y), which is
             # exactly the first-order Trotter product -- delegate to it.
             return self._trotter_fallback(qubit_hamiltonian)
-        if not (_MIN_ORDER <= order <= _MAX_ORDER):
-            raise NotImplementedError(
-                f"Zassenhaus order must be 1 (Trotter fallback) or in [{_MIN_ORDER}, {_MAX_ORDER}], got {order}."
-            )
 
         effective_time, power_repetitions = self._resolve_power()
         weight_threshold = self._settings.get("weight_threshold")
@@ -149,7 +270,16 @@ class Zassenhaus(TimeEvolutionBuilder):
         if not qubit_hamiltonian.is_hermitian(tolerance=weight_threshold):
             raise ValueError("Non-Hermitian Hamiltonian: coefficients have nonzero imaginary parts.")
 
-        num_divisions = max(1, self._settings.get("num_divisions"))
+        if order == 0:
+            # Pick the order from the accuracy budget (mirrors num_divisions=0).
+            order = self._resolve_auto_order(qubit_hamiltonian, effective_time)
+        if not (_MIN_ORDER <= order <= _MAX_ORDER):
+            raise NotImplementedError(
+                f"Zassenhaus order must be 0 (automatic), 1 (Trotter fallback), "
+                f"or in [{_MIN_ORDER}, {_MAX_ORDER}], got {order}."
+            )
+
+        num_divisions = self._resolve_num_divisions(qubit_hamiltonian, effective_time, order)
         delta = effective_time / num_divisions
 
         # One Zassenhaus product approximating exp(-i H delta).
@@ -161,6 +291,81 @@ class Zassenhaus(TimeEvolutionBuilder):
             num_qubits=qubit_hamiltonian.num_qubits,
         )
         return UnitaryRepresentation(container=container)
+
+    def _resolve_auto_order(self, qubit_hamiltonian: QubitHamiltonian, time: float) -> int:
+        r"""Pick the expansion order from ``target_accuracy`` (used when ``order == 0``).
+
+        Returns the smallest order p in ``[_MIN_ORDER, _MAX_ORDER]`` whose
+        single-division truncation bound ``||C_{p+1}|| t^{p+1}`` is within the
+        target (``||C_{p+1}||`` bounded by the 1-norm of its Pauli coefficients,
+        the same bound used for the division count). If none qualifies, the
+        maximum order is returned and ``num_divisions`` takes up the slack. This
+        is a closed-form accuracy bound in the spirit of the Trotter step-count
+        estimators, not a cost-optimal search.
+        """
+        target_accuracy = self._settings.get("target_accuracy")
+        if target_accuracy <= 0.0:
+            raise ValueError("Automatic order selection (order=0) requires target_accuracy > 0.")
+        groups = self._commuting_groups(qubit_hamiltonian)
+        if len(groups) < 2 or time == 0.0:
+            # A single commuting group is exact; nothing to expand.
+            return _MIN_ORDER
+
+        unit_ops = [(-1j) * group for group in groups]
+        word_exponents = _zassenhaus_word_exponents(len(groups), _MAX_ORDER + 1)
+        for order in range(_MIN_ORDER, _MAX_ORDER + 1):
+            leading = self._evaluate_exponent(word_exponents[order - 1], order + 1, unit_ops)
+            norm_bound = float(np.sum(np.abs(np.asarray(leading.coefficients))))
+            if norm_bound * abs(time) ** (order + 1) <= target_accuracy:
+                return order
+        return _MAX_ORDER
+
+    def _resolve_num_divisions(self, qubit_hamiltonian: QubitHamiltonian, time: float, order: int) -> int:
+        """Determine the number of Zassenhaus divisions N.
+
+        Uses ``max(num_divisions, auto)`` when ``target_accuracy`` is set, where
+        ``auto`` is :meth:`_estimate_divisions`; otherwise the explicit
+        ``num_divisions`` (>= 1, validated at construction).
+        """
+        manual = self._settings.get("num_divisions")
+        target_accuracy = self._settings.get("target_accuracy")
+        if target_accuracy <= 0.0:
+            return manual
+        estimated = self._estimate_divisions(qubit_hamiltonian, time, order, target_accuracy)
+        return max(manual, estimated)
+
+    def _estimate_divisions(
+        self, qubit_hamiltonian: QubitHamiltonian, time: float, order: int, target_accuracy: float
+    ) -> int:
+        r"""Estimate N so the leading Zassenhaus truncation error meets the target.
+
+        The dropped term is the degree-(p+1) exponent C_{p+1}; over N divisions of
+        time t the leading error is ``||C_{p+1}|| t^{p+1} / N^p`` (with C_{p+1} taken
+        at unit time). Bounding ``||C_{p+1}||`` by the 1-norm of its Pauli
+        coefficients (each Pauli has unit operator norm) and solving for N gives
+
+            N = ceil( ( ||C_{p+1}||_1 * t^{p+1} / target_accuracy )^{1/p} ).
+
+        Like the Trotter step-count bounds, this is an estimate (an upper bound on
+        the leading term), not an exact error guarantee.
+        """
+        if time == 0.0:
+            return 1
+        groups = self._commuting_groups(qubit_hamiltonian)
+        if len(groups) < 2:
+            # A single commuting group is evolved exactly; no truncation error.
+            return 1
+
+        # C_{p+1} at unit time: the leading dropped Zassenhaus exponent.
+        unit_ops = [(-1j) * group for group in groups]
+        word_exponents = _zassenhaus_word_exponents(len(groups), order + 1)
+        leading = self._evaluate_exponent(word_exponents[order - 1], order + 1, unit_ops)
+        norm_bound = float(np.sum(np.abs(np.asarray(leading.coefficients))))
+        if norm_bound <= 0.0:
+            return 1
+
+        n_float = (norm_bound * abs(time) ** (order + 1) / target_accuracy) ** (1.0 / order)
+        return max(1, int(np.ceil(n_float)))
 
     def _trotter_fallback(self, qubit_hamiltonian: QubitHamiltonian) -> UnitaryRepresentation:
         """Delegate order 1 to the first-order Trotter builder.
@@ -192,8 +397,11 @@ class Zassenhaus(TimeEvolutionBuilder):
     ) -> list[ExponentiatedPauliTerm]:
         r"""Decompose a single Zassenhaus step into exponentiated Pauli terms.
 
-        Partitions H into internally-commuting groups G_1, ..., G_K and builds
-        the recursive K-group Zassenhaus product (see :meth:`_zassenhaus_factors`),
+        Partitions H into internally-commuting groups G_0, ..., G_{K-1} and builds
+        the multi-operator Zassenhaus product (see :meth:`_multi_operator_factors`)
+
+            exp(-i t H) = exp(X_0) ... exp(X_{K-1}) exp(C_2) ... exp(C_order),
+
         then flattens each anti-Hermitian factor into ``ExponentiatedPauliTerm``s.
         """
         groups = self._commuting_groups(qubit_hamiltonian)
@@ -201,83 +409,76 @@ class Zassenhaus(TimeEvolutionBuilder):
             Logger.warn("No Pauli terms above the tolerance; returning empty term list.")
             return []
 
-        # Ordered (leftmost-first) list of (factor, is_correction) pairs.
-        factors = self._zassenhaus_factors(groups, time, order)
+        # Ordered (leftmost-first) list of (factor, degree) pairs; degree 0 marks a
+        # group (leaf) factor, degree n >= 2 marks the correction C_n.
+        factors = self._multi_operator_factors(groups, time, order)
 
-        # Flatten each factor in operator order exp(G_1) ... exp(C_n). Group
-        # factors are exact (internally commuting), so a plain product suffices.
-        # A degree-n correction flattens with error O(t^{2n}) (plain) or O(t^{3n})
-        # (symmetric/Strang). The lowest correction C_2 (n=2) gives O(t^4) plain,
-        # which is < O(t^{p+1}) only for p >= 4 -- so symmetric flattening is needed
-        # for order 4 but redundant (extra gates) for orders 2 and 3.
-        flatten_correction = self._exponentiate_factor_symmetric if order > 3 else self._exponentiate_factor
+        # Each factor exp(F) is realized by a Trotter-Suzuki product of its Pauli
+        # terms. A degree-n factor has ||F|| ~ t^n, so a Suzuki order-s product
+        # has error O(t^{n(s+1)}); we pick the smallest s in {1, 2, 4, 6, ...}
+        # with n(s+1) >= order + 1 so the flattening never dominates the O(t^{order+1})
+        # truncation (see :meth:`_correction_trotter_order`). Group (leaf) factors
+        # commute internally, so order 1 is already exact for them.
         terms: list[ExponentiatedPauliTerm] = []
-        for factor, is_correction in factors:
-            flatten = flatten_correction if is_correction else self._exponentiate_factor
-            terms.extend(flatten(factor, atol=atol))
+        for factor, degree in factors:
+            suzuki_order = self._correction_trotter_order(degree, order)
+            terms.extend(self._exponentiate_factor_suzuki(factor, suzuki_order, atol=atol))
 
         # The mapper applies step_terms[0] first (rightmost operator), so reverse
         # to realize the product above: the leftmost factor is applied last.
         terms.reverse()
         return terms
 
-    def _zassenhaus_factors(
+    def _multi_operator_factors(
         self, groups: list[QubitHamiltonian], time: float, order: int
-    ) -> list[tuple[QubitHamiltonian, bool]]:
-        r"""Recursive K-group Zassenhaus product.
+    ) -> list[tuple[QubitHamiltonian, int]]:
+        r"""Multi-operator (textbook) Zassenhaus product over all K groups at once.
 
-        For groups (G_1, ..., G_K), each internally commuting, with
-        X_1 = -i t G_1 and X_R = -i t (G_2 + ... + G_K):
+        With X_i = -i t G_i for the internally-commuting groups G_0, ..., G_{K-1},
 
-            Z_p(G_1, ..., G_K) = e^{X_1} . Z_p(G_2, ..., G_K) . e^{C_2} ... e^{C_p}
+            exp(sum_i X_i) = exp(X_0) ... exp(X_{K-1}) exp(C_2) ... exp(C_order),
 
-        where the corrections C_n = C_n(X_1, X_R) use the *exact* rest block X_R.
-        Returned as an ordered (leftmost-first) list of ``(factor, is_correction)``
-        pairs; each e^{X_i} group factor is exact because G_i is internally
-        commuting.
+        where each C_n is the genuine K-operator Zassenhaus exponent of degree n --
+        a single correction block per degree, with no recursive re-expansion and no
+        redundant per-level corrections. Returned as an ordered (leftmost-first)
+        list of ``(factor, degree)`` pairs: degree 0 for the exact group factors,
+        degree n for the correction C_n.
         """
-        x_first = (-1j * time) * groups[0]
-        if len(groups) == 1:
-            return [(x_first, False)]
-
-        rest = groups[1]
-        for group in groups[2:]:
-            rest = rest + group
-        x_rest = (-1j * time) * rest
-
-        inner = self._zassenhaus_factors(groups[1:], time, order)
-        corrections = [(c, True) for c in self._correction_factors(x_first, x_rest, order=order)]
-        return [(x_first, False), *inner, *corrections]
-
-    def _correction_factors(self, x: QubitHamiltonian, y: QubitHamiltonian, order: int) -> list[QubitHamiltonian]:
-        r"""Return the commutator-correction factors C_2 .. C_order for blocks X, Y.
-
-        Uses the native ``commutator`` (QDK-native, Qiskit-free) recursively.
-        Each returned factor is an anti-Hermitian ``QubitHamiltonian``.
-        """
-        k = commutator(x, y)  # [X, Y] -- shared building block
-
-        factors: list[QubitHamiltonian] = []
-
-        # Order 2: -1/2 [X, Y]
-        factors.append((-0.5) * k)
-        if order == 2:
+        ops = [(-1j * time) * group for group in groups]
+        factors: list[tuple[QubitHamiltonian, int]] = [(op, 0) for op in ops]
+        if len(ops) < 2:
+            # A single commuting group is exponentiated exactly; no corrections.
             return factors
 
-        # Order 3: 1/3 [Y, [X, Y]] + 1/6 [X, [X, Y]]
-        c3 = (1.0 / 3.0) * commutator(y, k) + (1.0 / 6.0) * commutator(x, k)
-        factors.append(c3)
-        if order == 3:
-            return factors
-
-        # Order 4: -1/24 [X,[X,[X,Y]]] - 1/8 [Y,[X,[X,Y]]] - 1/8 [Y,[Y,[X,Y]]].
-        # Coefficients verified two ways: (i) roots-of-unity extraction of the
-        # degree-4 term, and (ii) the operator-norm slope test gives p+1 = 5.
-        xk = commutator(x, k)  # [X, [X, Y]]
-        yk = commutator(y, k)  # [Y, [X, Y]]
-        c4 = (-1.0 / 24.0) * commutator(x, xk) + (-1.0 / 8.0) * commutator(y, xk) + (-1.0 / 8.0) * commutator(y, yk)
-        factors.append(c4)
+        word_exponents = _zassenhaus_word_exponents(len(ops), order)
+        for degree in range(2, order + 1):
+            c_n = self._evaluate_exponent(word_exponents[degree - 2], degree, ops)
+            factors.append((c_n, degree))
         return factors
+
+    def _evaluate_exponent(self, word_terms: tuple, degree: int, ops: list[QubitHamiltonian]) -> QubitHamiltonian:
+        r"""Evaluate a symbolic Zassenhaus exponent on the actual operators.
+
+        ``word_terms`` is the cached word expansion of C_n from
+        :func:`_zassenhaus_word_exponents`. By the Dynkin-Specht-Wever theorem a
+        homogeneous degree-n Lie element equals ``1/n`` times the right-nested
+        bracketing of its words, so
+
+            C_n = (1 / n) sum_w c_w [g_{w_0}, [g_{w_1}, [ ..., g_{w_{n-1}}]]],
+
+        evaluated with the QDK-native ``commutator`` (Qiskit-free). Nested
+        commutators of (anti-Hermitian) Pauli operators are again Pauli operators,
+        so the result is an anti-Hermitian ``QubitHamiltonian``.
+        """
+        inverse_degree = 1.0 / degree
+        total: QubitHamiltonian | None = None
+        for word, coeff in word_terms:
+            nested = ops[word[-1]]
+            for index in reversed(word[:-1]):
+                nested = commutator(ops[index], nested)
+            contribution = (float(coeff) * inverse_degree) * nested
+            total = contribution if total is None else total + contribution
+        return total
 
     # ------------------------------------------------------------------ #
     # Helpers
@@ -363,13 +564,25 @@ class Zassenhaus(TimeEvolutionBuilder):
         phases in PhaseEstimation (a leading ``I...I`` term, as in H2/STO-3G,
         carries a real physical phase).
 
-        Note: a factor's terms generally do NOT commute, so this first-order
-        flattening introduces an O(t^{2n}) error for an O(t^n) factor -- which
-        is >= O(t^{p+1}) for n >= 2, p <= 4, hence harmless to the target order.
+        This is the first-order (plain) Trotter product. A factor's terms
+        generally do NOT commute, so it carries an O(||F||^2) = O(t^{2n}) error
+        for a degree-n factor; the caller (:meth:`_decompose_zassenhaus_step`)
+        escalates to a higher Suzuki order when that is not high enough. Leaf
+        (group) factors commute internally, so this product is exact for them.
+
+        Like Pauli terms are summed before emission. ``QubitHamiltonian``
+        addition concatenates rather than merging, and the commutator sums in
+        :meth:`_correction_factors` can produce the same Pauli several times;
+        since ``exp(a P) exp(b P) = exp((a + b) P)`` exactly (P commutes with
+        itself), collecting them removes redundant rotations with no reordering
+        and no loss of accuracy.
         """
-        terms: list[ExponentiatedPauliTerm] = []
+        merged: dict[str, complex] = {}
         for label, coeff in zip(factor.pauli_strings, factor.coefficients, strict=True):
-            c = complex(coeff)
+            merged[label] = merged.get(label, 0j) + complex(coeff)
+
+        terms: list[ExponentiatedPauliTerm] = []
+        for label, c in merged.items():
             if abs(c) < atol:
                 continue
             if abs(c.real) > atol:
@@ -404,6 +617,52 @@ class Zassenhaus(TimeEvolutionBuilder):
         *body, last = half
         centre = ExponentiatedPauliTerm(pauli_term=last.pauli_term, angle=2.0 * last.angle)
         return [*body, centre, *body[::-1]]
+
+    def _exponentiate_factor_suzuki(
+        self, factor: QubitHamiltonian, suzuki_order: int, *, atol: float = 1e-12
+    ) -> list[ExponentiatedPauliTerm]:
+        r"""Flatten ``exp(F)`` with a Trotter-Suzuki product formula of order ``suzuki_order``.
+
+        Order 1 is the plain product (:meth:`_exponentiate_factor`), order 2 the
+        symmetric Strang product (:meth:`_exponentiate_factor_symmetric`), and even
+        orders 2k >= 4 use the standard Suzuki recursion (Suzuki 1992)
+
+            S_{2k}(F) = S_{2k-2}(u_k F)^2 S_{2k-2}((1 - 4 u_k) F) S_{2k-2}(u_k F)^2,
+            u_k = 1 / (4 - 4^{1/(2k-1)}),
+
+        whose error versus ``exp(F)`` is O(||F||^{2k+1}). Each S_{2k} is time
+        symmetric, so the emitted block is a palindrome and the outer
+        ``terms.reverse()`` in :meth:`_decompose_zassenhaus_step` leaves it intact.
+        """
+        if suzuki_order <= 1:
+            return self._exponentiate_factor(factor, atol=atol)
+        if suzuki_order == 2:
+            return self._exponentiate_factor_symmetric(factor, atol=atol)
+
+        k = suzuki_order // 2
+        u_k = 1.0 / (4.0 - 4.0 ** (1.0 / (2 * k - 1)))
+        outer = self._exponentiate_factor_suzuki(u_k * factor, suzuki_order - 2, atol=atol)
+        middle = self._exponentiate_factor_suzuki((1.0 - 4.0 * u_k) * factor, suzuki_order - 2, atol=atol)
+        return [*outer, *outer, *middle, *outer, *outer]
+
+    @staticmethod
+    def _correction_trotter_order(degree: int, order: int) -> int:
+        r"""Smallest Suzuki order s in {1, 2, 4, 6, ...} so the flattening is high enough.
+
+        A degree-n factor has ``||F|| ~ t^n``; a Suzuki order-s product formula
+        flattens it with error ``O(t^{n(s+1)})``. The truncation target is
+        ``O(t^{order+1})``, so we need ``n(s+1) >= order + 1``. Group (leaf) factors
+        (degree 0) commute internally and are exact at order 1.
+        """
+        if degree < 2:
+            return 1
+        needed = order + 1
+        if degree * 2 >= needed:  # plain product (s = 1) already suffices
+            return 1
+        suzuki_order = 2
+        while degree * (suzuki_order + 1) < needed:
+            suzuki_order += 2
+        return suzuki_order
 
     def name(self) -> str:
         """Return the name of the unitary builder."""

--- a/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
+++ b/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
@@ -72,6 +72,12 @@ __all__: list[str] = ["Zassenhaus", "ZassenhausSettings"]
 _MIN_ORDER = 2
 _MAX_ORDER = 6
 
+# The symbolic exponent generator builds ~num_generators^order words, so its cost
+# grows exponentially in the order. Warn before attempting an intractable size --
+# reached only for Hamiltonians with many commuting groups (large molecules),
+# especially via automatic accuracy estimation which probes up to _MAX_ORDER + 1.
+_WORD_SERIES_WARN_THRESHOLD = 100_000
+
 
 # ----------------------------------------------------------------------------------- #
 # Universal Zassenhaus exponents (symbolic, operator-independent, cached)
@@ -130,6 +136,17 @@ def _series_log(series: dict, max_degree: int) -> dict:
     return {w: c for w, c in result.items() if c}
 
 
+def _warn_if_series_large(num_generators: int, order: int) -> None:
+    """Warn when the word series (~``num_generators^order`` words) is large enough to be slow."""
+    estimated_words = num_generators**order
+    if estimated_words > _WORD_SERIES_WARN_THRESHOLD:
+        Logger.warn(
+            f"Zassenhaus exponent generation for {num_generators} commuting groups at order "
+            f"{order} builds ~{estimated_words:.1e} terms and may be slow or memory-intensive; "
+            f"consider a lower order, coarser grouping, or disabling automatic accuracy estimation."
+        )
+
+
 @cache
 def _zassenhaus_word_exponents(num_generators: int, order: int) -> tuple:
     """Return the Zassenhaus exponents C_2..C_order over ``num_generators`` symbols.
@@ -142,6 +159,7 @@ def _zassenhaus_word_exponents(num_generators: int, order: int) -> tuple:
     ``R = exp(-X_{K-1}) ... exp(-X_0) exp(S)`` has lowest degree 2, and
     ``C_n`` is the degree-n part of ``log(exp(-C_{n-1}) ... exp(-C_2) R)``.
     """
+    _warn_if_series_large(num_generators, order)
     generators = [{(i,): Fraction(1)} for i in range(num_generators)]
     total: dict = {}
     for gen in generators:
@@ -537,7 +555,7 @@ class Zassenhaus(TimeEvolutionBuilder):
             groups.append(
                 QubitHamiltonian(
                     pauli_strings=[labels[i] for i in indices],
-                    coefficients=np.asarray([coeffs[i] for i in indices]),
+                    coefficients=coeffs[list(indices)],
                     encoding=encoding,
                     fermion_mode_order=fmo,
                 )

--- a/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
+++ b/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
@@ -171,7 +171,10 @@ def _zassenhaus_word_exponents(num_generators: int, order: int) -> tuple:
 
     exponents: list = []
     for n in range(2, order + 1):
-        log_remainder = _series_log(remainder, order)
+        # Only the degree-n part of the log is needed for C_n, so truncate the log
+        # to degree n (the remainder itself stays truncated to `order` for the next
+        # iterations).
+        log_remainder = _series_log(remainder, n)
         c_n = {w: c for w, c in log_remainder.items() if len(w) == n}
         exponents.append(tuple(sorted(c_n.items())))
         neg_c_n = {w: -c for w, c in c_n.items()}

--- a/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
+++ b/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
@@ -61,9 +61,9 @@ from qdk_chemistry.data.unitary_representation.containers.pauli_product_formula 
 )
 from qdk_chemistry.utils import Logger
 from qdk_chemistry.utils.pauli_commutation import (
-    commutator,
     commutator_bound_higher_order,
     do_pauli_labels_commute,
+    nested_commutator,
 )
 
 __all__: list[str] = ["Zassenhaus", "ZassenhausSettings"]
@@ -440,16 +440,14 @@ class Zassenhaus(TimeEvolutionBuilder):
 
             C_n = (1 / n) sum_w c_w [g_{w_0}, [g_{w_1}, [ ..., g_{w_{n-1}}]]],
 
-        evaluated with the QDK-native ``commutator`` (Qiskit-free). Nested
-        commutators of (anti-Hermitian) Pauli operators are again Pauli operators,
-        so the result is an anti-Hermitian ``QubitHamiltonian``.
+        evaluated with the native ``commutator``. Nested commutators of
+        (anti-Hermitian) Pauli operators are again Pauli operators, so the result
+        is an anti-Hermitian ``QubitHamiltonian``.
         """
         inverse_degree = 1.0 / degree
         total: QubitHamiltonian | None = None
         for word, coeff in word_terms:
-            nested = ops[word[-1]]
-            for index in reversed(word[:-1]):
-                nested = commutator(ops[index], nested)
+            nested = nested_commutator([ops[index] for index in word])
             contribution = (float(coeff) * inverse_degree) * nested
             total = contribution if total is None else total + contribution
         return total

--- a/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
+++ b/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
@@ -388,15 +388,16 @@ class Zassenhaus(TimeEvolutionBuilder):
         factors = self._multi_operator_factors(groups, time, order)
 
         # Each factor exp(F) is realized by a Trotter-Suzuki product of its Pauli
-        # terms. A degree-n factor has ||F|| ~ t^n, so a Suzuki order-s product
-        # has error O(t^{n(s+1)}); we pick the smallest s in {1, 2, 4, 6, ...}
-        # with n(s+1) >= order + 1 so the flattening never dominates the O(t^{order+1})
-        # truncation (see :meth:`_correction_trotter_order`). Group (leaf) factors
-        # commute internally, so order 1 is already exact for them.
+        # terms (delegated to the Trotter builder). A degree-n factor has
+        # ||F|| ~ t^n, so a Suzuki order-s product has error O(t^{n(s+1)}); we pick
+        # the smallest s in {1, 2, 4, 6, ...} with n(s+1) >= order + 1 so the
+        # flattening never dominates the O(t^{order+1}) truncation
+        # (see :meth:`_correction_trotter_order`). Group (leaf) factors commute
+        # internally, so order 1 is already exact for them.
         terms: list[ExponentiatedPauliTerm] = []
         for factor, degree in factors:
             suzuki_order = self._correction_trotter_order(degree, order)
-            terms.extend(self._exponentiate_factor_suzuki(factor, suzuki_order, atol=atol))
+            terms.extend(self._exponentiate_factor(factor, suzuki_order, atol=atol))
 
         # The mapper applies step_terms[0] first (rightmost operator), so reverse
         # to realize the product above: the leftmost factor is applied last.
@@ -524,98 +525,49 @@ class Zassenhaus(TimeEvolutionBuilder):
             do_pauli_labels_commute(labels[i], labels[j]) for i in range(len(labels)) for j in range(i + 1, len(labels))
         )
 
-    def _exponentiate_factor(self, factor: QubitHamiltonian, *, atol: float = 1e-12) -> list[ExponentiatedPauliTerm]:
-        r"""Flatten an anti-Hermitian factor F = sum f_j P_j into exp terms.
+    def _exponentiate_factor(
+        self, factor: QubitHamiltonian, suzuki_order: int, *, atol: float = 1e-12
+    ) -> list[ExponentiatedPauliTerm]:
+        r"""Flatten an anti-Hermitian factor ``exp(F)`` with a Trotter-Suzuki product.
 
-        Since F is anti-Hermitian, f_j is purely imaginary, and
-        exp(F) = prod_j exp(f_j P_j) = prod_j exp(-i (-Im f_j) P_j),
-        i.e. the ``ExponentiatedPauliTerm`` angle is ``-Im(f_j)``.
+        ``F`` is anti-Hermitian, so ``G = i F`` is Hermitian and
+        ``exp(F) = exp(-i G)``. The flattening is delegated to the Trotter builder
+        on ``G`` at the requested Suzuki order, reusing its product-formula schedule
+        rather than re-implementing one here. The needed orders are always 1, 2 or
+        even (see :meth:`_correction_trotter_order`), all of which Trotter supports.
+        Identity terms are kept as global-phase rotations by the Trotter builder, as
+        required for PhaseEstimation.
 
-        Identity terms are kept as global-phase rotations (empty Pauli map),
-        matching the Trotter builder: dropping them corrupts controlled-U
-        phases in PhaseEstimation (a leading ``I...I`` term, as in H2/STO-3G,
-        carries a real physical phase).
+        Like Pauli terms are summed first: ``QubitHamiltonian`` addition
+        concatenates, and the commutator sums in ``C_n`` can repeat a Pauli, but
+        ``exp(a P) exp(b P) = exp((a + b) P)`` exactly, so collecting them removes
+        redundant rotations with no loss of accuracy. A leftover real part in ``F``
+        makes ``G`` non-Hermitian, which the Trotter builder rejects (the factor is
+        expected to be anti-Hermitian).
 
-        This is the first-order (plain) Trotter product. A factor's terms
-        generally do NOT commute, so it carries an O(||F||^2) = O(t^{2n}) error
-        for a degree-n factor; the caller (:meth:`_decompose_zassenhaus_step`)
-        escalates to a higher Suzuki order when that is not high enough. Leaf
-        (group) factors commute internally, so this product is exact for them.
-
-        Like Pauli terms are summed before emission. ``QubitHamiltonian``
-        addition concatenates rather than merging, and the commutator sums in
-        :meth:`_correction_factors` can produce the same Pauli several times;
-        since ``exp(a P) exp(b P) = exp((a + b) P)`` exactly (P commutes with
-        itself), collecting them removes redundant rotations with no reordering
-        and no loss of accuracy.
+        The Trotter container is in mapper order (``step_terms[0]`` applied first);
+        the caller assembles factors in product (leftmost-first) order and reverses
+        once at the end, so the terms are reversed here to match that convention.
         """
         merged: dict[str, complex] = {}
         for label, coeff in zip(factor.pauli_strings, factor.coefficients, strict=True):
             merged[label] = merged.get(label, 0j) + complex(coeff)
 
-        terms: list[ExponentiatedPauliTerm] = []
-        for label, c in merged.items():
-            if abs(c) < atol:
+        labels: list[str] = []
+        coeffs: list[complex] = []
+        for label, coeff in merged.items():
+            if abs(coeff) < atol:
                 continue
-            if abs(c.real) > atol:
-                # Anti-Hermitian factor should have ~zero real part. Surface
-                # violations instead of silently dropping them (Copilot review
-                # flagged this exact failure mode on PR #508).
-                raise ValueError(f"Expected anti-Hermitian factor; term {label!r} has real coeff {c.real}.")
-            angle = -c.imag
-            mapping = self._pauli_label_to_map(label)  # empty for identity -> global phase
-            terms.append(ExponentiatedPauliTerm(pauli_term=mapping, angle=angle))
-        return terms
-
-    def _exponentiate_factor_symmetric(
-        self, factor: QubitHamiltonian, *, atol: float = 1e-12
-    ) -> list[ExponentiatedPauliTerm]:
-        r"""Symmetric (Strang) flattening of an anti-Hermitian factor.
-
-        Emits half-angle terms forward then in reverse:
-        ``exp(f_1/2) ... exp(f_m/2) exp(f_m/2) ... exp(f_1/2)``, whose error
-        versus ``exp(F)`` is O(||F||^3). For a degree-n factor (||F|| ~ t^n)
-        this is O(t^{3n}), one symmetric order tighter than the plain product.
-        The emitted block is a palindrome, so the outer ``terms.reverse()`` in
-        :meth:`_decompose_zassenhaus_step` leaves its internal order intact.
-
-        The two identical centre terms ``exp(f_m/2) exp(f_m/2) = exp(f_m)`` are
-        merged into a single full-angle rotation, saving one gate per factor
-        (and collapsing a single-term factor to one rotation).
-        """
-        half = self._exponentiate_factor((0.5) * factor, atol=atol)
-        if not half:
+            labels.append(label)
+            coeffs.append(1j * coeff)  # G = i F is Hermitian when F is anti-Hermitian
+        if not labels:
             return []
-        *body, last = half
-        centre = ExponentiatedPauliTerm(pauli_term=last.pauli_term, angle=2.0 * last.angle)
-        return [*body, centre, *body[::-1]]
 
-    def _exponentiate_factor_suzuki(
-        self, factor: QubitHamiltonian, suzuki_order: int, *, atol: float = 1e-12
-    ) -> list[ExponentiatedPauliTerm]:
-        r"""Flatten ``exp(F)`` with a Trotter-Suzuki product formula of order ``suzuki_order``.
-
-        Order 1 is the plain product (:meth:`_exponentiate_factor`), order 2 the
-        symmetric Strang product (:meth:`_exponentiate_factor_symmetric`), and even
-        orders 2k >= 4 use the standard Suzuki recursion (Suzuki 1992)
-
-            S_{2k}(F) = S_{2k-2}(u_k F)^2 S_{2k-2}((1 - 4 u_k) F) S_{2k-2}(u_k F)^2,
-            u_k = 1 / (4 - 4^{1/(2k-1)}),
-
-        whose error versus ``exp(F)`` is O(||F||^{2k+1}). Each S_{2k} is time
-        symmetric, so the emitted block is a palindrome and the outer
-        ``terms.reverse()`` in :meth:`_decompose_zassenhaus_step` leaves it intact.
-        """
-        if suzuki_order <= 1:
-            return self._exponentiate_factor(factor, atol=atol)
-        if suzuki_order == 2:
-            return self._exponentiate_factor_symmetric(factor, atol=atol)
-
-        k = suzuki_order // 2
-        u_k = 1.0 / (4.0 - 4.0 ** (1.0 / (2 * k - 1)))
-        outer = self._exponentiate_factor_suzuki(u_k * factor, suzuki_order - 2, atol=atol)
-        middle = self._exponentiate_factor_suzuki((1.0 - 4.0 * u_k) * factor, suzuki_order - 2, atol=atol)
-        return [*outer, *outer, *middle, *outer, *outer]
+        hermitian = QubitHamiltonian(labels, np.asarray(coeffs))
+        container = (
+            Trotter(order=suzuki_order, time=1.0, num_divisions=1, weight_threshold=atol).run(hermitian).get_container()
+        )
+        return list(reversed(container.step_terms))
 
     @staticmethod
     def _correction_trotter_order(degree: int, order: int) -> int:

--- a/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
+++ b/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
@@ -64,18 +64,12 @@ from qdk_chemistry.utils.pauli_commutation import commutator, do_pauli_labels_co
 
 __all__: list[str] = ["Zassenhaus", "ZassenhausSettings"]
 
-# Supported expansion orders. Corrections C_2..C_order are generated symbolically
-# (see below) for any order, and each is flattened with a Trotter-Suzuki product of
-# just-high-enough order (see Zassenhaus._correction_trotter_order), so the method
-# generalises to any order. The upper bound is a practical/tested cap, not a
-# fundamental one -- raise it as needed (cost grows ~K^order in the generator).
-_MIN_ORDER = 2
-_MAX_ORDER = 6
-
 # The symbolic exponent generator builds ~num_generators^order words, so its cost
 # grows exponentially in the order. Warn before attempting an intractable size --
-# reached only for Hamiltonians with many commuting groups (large molecules),
-# especially via automatic accuracy estimation which probes up to _MAX_ORDER + 1.
+# reached only for Hamiltonians with many commuting groups (large molecules) at high
+# order. No hardcoded maximum order is needed: corrections are generated and flattened
+# for any order (see Zassenhaus._correction_trotter_order), and this guardrail flags
+# the rare case where that becomes too expensive.
 _WORD_SERIES_WARN_THRESHOLD = 100_000
 
 
@@ -188,10 +182,9 @@ class ZassenhausSettings(TimeEvolutionSettings):
         """Initialize ZassenhausSettings with default values.
 
         Attributes:
-            order: Expansion order p; corrections C_2..C_p are included so the
-                truncation error scales as O(t^{p+1}). Supported: 2, 3, 4, 5, 6.
-                Order 1 (no corrections) falls back to the first-order Trotter builder;
-                order 0 selects the order automatically from ``target_accuracy``.
+            order: Expansion order p (>= 2); corrections C_2..C_p are included so the
+                truncation error scales as O(t^{p+1}). Order 1 (no corrections) falls
+                back to the first-order Trotter builder.
             num_divisions: Number of time divisions N. The full Zassenhaus
                 product approximates exp(-iH t/N) and is repeated N times.
             target_accuracy: Target operator-norm accuracy for automatic N
@@ -201,9 +194,7 @@ class ZassenhausSettings(TimeEvolutionSettings):
 
         """
         super().__init__()
-        self._set_default(
-            "order", "int", 2, "The Zassenhaus expansion order p (2-6; 1 falls back to Trotter; 0 = auto)."
-        )
+        self._set_default("order", "int", 2, "The Zassenhaus expansion order p (>= 2; 1 falls back to Trotter).")
         self._set_default("num_divisions", "int", 1, "Number of time divisions N (>= 1).")
         self._set_default(
             "target_accuracy",
@@ -223,8 +214,7 @@ class Zassenhaus(TimeEvolutionBuilder):
         ``num_divisions`` N may be set explicitly (default 1) or estimated
         automatically from ``target_accuracy`` (Zassenhaus error scales as
         ``||C_{p+1}|| t^{p+1} / N^p``); when both are given the larger N wins.
-        With ``order=0`` the expansion order itself is chosen from
-        ``target_accuracy`` (the smallest order meeting the single-division bound).
+        The expansion ``order`` is always user-provided (1 falls back to Trotter).
 
         Remaining gate-count optimisations are left as future work: exploiting
         disjoint-support (layer) parallelism instead of flattening layers, and
@@ -246,8 +236,7 @@ class Zassenhaus(TimeEvolutionBuilder):
         r"""Initialize the Zassenhaus builder.
 
         Args:
-            order: Expansion order p in {2, 3, 4, 5, 6}; order 1 falls back to first-order Trotter; order 0
-                selects the order automatically from ``target_accuracy``. Defaults to 2.
+            order: Expansion order p >= 2; order 1 falls back to first-order Trotter. Defaults to 2.
             time: The evolution time. Defaults to 0.0.
             num_divisions: Number of time divisions N (>= 1). Defaults to 1.
             target_accuracy: Target accuracy for automatic N estimation. Use 0.0 (default) to disable.
@@ -277,6 +266,8 @@ class Zassenhaus(TimeEvolutionBuilder):
     def _run_impl(self, qubit_hamiltonian: QubitHamiltonian) -> UnitaryRepresentation:
         """Construct the unitary representation using the Zassenhaus expansion."""
         order = self._settings.get("order")
+        if order < 1:
+            raise ValueError(f"Zassenhaus order must be >= 1 (1 falls back to Trotter); got {order}.")
         if order == 1:
             # Order 1 carries no commutator corrections (e^X e^Y), which is
             # exactly the first-order Trotter product -- delegate to it.
@@ -287,15 +278,6 @@ class Zassenhaus(TimeEvolutionBuilder):
 
         if not qubit_hamiltonian.is_hermitian(tolerance=weight_threshold):
             raise ValueError("Non-Hermitian Hamiltonian: coefficients have nonzero imaginary parts.")
-
-        if order == 0:
-            # Pick the order from the accuracy budget (mirrors num_divisions=0).
-            order = self._resolve_auto_order(qubit_hamiltonian, effective_time)
-        if not (_MIN_ORDER <= order <= _MAX_ORDER):
-            raise NotImplementedError(
-                f"Zassenhaus order must be 0 (automatic), 1 (Trotter fallback), "
-                f"or in [{_MIN_ORDER}, {_MAX_ORDER}], got {order}."
-            )
 
         num_divisions = self._resolve_num_divisions(qubit_hamiltonian, effective_time, order)
         delta = effective_time / num_divisions
@@ -309,34 +291,6 @@ class Zassenhaus(TimeEvolutionBuilder):
             num_qubits=qubit_hamiltonian.num_qubits,
         )
         return UnitaryRepresentation(container=container)
-
-    def _resolve_auto_order(self, qubit_hamiltonian: QubitHamiltonian, time: float) -> int:
-        r"""Pick the expansion order from ``target_accuracy`` (used when ``order == 0``).
-
-        Returns the smallest order p in ``[_MIN_ORDER, _MAX_ORDER]`` whose
-        single-division truncation bound ``||C_{p+1}|| t^{p+1}`` is within the
-        target (``||C_{p+1}||`` bounded by the 1-norm of its Pauli coefficients,
-        the same bound used for the division count). If none qualifies, the
-        maximum order is returned and ``num_divisions`` takes up the slack. This
-        is a closed-form accuracy bound in the spirit of the Trotter step-count
-        estimators, not a cost-optimal search.
-        """
-        target_accuracy = self._settings.get("target_accuracy")
-        if target_accuracy <= 0.0:
-            raise ValueError("Automatic order selection (order=0) requires target_accuracy > 0.")
-        groups = self._commuting_groups(qubit_hamiltonian)
-        if len(groups) < 2 or time == 0.0:
-            # A single commuting group is exact; nothing to expand.
-            return _MIN_ORDER
-
-        unit_ops = [(-1j) * group for group in groups]
-        word_exponents = _zassenhaus_word_exponents(len(groups), _MAX_ORDER + 1)
-        for order in range(_MIN_ORDER, _MAX_ORDER + 1):
-            leading = self._evaluate_exponent(word_exponents[order - 1], order + 1, unit_ops)
-            norm_bound = float(np.sum(np.abs(np.asarray(leading.coefficients))))
-            if norm_bound * abs(time) ** (order + 1) <= target_accuracy:
-                return order
-        return _MAX_ORDER
 
     def _resolve_num_divisions(self, qubit_hamiltonian: QubitHamiltonian, time: float, order: int) -> int:
         """Determine the number of Zassenhaus divisions N.

--- a/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
+++ b/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
@@ -60,7 +60,11 @@ from qdk_chemistry.data.unitary_representation.containers.pauli_product_formula 
     PauliProductFormulaContainer,
 )
 from qdk_chemistry.utils import Logger
-from qdk_chemistry.utils.pauli_commutation import commutator, do_pauli_labels_commute
+from qdk_chemistry.utils.pauli_commutation import (
+    commutator,
+    commutator_bound_higher_order,
+    do_pauli_labels_commute,
+)
 
 __all__: list[str] = ["Zassenhaus", "ZassenhausSettings"]
 
@@ -311,32 +315,30 @@ class Zassenhaus(TimeEvolutionBuilder):
     ) -> int:
         r"""Estimate N so the leading Zassenhaus truncation error meets the target.
 
-        The dropped term is the degree-(p+1) exponent C_{p+1}; over N divisions of
-        time t the leading error is ``||C_{p+1}|| t^{p+1} / N^p`` (with C_{p+1} taken
-        at unit time). Bounding ``||C_{p+1}||`` by the 1-norm of its Pauli
-        coefficients (each Pauli has unit operator norm) and solving for N gives
+        An order-p Zassenhaus step has leading error ``||C_{p+1}|| t^{p+1} / N^p``,
+        the same scaling as an order-p Trotter step. We reuse the shared
+        commutator bound :func:`~qdk_chemistry.utils.pauli_commutation.commutator_bound_higher_order`
+        (the alpha multiplying ``t^{p+1}`` in Theorem 6 of Childs et al. 2021, also
+        used by the Trotter step-count estimators) and solve for N with the same
+        closed form:
 
-            N = ceil( ( ||C_{p+1}||_1 * t^{p+1} / target_accuracy )^{1/p} ).
+            N = ceil( alpha^{1/p} * t^{1 + 1/p} / target_accuracy^{1/p} ).
 
-        Like the Trotter step-count bounds, this is an estimate (an upper bound on
-        the leading term), not an exact error guarantee.
+        The bound is shared with -- not re-derived from -- the Trotter machinery;
+        unlike ``trotter_steps_commutator`` it is applied at every order p (the
+        Trotter wrapper only supports orders 1, 2 and even, whereas Zassenhaus also
+        allows odd orders). Like all such bounds it is a conservative estimate, not
+        an exact error guarantee.
         """
         if time == 0.0:
             return 1
-        groups = self._commuting_groups(qubit_hamiltonian)
-        if len(groups) < 2:
-            # A single commuting group is evolved exactly; no truncation error.
+        weight_threshold = self._settings.get("weight_threshold")
+        alpha = commutator_bound_higher_order(qubit_hamiltonian, order=order, weight_threshold=weight_threshold)
+        if alpha <= 0.0:
+            # No inter-term commutators: the step is already exact.
             return 1
 
-        # C_{p+1} at unit time: the leading dropped Zassenhaus exponent.
-        unit_ops = [(-1j) * group for group in groups]
-        word_exponents = _zassenhaus_word_exponents(len(groups), order + 1)
-        leading = self._evaluate_exponent(word_exponents[order - 1], order + 1, unit_ops)
-        norm_bound = float(np.sum(np.abs(np.asarray(leading.coefficients))))
-        if norm_bound <= 0.0:
-            return 1
-
-        n_float = (norm_bound * abs(time) ** (order + 1) / target_accuracy) ** (1.0 / order)
+        n_float = alpha ** (1.0 / order) * abs(time) ** (1.0 + 1.0 / order) / target_accuracy ** (1.0 / order)
         return max(1, int(np.ceil(n_float)))
 
     def _trotter_fallback(self, qubit_hamiltonian: QubitHamiltonian) -> UnitaryRepresentation:

--- a/python/src/qdk_chemistry/algorithms/registry.py
+++ b/python/src/qdk_chemistry/algorithms/registry.py
@@ -596,6 +596,9 @@ def _register_python_algorithms():
     )
     from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.qdrift import QDrift  # noqa: PLC0415
     from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.trotter import Trotter  # noqa: PLC0415
+    from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus import (  # noqa: PLC0415
+        Zassenhaus,
+    )
     from qdk_chemistry.algorithms.phase_estimation.circuit_builder.iterative_builder import (  # noqa: PLC0415
         QdkIterativeQpeCircuitBuilder,
     )
@@ -625,6 +628,7 @@ def _register_python_algorithms():
     register(lambda: QubitWiseCommutingTermGrouper())
     register(lambda: IdentityTermGrouper())
     register(lambda: Trotter())
+    register(lambda: Zassenhaus())
     register(lambda: QDrift())
     register(lambda: PartiallyRandomized())
     register(lambda: PauliSequenceMapper())

--- a/python/src/qdk_chemistry/utils/pauli_commutation.py
+++ b/python/src/qdk_chemistry/utils/pauli_commutation.py
@@ -105,7 +105,12 @@ def nested_commutator(operators: list[QubitHamiltonian]) -> QubitHamiltonian:
     Returns:
         The right-nested commutator as a :class:`~qdk_chemistry.data.QubitHamiltonian`.
 
+    Raises:
+        ValueError: If ``operators`` is empty.
+
     """
+    if not operators:
+        raise ValueError("nested_commutator requires at least one operator.")
     nested = operators[-1]
     for operator in reversed(operators[:-1]):
         nested = commutator(operator, nested)

--- a/python/src/qdk_chemistry/utils/pauli_commutation.py
+++ b/python/src/qdk_chemistry/utils/pauli_commutation.py
@@ -49,6 +49,7 @@ __all__: list[str] = [
     "do_pauli_maps_qw_commute",
     "does_nested_commutator_vanish",
     "get_commutation_checker",
+    "nested_commutator",
 ]
 
 
@@ -89,6 +90,26 @@ def commutator(h_a: QubitHamiltonian, h_b: QubitHamiltonian) -> QubitHamiltonian
     labels = [label[::-1] for _, label in terms]
     coeffs = np.array([complex(c) for c, _ in terms])
     return _QubitHamiltonian(labels, coeffs)
+
+
+def nested_commutator(operators: list[QubitHamiltonian]) -> QubitHamiltonian:
+    r"""Right-nested commutator :math:`[g_0, [g_1, [\ldots, [g_{m-2}, g_{m-1}]]]]`.
+
+    Builds the bracket from the inside out using :func:`commutator`; a single
+    operator is returned unchanged. A nested commutator of Pauli operators is again
+    a (combination of) Pauli operators, so the result stays in the Pauli basis.
+
+    Args:
+        operators: The operators :math:`g_0, \ldots, g_{m-1}` to bracket, in order.
+
+    Returns:
+        The right-nested commutator as a :class:`~qdk_chemistry.data.QubitHamiltonian`.
+
+    """
+    nested = operators[-1]
+    for operator in reversed(operators[:-1]):
+        nested = commutator(operator, nested)
+    return nested
 
 
 def _label_to_sparse_word(label: str) -> list[tuple[int, int]]:

--- a/python/tests/test_pauli_commutation.py
+++ b/python/tests/test_pauli_commutation.py
@@ -311,3 +311,8 @@ class TestCommutator:
         result = nested_commutator([h_x])
         assert result.pauli_strings[0] == "X"
         np.testing.assert_allclose(result.coefficients[0], 1.0, atol=1e-14)
+
+    def test_nested_commutator_empty_raises(self):
+        """An empty operator list raises a clear ValueError, not an IndexError."""
+        with pytest.raises(ValueError, match="at least one operator"):
+            nested_commutator([])

--- a/python/tests/test_pauli_commutation.py
+++ b/python/tests/test_pauli_commutation.py
@@ -17,6 +17,7 @@ from qdk_chemistry.utils.pauli_commutation import (
     do_pauli_maps_commute,
     do_pauli_maps_qw_commute,
     get_commutation_checker,
+    nested_commutator,
 )
 
 
@@ -295,3 +296,18 @@ class TestCommutator:
         # [XI, ZI] = [X,Z]⊗I = -2iYI; [IX, ZI] commutes → only -2i YI
         idx = result.pauli_strings.index("YI")
         np.testing.assert_allclose(result.coefficients[idx], -2.0j, atol=1e-14)
+
+    def test_nested_commutator_right_nested(self):
+        """nested_commutator([X, X, Z]) = [X, [X, Z]] = 4Z."""
+        h_x = _make_hamiltonian(["X"], [1.0])
+        h_z = _make_hamiltonian(["Z"], [1.0])
+        result = nested_commutator([h_x, h_x, h_z])
+        assert result.pauli_strings[0] == "Z"
+        np.testing.assert_allclose(result.coefficients[0], 4.0, atol=1e-14)
+
+    def test_nested_commutator_single_operator(self):
+        """A single operator is returned unchanged."""
+        h_x = _make_hamiltonian(["X"], [1.0])
+        result = nested_commutator([h_x])
+        assert result.pauli_strings[0] == "X"
+        np.testing.assert_allclose(result.coefficients[0], 1.0, atol=1e-14)

--- a/python/tests/test_time_evolution_zassenhaus.py
+++ b/python/tests/test_time_evolution_zassenhaus.py
@@ -178,12 +178,17 @@ class TestZassenhausBuilder:
         with pytest.raises(ValueError, match="num_divisions"):
             Zassenhaus(order=2, time=0.1, num_divisions=0)
 
-    def test_target_accuracy_increases_divisions(self):
-        """A target_accuracy raises N automatically until the error meets the target."""
+    @pytest.mark.parametrize("order", [2, 3])
+    def test_target_accuracy_increases_divisions(self, order):
+        """target_accuracy raises N until the error meets the target (even and odd orders).
+
+        The shared ``commutator_bound_higher_order`` estimate is applied directly, so
+        it also covers odd orders that the ``trotter_steps_*`` wrappers reject.
+        """
         hamiltonian = _heisenberg_hamiltonian()
         time = 1.0
         target = 1e-2
-        container = Zassenhaus(order=2, time=time, target_accuracy=target).run(hamiltonian).get_container()
+        container = Zassenhaus(order=order, time=time, target_accuracy=target).run(hamiltonian).get_container()
         assert container.step_reps > 1  # auto-estimation engaged
         error = np.linalg.norm(_exact_unitary(hamiltonian, time) - _builder_unitary(container), 2)
         assert error < target

--- a/python/tests/test_time_evolution_zassenhaus.py
+++ b/python/tests/test_time_evolution_zassenhaus.py
@@ -7,11 +7,13 @@
 
 from __future__ import annotations
 
+from functools import cache
+
 import numpy as np
 import pytest
 import scipy
 
-from qdk_chemistry.algorithms import registry
+from qdk_chemistry.algorithms import create, registry
 from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution import zassenhaus as zassenhaus_module
 from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus import Zassenhaus
 from qdk_chemistry.algorithms.phase_estimation.iterative_phase_estimation import IterativePhaseEstimation
@@ -19,7 +21,9 @@ from qdk_chemistry.data import (
     AlgorithmRef,
     Circuit,
     LatticeGraph,
+    MajoranaMapping,
     QubitHamiltonian,
+    Structure,
     UnitaryRepresentation,
 )
 from qdk_chemistry.data.circuit import QsharpFactoryData
@@ -28,50 +32,21 @@ from qdk_chemistry.utils.model_hamiltonians import create_heisenberg_hamiltonian
 from qdk_chemistry.utils.phase import energy_from_phase
 from qdk_chemistry.utils.qsharp import QSHARP_UTILS
 
-# H2 / STO-3G qubit Hamiltonian (4-qubit Jordan-Wigner, equilibrium geometry).
-# Coefficients follow the standard ordering used throughout the literature
-# (e.g. Seeley, Richard, Love 2012; O'Malley et al. 2016).
-_H2_LABELS = [
-    "IIII",
-    "IIIZ",
-    "IIZI",
-    "IZII",
-    "ZIII",
-    "IIZZ",
-    "IZIZ",
-    "ZIIZ",
-    "IZZI",
-    "ZIZI",
-    "ZZII",
-    "XXYY",
-    "YYXX",
-    "XYYX",
-    "YXXY",
-]
-_H2_COEFFS = np.array(
-    [
-        -0.81261,
-        0.171201,
-        0.171201,
-        -0.2227965,
-        -0.2227965,
-        0.16862325,
-        0.12054625,
-        0.165868,
-        0.165868,
-        0.12054625,
-        0.17434925,
-        -0.04532175,
-        -0.04532175,
-        0.04532175,
-        0.04532175,
-    ]
-)
 
-
+@cache
 def _h2_hamiltonian() -> QubitHamiltonian:
-    """Return the 4-qubit H2/STO-3G Jordan-Wigner qubit Hamiltonian."""
-    return QubitHamiltonian(pauli_strings=list(_H2_LABELS), coefficients=_H2_COEFFS.copy())
+    """Return the 4-qubit H2/STO-3G Jordan-Wigner qubit Hamiltonian.
+
+    Built end-to-end with the QDK pipeline (SCF -> Hamiltonian -> Jordan-Wigner
+    qubit mapping) rather than hardcoded coefficients, so the test exercises the
+    real chemistry stack. Cached so the SCF runs once across the test module.
+    """
+    structure = Structure.from_xyz("2\nH2 molecule\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74\n")
+    _, wavefunction = create("scf_solver").run(structure, charge=0, spin_multiplicity=1, basis_or_guess="sto-3g")
+    orbitals = wavefunction.get_orbitals()
+    classical_hamiltonian = create("hamiltonian_constructor").run(orbitals)
+    num_spin_orbitals = 2 * len(orbitals.get_active_space_indices()[0])
+    return create("qubit_mapper", "qdk").run(classical_hamiltonian, MajoranaMapping.jordan_wigner(num_spin_orbitals))
 
 
 def _heisenberg_hamiltonian() -> QubitHamiltonian:
@@ -327,13 +302,17 @@ class TestZassenhausPhaseEstimation:
         ground_energy = float(eigenvalues[0])
         ground_state = eigenvectors[:, 0].real
 
+        # Evolution time from the Hamiltonian (the base time of compute_evolution_time
+        # in the QPE example): pi / ||H|| keeps the phase within one period.
+        time = float(np.pi / hamiltonian.schatten_norm)
+
         energy = self._run_iqpe(
             hamiltonian,
             ground_state,
-            time=0.5,
-            num_bits=12,
+            time=time,
+            num_bits=13,
             order=4,
-            num_divisions=2,
+            num_divisions=4,
             reference_energy=ground_energy,
         )
         assert abs(energy - ground_energy) < 1.6e-3

--- a/python/tests/test_time_evolution_zassenhaus.py
+++ b/python/tests/test_time_evolution_zassenhaus.py
@@ -12,6 +12,7 @@ import pytest
 import scipy
 
 from qdk_chemistry.algorithms import registry
+from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution import zassenhaus as zassenhaus_module
 from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus import Zassenhaus
 from qdk_chemistry.algorithms.phase_estimation.iterative_phase_estimation import IterativePhaseEstimation
 from qdk_chemistry.data import (
@@ -156,6 +157,21 @@ class TestZassenhausBuilder:
         hamiltonian = QubitHamiltonian(pauli_strings=["XX", "ZI", "IZ"], coefficients=[0.7, 0.3, 0.5])
         container = Zassenhaus(order=2, time=0.2, num_divisions=4).run(hamiltonian).get_container()
         assert container.step_reps == 4
+
+    def test_large_generator_warns(self, monkeypatch):
+        """The symbolic generator warns (not silently hangs) when ~K^order is huge."""
+        messages: list[str] = []
+
+        class _RecordingLogger:
+            @staticmethod
+            def warn(message: str) -> None:
+                messages.append(message)
+
+        monkeypatch.setattr(zassenhaus_module, "Logger", _RecordingLogger)
+        zassenhaus_module._warn_if_series_large(20, 7)  # ~1.3e9 words -> over threshold
+        zassenhaus_module._warn_if_series_large(3, 7)  # 2187 words (e.g. Heisenberg) -> under threshold
+        assert len(messages) == 1
+        assert "may be slow" in messages[0]
 
     def test_num_divisions_below_one_raises(self):
         """num_divisions < 1 is rejected at construction, not silently clamped."""

--- a/python/tests/test_time_evolution_zassenhaus.py
+++ b/python/tests/test_time_evolution_zassenhaus.py
@@ -206,9 +206,14 @@ class TestZassenhausErrorScaling:
         slope = _fitted_error_slope(_heisenberg_hamiltonian(), order)
         assert abs(slope - (order + 1)) < 0.1
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("order", [2, 3, 4])
     def test_h2_scaling(self, order):
-        """H2/STO-3G (K = 2 commuting groups, with an identity term) scales as O(t^{p+1})."""
+        """H2/STO-3G (K = 2 commuting groups, with an identity term) scales as O(t^{p+1}).
+
+        Marked slow because ``_h2_hamiltonian`` runs the end-to-end SCF + qubit-mapping
+        pipeline; the Heisenberg scaling test covers the fast suite.
+        """
         slope = _fitted_error_slope(_h2_hamiltonian(), order)
         assert abs(slope - (order + 1)) < 0.1
 

--- a/python/tests/test_time_evolution_zassenhaus.py
+++ b/python/tests/test_time_evolution_zassenhaus.py
@@ -1,0 +1,296 @@
+"""Tests for the Zassenhaus product-formula builder in QDK/Chemistry."""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import scipy
+
+from qdk_chemistry.algorithms import registry
+from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus import Zassenhaus
+from qdk_chemistry.algorithms.phase_estimation.iterative_phase_estimation import IterativePhaseEstimation
+from qdk_chemistry.data import (
+    AlgorithmRef,
+    Circuit,
+    LatticeGraph,
+    QubitHamiltonian,
+    UnitaryRepresentation,
+)
+from qdk_chemistry.data.circuit import QsharpFactoryData
+from qdk_chemistry.data.unitary_representation.containers.pauli_product_formula import PauliProductFormulaContainer
+from qdk_chemistry.utils.model_hamiltonians import create_heisenberg_hamiltonian
+from qdk_chemistry.utils.phase import energy_from_phase
+from qdk_chemistry.utils.qsharp import QSHARP_UTILS
+
+# H2 / STO-3G qubit Hamiltonian (4-qubit Jordan-Wigner, equilibrium geometry).
+# Coefficients follow the standard ordering used throughout the literature
+# (e.g. Seeley, Richard, Love 2012; O'Malley et al. 2016).
+_H2_LABELS = [
+    "IIII",
+    "IIIZ",
+    "IIZI",
+    "IZII",
+    "ZIII",
+    "IIZZ",
+    "IZIZ",
+    "ZIIZ",
+    "IZZI",
+    "ZIZI",
+    "ZZII",
+    "XXYY",
+    "YYXX",
+    "XYYX",
+    "YXXY",
+]
+_H2_COEFFS = np.array(
+    [
+        -0.81261,
+        0.171201,
+        0.171201,
+        -0.2227965,
+        -0.2227965,
+        0.16862325,
+        0.12054625,
+        0.165868,
+        0.165868,
+        0.12054625,
+        0.17434925,
+        -0.04532175,
+        -0.04532175,
+        0.04532175,
+        0.04532175,
+    ]
+)
+
+
+def _h2_hamiltonian() -> QubitHamiltonian:
+    """Return the 4-qubit H2/STO-3G Jordan-Wigner qubit Hamiltonian."""
+    return QubitHamiltonian(pauli_strings=list(_H2_LABELS), coefficients=_H2_COEFFS.copy())
+
+
+def _heisenberg_hamiltonian() -> QubitHamiltonian:
+    """Return the 4-site open Heisenberg chain Hamiltonian with J = 1."""
+    chain = LatticeGraph.chain(4, periodic=False)
+    return create_heisenberg_hamiltonian(chain, jx=1.0, jy=1.0, jz=1.0)
+
+
+def _builder_unitary(container: PauliProductFormulaContainer) -> np.ndarray:
+    """Reconstruct the dense unitary realised by a Pauli-product-formula container.
+
+    The Pauli sequence mapper applies ``step_terms[0]`` first (rightmost in the
+    operator product) and repeats the whole step ``step_reps`` times. Identity
+    terms (empty Pauli map) contribute a global phase.
+    """
+    num_qubits = container.num_qubits
+    dim = 2**num_qubits
+    step = np.eye(dim, dtype=complex)
+    for term in container.step_terms:
+        chars = ["I"] * num_qubits
+        for qubit, axis in term.pauli_term.items():
+            chars[num_qubits - 1 - qubit] = axis  # little-endian: qubit 0 -> rightmost
+        pauli = QubitHamiltonian([("".join(chars))], np.array([1.0])).to_matrix()
+        step = scipy.linalg.expm(-1j * term.angle * pauli) @ step
+    return np.linalg.matrix_power(step, container.step_reps)
+
+
+def _zassenhaus_unitary(hamiltonian: QubitHamiltonian, time: float, order: int) -> np.ndarray:
+    """Build the Zassenhaus approximation to ``exp(-i H t)`` as a dense matrix."""
+    builder = Zassenhaus(order=order, time=time, num_divisions=1)
+    return _builder_unitary(builder.run(hamiltonian).get_container())
+
+
+def _exact_unitary(hamiltonian: QubitHamiltonian, time: float) -> np.ndarray:
+    """Return the exact time-evolution operator ``exp(-i H t)``."""
+    return scipy.linalg.expm(-1j * time * hamiltonian.to_matrix())
+
+
+def _fitted_error_slope(hamiltonian: QubitHamiltonian, order: int) -> float:
+    """Fit the slope of ``log(error)`` vs ``log(t)`` for the operator-norm error.
+
+    The acceptance criterion specifies ``t in [1e-3, 1e-1]``. The fit is taken
+    over the upper decade ``[1e-2, 1e-1]``: there every order is comfortably
+    above the ~1e-13 double-precision floor, whereas an order-4 (O(t^5)) error
+    near ``t = 1e-3`` is ~1e-13 and would be pure round-off noise.
+    """
+    times = np.geomspace(1e-2, 1e-1, 7)
+    errors = np.array(
+        [np.linalg.norm(_exact_unitary(hamiltonian, t) - _zassenhaus_unitary(hamiltonian, t, order), 2) for t in times]
+    )
+    return float(np.polyfit(np.log(times), np.log(errors), 1)[0])
+
+
+class TestZassenhausBuilder:
+    """Structural and registry tests for the Zassenhaus builder."""
+
+    def test_name(self):
+        """The builder reports its registry name and algorithm type."""
+        builder = Zassenhaus()
+        assert builder.name() == "zassenhaus"
+        assert builder.type_name() == "hamiltonian_unitary_builder"
+
+    def test_discoverable_via_registry(self):
+        """The builder is discoverable under the hamiltonian_unitary_builder type."""
+        builder = registry.create("hamiltonian_unitary_builder", "zassenhaus", time=0.1, order=2)
+        assert isinstance(builder, Zassenhaus)
+        assert "zassenhaus" in registry.available("hamiltonian_unitary_builder")
+
+    def test_returns_pauli_product_formula_container(self):
+        """The output has the same shape as the trotter builder's output."""
+        hamiltonian = QubitHamiltonian(pauli_strings=["XX", "ZI", "IZ"], coefficients=[0.7, 0.3, 0.5])
+        unitary = Zassenhaus(order=2, time=0.1, num_divisions=1).run(hamiltonian)
+
+        assert isinstance(unitary, UnitaryRepresentation)
+        container = unitary.get_container()
+        assert isinstance(container, PauliProductFormulaContainer)
+        assert container.num_qubits == 2
+        assert container.step_reps == 1
+        assert len(container.step_terms) > 0
+
+    def test_num_divisions_sets_step_reps(self):
+        """num_divisions controls the repetition count of the product formula."""
+        hamiltonian = QubitHamiltonian(pauli_strings=["XX", "ZI", "IZ"], coefficients=[0.7, 0.3, 0.5])
+        container = Zassenhaus(order=2, time=0.2, num_divisions=4).run(hamiltonian).get_container()
+        assert container.step_reps == 4
+
+    def test_accepts_partitioned_hamiltonian(self):
+        """A Hamiltonian carrying a commuting term_partition is accepted (as trotter accepts)."""
+        hamiltonian = _heisenberg_hamiltonian()
+        partitioned = registry.create("term_grouper", "commuting").run(hamiltonian)
+        unitary = Zassenhaus(order=2, time=0.05, num_divisions=1).run(partitioned)
+        assert isinstance(unitary.get_container(), PauliProductFormulaContainer)
+
+    def test_unsupported_order_raises(self):
+        """Orders outside the supported {1, 2, 3, 4} range raise NotImplementedError."""
+        hamiltonian = QubitHamiltonian(pauli_strings=["XX", "ZI"], coefficients=[0.7, 0.5])
+        with pytest.raises(NotImplementedError):
+            Zassenhaus(order=5, time=0.1).run(hamiltonian)
+
+    def test_order_one_falls_back_to_trotter(self):
+        """Order 1 (no commutator corrections) reproduces the first-order Trotter product."""
+        hamiltonian = QubitHamiltonian(pauli_strings=["XX", "ZI", "IZ"], coefficients=[0.7, 0.3, 0.5])
+        zassenhaus = Zassenhaus(order=1, time=0.2, num_divisions=2).run(hamiltonian).get_container()
+        trotter = (
+            registry.create("hamiltonian_unitary_builder", "trotter", order=1, time=0.2, num_divisions=2)
+            .run(hamiltonian)
+            .get_container()
+        )
+
+        assert zassenhaus.step_reps == trotter.step_reps
+        assert [(t.pauli_term, t.angle) for t in zassenhaus.step_terms] == [
+            (t.pauli_term, t.angle) for t in trotter.step_terms
+        ]
+
+
+class TestZassenhausErrorScaling:
+    """Verify the operator-norm error scales as O(t^{p+1}) for orders p in {2, 3, 4}."""
+
+    @pytest.mark.parametrize("order", [2, 3, 4])
+    def test_heisenberg_scaling(self, order):
+        """Heisenberg 4-site open chain (K = 3 commuting groups) scales as O(t^{p+1})."""
+        slope = _fitted_error_slope(_heisenberg_hamiltonian(), order)
+        assert abs(slope - (order + 1)) < 0.1
+
+    @pytest.mark.parametrize("order", [2, 3, 4])
+    def test_h2_scaling(self, order):
+        """H2/STO-3G (K = 2 commuting groups, with an identity term) scales as O(t^{p+1})."""
+        slope = _fitted_error_slope(_h2_hamiltonian(), order)
+        assert abs(slope - (order + 1)) < 0.1
+
+    def test_more_accurate_than_first_order_trotter(self):
+        """At small t the order-2 Zassenhaus beats first-order Trotter on the same Hamiltonian."""
+        hamiltonian = _heisenberg_hamiltonian()
+        time = 0.05
+        trotter = registry.create("hamiltonian_unitary_builder", "trotter", time=time, num_divisions=1)
+        exact = _exact_unitary(hamiltonian, time)
+        trotter_error = np.linalg.norm(exact - _builder_unitary(trotter.run(hamiltonian).get_container()), 2)
+        zassenhaus_error = np.linalg.norm(exact - _zassenhaus_unitary(hamiltonian, time, order=2), 2)
+        assert zassenhaus_error < trotter_error
+
+
+class TestZassenhausPhaseEstimation:
+    """End-to-end phase-estimation tests using the Zassenhaus builder as the unitary source."""
+
+    @staticmethod
+    def _run_iqpe(
+        hamiltonian: QubitHamiltonian,
+        state_vector: np.ndarray,
+        *,
+        time: float,
+        num_bits: int,
+        order: int,
+        reference_energy: float,
+        num_divisions: int = 1,
+    ) -> float:
+        """Run iterative phase estimation with the Zassenhaus builder; return the estimated energy.
+
+        ``reference_energy`` selects which periodic phase-fraction branch (and
+        eigenstate) to resolve against.
+        """
+        num_qubits = int(np.log2(len(state_vector)))
+        params = {
+            "rowMap": list(range(num_qubits - 1, -1, -1)),
+            "stateVector": list(state_vector),
+            "expansionOps": [],
+            "numQubits": num_qubits,
+        }
+        qsharp_op = QSHARP_UTILS.StatePreparation.MakeStatePreparationOp(params)
+        factories = QsharpFactoryData(
+            program=QSHARP_UTILS.StatePreparation.MakeStatePreparationCircuit, parameter=params
+        )
+        circuit_builder = AlgorithmRef(
+            "qpe_circuit_builder",
+            "qdk_iterative",
+            num_bits=num_bits,
+            controlled_circuit_mapper=AlgorithmRef("controlled_circuit_mapper", "pauli_sequence"),
+            unitary_builder=AlgorithmRef(
+                "hamiltonian_unitary_builder", "zassenhaus", time=time, order=order, num_divisions=num_divisions
+            ),
+        )
+        iqpe = IterativePhaseEstimation(shots_per_bit=1)
+        iqpe.settings().set("qpe_circuit_builder", circuit_builder)
+        iqpe.settings().set("circuit_executor", AlgorithmRef("circuit_executor", "qdk_full_state_simulator", seed=42))
+        result = iqpe.run(
+            qubit_hamiltonian=hamiltonian,
+            state_preparation=Circuit(qsharp_factory=factories, qsharp_op=qsharp_op),
+        )
+        # Resolve the periodic phase-fraction branch closest to the reference energy.
+        candidates = [result.phase_fraction % 1.0, (1.0 - result.phase_fraction) % 1.0]
+        energies = [energy_from_phase(candidate, evolution_time=time) for candidate in candidates]
+        return energies[int(np.argmin([abs(energy - reference_energy) for energy in energies]))]
+
+    def test_consumed_by_phase_estimation_exact_for_commuting(self):
+        """A commuting Hamiltonian is evolved exactly, so QPE recovers the energy with no algorithmic error."""
+        hamiltonian = QubitHamiltonian(pauli_strings=["XX", "ZZ"], coefficients=[0.25, 0.5])
+        energy = self._run_iqpe(
+            hamiltonian,
+            np.array([0.6, 0.0, 0.0, 0.8]),
+            time=float(np.pi / 2),
+            num_bits=4,
+            order=2,
+            reference_energy=0.75,
+        )
+        assert np.isclose(energy, 0.75, atol=1e-9)
+
+    @pytest.mark.slow
+    def test_h2_ground_state_to_chemical_accuracy(self):
+        """Iterative QPE with the Zassenhaus builder recovers the H2 ground-state energy to 1.6e-3 Ha."""
+        hamiltonian = _h2_hamiltonian()
+        eigenvalues, eigenvectors = np.linalg.eigh(hamiltonian.to_matrix())
+        ground_energy = float(eigenvalues[0])
+        ground_state = eigenvectors[:, 0].real
+
+        energy = self._run_iqpe(
+            hamiltonian,
+            ground_state,
+            time=0.5,
+            num_bits=12,
+            order=4,
+            num_divisions=2,
+            reference_energy=ground_energy,
+        )
+        assert abs(energy - ground_energy) < 1.6e-3

--- a/python/tests/test_time_evolution_zassenhaus.py
+++ b/python/tests/test_time_evolution_zassenhaus.py
@@ -188,24 +188,6 @@ class TestZassenhausBuilder:
         error = np.linalg.norm(_exact_unitary(hamiltonian, time) - _builder_unitary(container), 2)
         assert error < target
 
-    def test_order_zero_selects_order_from_target_accuracy(self):
-        """order=0 picks the expansion order from target_accuracy (tighter -> higher order)."""
-        hamiltonian = _heisenberg_hamiltonian()
-        time = 0.1
-        loose = Zassenhaus(order=0, time=time, target_accuracy=1.0).run(hamiltonian).get_container()
-        tight = Zassenhaus(order=0, time=time, target_accuracy=1e-2).run(hamiltonian).get_container()
-        # A tighter accuracy selects a higher order, hence more terms per step.
-        assert len(tight.step_terms) > len(loose.step_terms)
-        # The auto-selected configuration meets the requested accuracy.
-        error = np.linalg.norm(_exact_unitary(hamiltonian, time) - _builder_unitary(tight), 2)
-        assert error < 1e-2
-
-    def test_order_zero_without_target_accuracy_raises(self):
-        """Automatic order selection needs an accuracy budget to choose from."""
-        hamiltonian = QubitHamiltonian(pauli_strings=["XX", "ZI"], coefficients=[0.7, 0.5])
-        with pytest.raises(ValueError, match="target_accuracy"):
-            Zassenhaus(order=0, time=0.1).run(hamiltonian)
-
     def test_accepts_partitioned_hamiltonian(self):
         """A Hamiltonian carrying a commuting term_partition is accepted (as trotter accepts)."""
         hamiltonian = _heisenberg_hamiltonian()
@@ -213,11 +195,11 @@ class TestZassenhausBuilder:
         unitary = Zassenhaus(order=2, time=0.05, num_divisions=1).run(partitioned)
         assert isinstance(unitary.get_container(), PauliProductFormulaContainer)
 
-    def test_unsupported_order_raises(self):
-        """Orders outside the supported {1, 2, 3, 4, 5, 6} range raise NotImplementedError."""
+    def test_invalid_order_raises(self):
+        """Orders below 1 are rejected (1 = Trotter fallback, >= 2 = Zassenhaus)."""
         hamiltonian = QubitHamiltonian(pauli_strings=["XX", "ZI"], coefficients=[0.7, 0.5])
-        with pytest.raises(NotImplementedError):
-            Zassenhaus(order=7, time=0.1).run(hamiltonian)
+        with pytest.raises(ValueError, match="order"):
+            Zassenhaus(order=0, time=0.1).run(hamiltonian)
 
     def test_order_one_falls_back_to_trotter(self):
         """Order 1 (no commutator corrections) reproduces the first-order Trotter product."""

--- a/python/tests/test_time_evolution_zassenhaus.py
+++ b/python/tests/test_time_evolution_zassenhaus.py
@@ -157,6 +157,39 @@ class TestZassenhausBuilder:
         container = Zassenhaus(order=2, time=0.2, num_divisions=4).run(hamiltonian).get_container()
         assert container.step_reps == 4
 
+    def test_num_divisions_below_one_raises(self):
+        """num_divisions < 1 is rejected at construction, not silently clamped."""
+        with pytest.raises(ValueError, match="num_divisions"):
+            Zassenhaus(order=2, time=0.1, num_divisions=0)
+
+    def test_target_accuracy_increases_divisions(self):
+        """A target_accuracy raises N automatically until the error meets the target."""
+        hamiltonian = _heisenberg_hamiltonian()
+        time = 1.0
+        target = 1e-2
+        container = Zassenhaus(order=2, time=time, target_accuracy=target).run(hamiltonian).get_container()
+        assert container.step_reps > 1  # auto-estimation engaged
+        error = np.linalg.norm(_exact_unitary(hamiltonian, time) - _builder_unitary(container), 2)
+        assert error < target
+
+    def test_order_zero_selects_order_from_target_accuracy(self):
+        """order=0 picks the expansion order from target_accuracy (tighter -> higher order)."""
+        hamiltonian = _heisenberg_hamiltonian()
+        time = 0.1
+        loose = Zassenhaus(order=0, time=time, target_accuracy=1.0).run(hamiltonian).get_container()
+        tight = Zassenhaus(order=0, time=time, target_accuracy=1e-2).run(hamiltonian).get_container()
+        # A tighter accuracy selects a higher order, hence more terms per step.
+        assert len(tight.step_terms) > len(loose.step_terms)
+        # The auto-selected configuration meets the requested accuracy.
+        error = np.linalg.norm(_exact_unitary(hamiltonian, time) - _builder_unitary(tight), 2)
+        assert error < 1e-2
+
+    def test_order_zero_without_target_accuracy_raises(self):
+        """Automatic order selection needs an accuracy budget to choose from."""
+        hamiltonian = QubitHamiltonian(pauli_strings=["XX", "ZI"], coefficients=[0.7, 0.5])
+        with pytest.raises(ValueError, match="target_accuracy"):
+            Zassenhaus(order=0, time=0.1).run(hamiltonian)
+
     def test_accepts_partitioned_hamiltonian(self):
         """A Hamiltonian carrying a commuting term_partition is accepted (as trotter accepts)."""
         hamiltonian = _heisenberg_hamiltonian()
@@ -165,10 +198,10 @@ class TestZassenhausBuilder:
         assert isinstance(unitary.get_container(), PauliProductFormulaContainer)
 
     def test_unsupported_order_raises(self):
-        """Orders outside the supported {1, 2, 3, 4} range raise NotImplementedError."""
+        """Orders outside the supported {1, 2, 3, 4, 5, 6} range raise NotImplementedError."""
         hamiltonian = QubitHamiltonian(pauli_strings=["XX", "ZI"], coefficients=[0.7, 0.5])
         with pytest.raises(NotImplementedError):
-            Zassenhaus(order=5, time=0.1).run(hamiltonian)
+            Zassenhaus(order=7, time=0.1).run(hamiltonian)
 
     def test_order_one_falls_back_to_trotter(self):
         """Order 1 (no commutator corrections) reproduces the first-order Trotter product."""
@@ -264,11 +297,18 @@ class TestZassenhausPhaseEstimation:
         return energies[int(np.argmin([abs(energy - reference_energy) for energy in energies]))]
 
     def test_consumed_by_phase_estimation_exact_for_commuting(self):
-        """A commuting Hamiltonian is evolved exactly, so QPE recovers the energy with no algorithmic error."""
+        """A commuting Hamiltonian is evolved exactly, so QPE recovers the energy with no algorithmic error.
+
+        ``H = 0.25 XX + 0.5 ZZ`` has the Bell state ``(|00> + |11>)/sqrt(2)`` as an
+        exact eigenstate with eigenvalue ``0.25 + 0.5 = 0.75`` (XX and ZZ both act
+        as +1 on it). Using a genuine eigenstate makes the result deterministic --
+        a non-eigenstate would collapse onto an eigenvalue only probabilistically.
+        """
         hamiltonian = QubitHamiltonian(pauli_strings=["XX", "ZZ"], coefficients=[0.25, 0.5])
+        bell = np.array([1.0, 0.0, 0.0, 1.0]) / np.sqrt(2.0)
         energy = self._run_iqpe(
             hamiltonian,
-            np.array([0.6, 0.0, 0.0, 0.8]),
+            bell,
             time=float(np.pi / 2),
             num_bits=4,
             order=2,


### PR DESCRIPTION
> **Note:** This is likely a late submission; I'm opening it mainly to finish an
> implementation I had already started, as a portfolio / learning piece. Sharing
> it in case any part is useful.

## Summary
Adds a `zassenhaus` HamiltonianUnitaryBuilder that constructs exp(-iHt) via the
Zassenhaus expansion (the dual of BCH), exposing low-order nested-commutator
corrections (C2..C4) as explicit factors rather than absorbing them into the
step count. Output is a PauliProductFormulaContainer of the same shape as the
trotter builder, consumable by PhaseEstimation without changes.

## Design
- Recursive K-group construction over internally-commuting groups; corrections
  evaluated against the exact remaining block. Each exp(-itG_i) is exact.
- Commutator-based corrections built from the Hamiltonian's Pauli terms.
- Orders 2-4 give O(t^{p+1}); order 1 falls back to first-order Trotter.
- Adaptive flattening (plain for orders 2-3, symmetric/Strang for order 4).

## Acceptance criteria
- [x] "zassenhaus" factory registered; accepts trotter inputs; returns
      PauliProductFormulaContainer.
- [x] Error-norm slope p+1 (±0.1) for p in {2,3,4} on 4-site open Heisenberg
      (J=1) and H2/STO-3G (JW).
- [x] Iterative QPE recovers H2/STO-3G ground-state energy to 1.6e-3 Ha.
- [x] New pytest module; existing suite continues to pass.
- [x] Docs ("Available implementations") + references.bib (Wilcox 1967, Casas 2012).

Notes:
- The slope is fit over [1e-2, 1e-1] (upper decade of the criterion's [1e-3, 1e-1]);
  for order 4 the O(t^5) error near t=1e-3 (~1e-13) underflows to the
  double-precision floor.
- Gate-count reduction (merging redundant rotations at division / Suzuki-copy
  boundaries, group ordering, layer parallelism) is left as a follow-up optimization.

## AI disclosure
I used Claude (Claude Code) to help draft the implementation, tests, and docs,
which I then reviewed line-by-line, ran locally, and verified.

Closes #483
