### PR TITLE
Specialized fast paths in `QdkQubitMapper`

### DIFF
--- a/cpp/include/qdk/chemistry/data/lattice_graph.hpp
+++ b/cpp/include/qdk/chemistry/data/lattice_graph.hpp
@@ -232,7 +232,7 @@ class LatticeGraph : public DataClass {
    * @throws std::invalid_argument If n == 0.
    */
   static LatticeGraph chain(std::uint64_t n, bool periodic = false,
-                            double t = 1.0);
+                            double t = 1.0, bool optimal_ordering = false);
 
   /**
    * @brief Create a two-dimensional square lattice.
@@ -266,7 +266,7 @@ class LatticeGraph : public DataClass {
    */
   static LatticeGraph square(std::uint64_t nx, std::uint64_t ny,
                              bool periodic_x = false, bool periodic_y = false,
-                             double t = 1.0);
+                             double t = 1.0, bool optimal_ordering = false);
 
   /**
    * @brief Create a two-dimensional triangular lattice.
@@ -305,7 +305,8 @@ class LatticeGraph : public DataClass {
   static LatticeGraph triangular(std::uint64_t nx, std::uint64_t ny,
                                  bool periodic_x = false,
                                  bool periodic_y = false, double t = 1.0,
-                                 int coloring_seed = 0);
+                                 int coloring_seed = 0,
+                                 bool optimal_ordering = false);
 
   /**
    * @brief Create a two-dimensional honeycomb lattice.
@@ -344,7 +345,8 @@ class LatticeGraph : public DataClass {
    */
   static LatticeGraph honeycomb(std::uint64_t nx, std::uint64_t ny,
                                 bool periodic_x = false,
-                                bool periodic_y = false, double t = 1.0);
+                                bool periodic_y = false, double t = 1.0,
+                                bool optimal_ordering = false);
 
   /**
    * @brief Create a two-dimensional kagome lattice.
@@ -394,7 +396,8 @@ class LatticeGraph : public DataClass {
    */
   static LatticeGraph kagome(std::uint64_t nx, std::uint64_t ny,
                              bool periodic_x = false, bool periodic_y = false,
-                             double t = 1.0, int coloring_seed = 0);
+                             double t = 1.0, int coloring_seed = 0,
+                             bool optimal_ordering = false);
 
   /**
    * @brief Edge coloring stored at construction time, if any.
@@ -494,6 +497,22 @@ class LatticeGraph : public DataClass {
   /** @brief Check if a sparse matrix is symmetric within a numerical tolerance.
    */
   static bool _check_symmetry(const Eigen::SparseMatrix<double>& mat);
+
+  /**
+   * @brief Permutes the vertices of the lattice graph according to the given
+   * path.
+   *
+   * Reorders the sparse adjacency matrix using Eigen's permutation operations
+   * and updates the edge coloring to align with the new vertex indexing.
+   *
+   * @param graph The source lattice graph to permute.
+   * @param path The sequence of original vertex indices representing the target
+   * permutation.
+   * @return A new LatticeGraph with the permuted adjacency matrix and edge
+   * coloring.
+   */
+  static LatticeGraph permute(const LatticeGraph& graph,
+                              const std::vector<std::uint64_t>& path);
 
   /// Number of sites (vertices) in the lattice
   std::uint64_t _num_sites;

--- a/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
+++ b/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
@@ -18,6 +18,8 @@
 
 namespace qdk::chemistry::data {
 
+class LatticeGraph;
+
 /**
  * @brief Data class describing a fermion-to-qubit encoding.
  *
@@ -101,6 +103,12 @@ class MajoranaMapping : public DataClass {
     return tapering_;
   }
 
+  /// Grid X dimension (for Verstraete-Cirac mapping).
+  std::size_t grid_nx() const { return grid_nx_; }
+
+  /// Grid Y dimension (for Verstraete-Cirac mapping).
+  std::size_t grid_ny() const { return grid_ny_; }
+
   /**
    * @brief Return a copy with tapering removed and the base encoding name
    *        restored.
@@ -160,6 +168,19 @@ class MajoranaMapping : public DataClass {
                                    const std::string& type);
 
   // --- Factory methods for standard encodings ---
+
+  /**
+   * @brief Verstraete-Cirac encoding.
+   *
+   * Maps fermionic modes on a 2D square lattice to qubits.
+   *
+   * @param lattice The 2D square lattice connectivity.
+   * @param num_spin_species Number of spin species (usually 2 for spinful, 1
+   * for spinless). Default: 2.
+   * @return MajoranaMapping with name ``"verstraete-cirac"``.
+   */
+  static MajoranaMapping verstraete_cirac(const LatticeGraph& lattice,
+                                          std::size_t num_spin_species = 2);
 
   /**
    * @brief Jordan-Wigner encoding.
@@ -250,7 +271,8 @@ class MajoranaMapping : public DataClass {
       std::vector<std::pair<std::complex<double>, SparsePauliWord>> bilinears,
       std::string name, std::size_t num_modes, std::size_t num_qubits,
       std::string base_encoding,
-      std::optional<TaperingSpecification> tapering = std::nullopt);
+      std::optional<TaperingSpecification> tapering = std::nullopt,
+      std::size_t grid_nx = 0, std::size_t grid_ny = 0);
 
   /// Majorana-to-Pauli table (empty for bilinear-only mappings).
   std::vector<SparsePauliWord> table_;

--- a/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
+++ b/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
@@ -353,10 +353,17 @@ struct MajoranaMapResult {
  * @param integral_threshold Integrals with |value| < this are skipped.
  * @return MajoranaMapResult with Pauli words and coefficients.
  */
+class Hamiltonian;
+
 MajoranaMapResult majorana_map_hamiltonian(
     const MajoranaMapping& mapping, double core_energy, const double* h1_alpha,
     const double* h1_beta, const double* eri_aaaa, const double* eri_aabb,
     const double* eri_bbbb, std::size_t n_spatial, bool spin_symmetric,
     double threshold, double integral_threshold);
+
+MajoranaMapResult majorana_map_hamiltonian(const MajoranaMapping& mapping,
+                                           const Hamiltonian& hamiltonian,
+                                           double threshold,
+                                           double integral_threshold);
 
 }  // namespace qdk::chemistry::data

--- a/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
+++ b/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
@@ -258,9 +258,9 @@ class MajoranaMapping : public DataClass {
   /**
    * @brief Verstraete-Cirac encoding.
    *
-   * Maps fermionic modes on a 2D square lattice to qubits.
+   * Maps fermionic modes on a `LatticeGraph` to qubits.
    *
-   * @param lattice The 2D square lattice connectivity.
+   * @param lattice The `LatticeGraph` connectivity.
    * @param num_spin_species Number of spin species (usually 2 for spinful, 1
    *        for spinless). Default: 2.
    * @return MajoranaMapping with name ``"verstraete-cirac"``.

--- a/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
+++ b/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
@@ -103,11 +103,14 @@ class MajoranaMapping : public DataClass {
     return tapering_;
   }
 
-  /// Grid X dimension (for Verstraete-Cirac mapping).
-  std::size_t grid_nx() const { return grid_nx_; }
-
-  /// Grid Y dimension (for Verstraete-Cirac mapping).
-  std::size_t grid_ny() const { return grid_ny_; }
+  /**
+   * @brief Stabilizer terms carried by this mapping.
+   * @return Reference to the vector of stabilizers.
+   */
+  const std::vector<std::pair<std::complex<double>, SparsePauliWord>>&
+  stabilizers() const {
+    return stabilizers_;
+  }
 
   /**
    * @brief Return a copy with tapering removed and the base encoding name
@@ -168,19 +171,6 @@ class MajoranaMapping : public DataClass {
                                    const std::string& type);
 
   // --- Factory methods for standard encodings ---
-
-  /**
-   * @brief Verstraete-Cirac encoding.
-   *
-   * Maps fermionic modes on a 2D square lattice to qubits.
-   *
-   * @param lattice The 2D square lattice connectivity.
-   * @param num_spin_species Number of spin species (usually 2 for spinful, 1
-   * for spinless). Default: 2.
-   * @return MajoranaMapping with name ``"verstraete-cirac"``.
-   */
-  static MajoranaMapping verstraete_cirac(const LatticeGraph& lattice,
-                                          std::size_t num_spin_species = 2);
 
   /**
    * @brief Jordan-Wigner encoding.
@@ -265,6 +255,19 @@ class MajoranaMapping : public DataClass {
   static MajoranaMapping symmetry_conserving_bravyi_kitaev(
       std::size_t num_modes, std::size_t n_alpha, std::size_t n_beta);
 
+  /**
+   * @brief Verstraete-Cirac encoding.
+   *
+   * Maps fermionic modes on a 2D square lattice to qubits.
+   *
+   * @param lattice The 2D square lattice connectivity.
+   * @param num_spin_species Number of spin species (usually 2 for spinful, 1
+   *        for spinless). Default: 2.
+   * @return MajoranaMapping with name ``"verstraete-cirac"``.
+   */
+  static MajoranaMapping verstraete_cirac(const LatticeGraph& lattice,
+                                          std::size_t num_spin_species = 2);
+
  private:
   MajoranaMapping(
       std::vector<SparsePauliWord> table,
@@ -272,7 +275,8 @@ class MajoranaMapping : public DataClass {
       std::string name, std::size_t num_modes, std::size_t num_qubits,
       std::string base_encoding,
       std::optional<TaperingSpecification> tapering = std::nullopt,
-      std::size_t grid_nx = 0, std::size_t grid_ny = 0);
+      std::vector<std::pair<std::complex<double>, SparsePauliWord>>
+          stabilizers = {});
 
   /// Majorana-to-Pauli table (empty for bilinear-only mappings).
   std::vector<SparsePauliWord> table_;
@@ -300,6 +304,9 @@ class MajoranaMapping : public DataClass {
 
   /// Feed the mapping's identifying data into a content hash.
   void hash_update(qdk::chemistry::utils::HashContext& ctx) const override;
+
+  /// Optional stabilizer terms.
+  std::vector<std::pair<std::complex<double>, SparsePauliWord>> stabilizers_;
 
   /// Upper-triangle index: (j, k) with j < k, M = 2*num_modes.
   std::size_t bilinear_index(std::size_t j, std::size_t k) const {

--- a/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
+++ b/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
@@ -261,12 +261,9 @@ class MajoranaMapping : public DataClass {
    * Maps fermionic modes on a `LatticeGraph` to qubits.
    *
    * @param lattice The `LatticeGraph` connectivity.
-   * @param num_spin_species Number of spin species (usually 2 for spinful, 1
-   *        for spinless). Default: 2.
    * @return MajoranaMapping with name ``"verstraete-cirac"``.
    */
-  static MajoranaMapping verstraete_cirac(const LatticeGraph& lattice,
-                                          std::size_t num_spin_species = 2);
+  static MajoranaMapping verstraete_cirac(const LatticeGraph& lattice);
 
  private:
   MajoranaMapping(

--- a/cpp/src/qdk/chemistry/data/lattice_graph.cpp
+++ b/cpp/src/qdk/chemistry/data/lattice_graph.cpp
@@ -28,6 +28,44 @@ static void add_edge(std::vector<Triplet>& triplets, int i, int j, double t) {
   triplets.emplace_back(i, j, t);
   triplets.emplace_back(j, i, t);
 }
+
+bool find_hamiltonian_path_dfs(std::uint64_t curr,
+                               const Eigen::SparseMatrix<double>& adj,
+                               std::vector<bool>& visited,
+                               std::vector<std::uint64_t>& path) {
+  path.push_back(curr);
+  if (path.size() == static_cast<std::size_t>(adj.rows())) {
+    return true;
+  }
+  visited[curr] = true;
+
+  // Iterate directly over the sparse matrix columns/rows for neighbors
+  for (Eigen::SparseMatrix<double>::InnerIterator it(adj, curr); it; ++it) {
+    std::uint64_t neighbor = it.row();
+    if (neighbor != curr && !visited[neighbor]) {
+      if (find_hamiltonian_path_dfs(neighbor, adj, visited, path)) {
+        return true;
+      }
+    }
+  }
+  visited[curr] = false;
+  path.pop_back();
+  return false;
+}
+
+std::vector<std::uint64_t> find_hamiltonian_path(
+    const Eigen::SparseMatrix<double>& adj) {
+  std::uint64_t V = adj.rows();
+  std::vector<bool> visited(V, false);
+  std::vector<std::uint64_t> path;
+  for (std::uint64_t start = 0; start < V; ++start) {
+    if (find_hamiltonian_path_dfs(start, adj, visited, path)) {
+      return path;
+    }
+  }
+  return {};
+}
+
 }  // namespace detail
 
 LatticeGraph::LatticeGraph(
@@ -164,7 +202,8 @@ std::uint64_t LatticeGraph::num_edges() const {
   return count;
 }
 
-LatticeGraph LatticeGraph::chain(std::uint64_t n, bool periodic, double t) {
+LatticeGraph LatticeGraph::chain(std::uint64_t n, bool periodic, double t,
+                                 bool optimal_ordering) {
   if (n == 0) {
     throw std::invalid_argument("chain: n must be > 0.");
   }
@@ -186,12 +225,23 @@ LatticeGraph LatticeGraph::chain(std::uint64_t n, bool periodic, double t) {
   Eigen::SparseMatrix<double> adj(N, N);
   adj.setFromTriplets(triplets.begin(), triplets.end());
   adj.makeCompressed();
-  return LatticeGraph(std::move(adj),
-                      chain_coloring(static_cast<std::int64_t>(N), periodic));
+  LatticeGraph g(std::move(adj),
+                 chain_coloring(static_cast<std::int64_t>(N), periodic));
+  if (optimal_ordering) {
+    auto path = detail::find_hamiltonian_path(g.sparse_adjacency_matrix());
+    if (!path.empty()) {
+      return permute(g, path);
+    } else {
+      throw std::runtime_error(
+          "No Hamiltonian path found in the lattice graph.");
+    }
+  }
+  return g;
 }
 
 LatticeGraph LatticeGraph::square(std::uint64_t nx, std::uint64_t ny,
-                                  bool periodic_x, bool periodic_y, double t) {
+                                  bool periodic_x, bool periodic_y, double t,
+                                  bool optimal_ordering) {
   if (nx == 0 || ny == 0) {
     throw std::invalid_argument("square: nx and ny must be > 0.");
   }
@@ -234,13 +284,24 @@ LatticeGraph LatticeGraph::square(std::uint64_t nx, std::uint64_t ny,
   Eigen::SparseMatrix<double> adj(N, N);
   adj.setFromTriplets(triplets.begin(), triplets.end());
   adj.makeCompressed();
-  return LatticeGraph(std::move(adj),
-                      square_coloring(Nx, Ny, periodic_x, periodic_y));
+  LatticeGraph g(std::move(adj),
+                 square_coloring(Nx, Ny, periodic_x, periodic_y));
+  if (optimal_ordering) {
+    auto path = detail::find_hamiltonian_path(g.sparse_adjacency_matrix());
+    if (!path.empty()) {
+      return permute(g, path);
+    } else {
+      throw std::runtime_error(
+          "No Hamiltonian path found in the lattice graph.");
+    }
+  }
+  return g;
 }
 
 LatticeGraph LatticeGraph::triangular(std::uint64_t nx, std::uint64_t ny,
                                       bool periodic_x, bool periodic_y,
-                                      double t, int coloring_seed) {
+                                      double t, int coloring_seed,
+                                      bool optimal_ordering) {
   if (nx == 0 || ny == 0) {
     throw std::invalid_argument("triangular: nx and ny must be > 0.");
   }
@@ -295,13 +356,23 @@ LatticeGraph LatticeGraph::triangular(std::uint64_t nx, std::uint64_t ny,
   adj.makeCompressed();
   // No known deterministic coloring for triangular lattices with arbitrary
   // periodic boundaries; use greedy with multiple trials instead.
-  return LatticeGraph(std::move(adj),
-                      greedy_edge_coloring(adj, coloring_seed, 32));
+  LatticeGraph g(std::move(adj), greedy_edge_coloring(adj, coloring_seed, 32));
+  if (optimal_ordering) {
+    auto path = detail::find_hamiltonian_path(g.sparse_adjacency_matrix());
+    if (!path.empty()) {
+      return permute(g, path);
+    } else {
+      throw std::runtime_error(
+          "No Hamiltonian path found in the lattice graph.");
+    }
+  }
+  return g;
 }
 
 LatticeGraph LatticeGraph::honeycomb(std::uint64_t nx, std::uint64_t ny,
-                                     bool periodic_x, bool periodic_y,
-                                     double t) {
+                                     bool periodic_x, bool periodic_y, double t,
+                                     bool optimal_ordering) {
+  (void)optimal_ordering;
   if (nx == 0 || ny == 0) {
     throw std::invalid_argument("honeycomb: nx and ny must be > 0.");
   }
@@ -354,7 +425,8 @@ LatticeGraph LatticeGraph::honeycomb(std::uint64_t nx, std::uint64_t ny,
 
 LatticeGraph LatticeGraph::kagome(std::uint64_t nx, std::uint64_t ny,
                                   bool periodic_x, bool periodic_y, double t,
-                                  int coloring_seed) {
+                                  int coloring_seed, bool optimal_ordering) {
+  (void)optimal_ordering;
   if (nx == 0 || ny == 0) {
     throw std::invalid_argument("kagome: nx and ny must be > 0.");
   }
@@ -947,6 +1019,40 @@ void LatticeGraph::hash_update(qdk::chemistry::utils::HashContext& ctx) const {
   hash_value(ctx, static_cast<uint64_t>(_num_sites));
   hash_value(ctx, adjacency_);
   hash_value(ctx, _is_symmetric);
+}
+
+LatticeGraph LatticeGraph::permute(const LatticeGraph& graph,
+                                   const std::vector<std::uint64_t>& path) {
+  std::uint64_t V = graph.num_sites();
+  const auto& adj = graph.sparse_adjacency_matrix();
+
+  // Reorder the adjacency matrix using Eigen's PermutationMatrix
+  Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic, int> P(
+      static_cast<Eigen::Index>(V));
+  for (std::uint64_t i = 0; i < V; ++i) {
+    P.indices()[static_cast<Eigen::Index>(i)] = static_cast<int>(path[i]);
+  }
+  Eigen::SparseMatrix<double> new_adj = P * adj * P.transpose();
+  new_adj.makeCompressed();
+
+  std::vector<std::uint64_t> inv_p(V);
+  for (std::uint64_t i = 0; i < V; ++i) {
+    inv_p[path[i]] = i;
+  }
+
+  std::optional<EdgeColoring> new_coloring = std::nullopt;
+  if (graph.edge_coloring().has_value()) {
+    EdgeColoring coloring;
+    for (const auto& [edge, color] : *(graph.edge_coloring())) {
+      std::uint64_t new_u = inv_p[edge.first];
+      std::uint64_t new_v = inv_p[edge.second];
+      auto new_edge = std::minmax(new_u, new_v);
+      coloring[{new_edge.first, new_edge.second}] = color;
+    }
+    new_coloring = std::move(coloring);
+  }
+
+  return LatticeGraph(std::move(new_adj), std::move(new_coloring));
 }
 
 }  // namespace qdk::chemistry::data

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -198,6 +198,8 @@ MajoranaMapResult majorana_map_impl(
     const double* eri_bbbb, std::size_t n_spatial, bool spin_symmetric,
     double threshold, double integral_threshold) {
   const std::size_t n_modes = 2 * n_spatial;
+  const std::size_t num_spin_species =
+      (mapping.num_modes() < 2 * n_spatial) ? 1 : 2;
 
   PackedAccumulator<NW> acc;
 
@@ -231,9 +233,6 @@ MajoranaMapResult majorana_map_impl(
     }
     return cache;
   };
-
-  const std::size_t num_spin_species = (mapping.num_modes() < 2 * n_spatial) ? 1 : 2;
-  const bool use_spin_symmetric = spin_symmetric && (num_spin_species == 2);
 
   auto ppair_alpha = build_pair_cache(alpha_offset);
   std::vector<PackedPairProduct> ppair_beta;
@@ -287,8 +286,8 @@ MajoranaMapResult majorana_map_impl(
   for (std::size_t p = 0; p < n_spatial; ++p) {
     for (std::size_t s = 0; s < n_spatial; ++s) {
       double h_a = h1_alpha[p * n_spatial + s];
-      double h_b = use_spin_symmetric ? h_a : h1_beta[p * n_spatial + s];
-      if (use_spin_symmetric) {
+      double h_b = spin_symmetric ? h_a : h1_beta[p * n_spatial + s];
+      if (spin_symmetric) {
         double delta_corr = 0.0;
         for (std::size_t q = 0; q < n_spatial; ++q) {
           delta_corr += eri_aaaa[idx4(p, q, q, s)];
@@ -318,7 +317,7 @@ MajoranaMapResult majorana_map_impl(
 
   // ─── Two-body terms ───────────────────────────────────────────────
 
-  if (use_spin_symmetric) {
+  if (spin_symmetric) {
     struct SpinSummedE {
       std::vector<std::pair<std::complex<double>, PackedPauliWord<NW>>> terms;
     };
@@ -332,9 +331,11 @@ MajoranaMapResult majorana_map_impl(
             const auto& [coeff_a, word_a] = alpha_pair(2 * p + a, 2 * q + b);
             sse.terms.emplace_back(coeff_a * 0.25 * excitation_coeff[a][b],
                                    word_a);
-            const auto& [coeff_b, word_b] = beta_pair(2 * p + a, 2 * q + b);
-            sse.terms.emplace_back(coeff_b * 0.25 * excitation_coeff[a][b],
-                                   word_b);
+            if (num_spin_species == 2) {
+              const auto& [coeff_b, word_b] = beta_pair(2 * p + a, 2 * q + b);
+              sse.terms.emplace_back(coeff_b * 0.25 * excitation_coeff[a][b],
+                                     word_b);
+            }
           }
         }
       }
@@ -459,8 +460,8 @@ MajoranaMapResult majorana_map_impl(
       }
     }
 
+    // ββ channel
     if (num_spin_species == 2) {
-      // ββ channel
       for (std::size_t p = 0; p < n_spatial; ++p) {
         for (std::size_t q = 0; q < n_spatial; ++q) {
           for (std::size_t r = 0; r < n_spatial; ++r) {
@@ -476,8 +477,10 @@ MajoranaMapResult majorana_map_impl(
           }
         }
       }
+    }
 
-      // αβ + βα cross-spin channels, related by Coulomb symmetry (pq|rs)=(rs|pq)
+    // αβ + βα cross-spin channels, related by Coulomb symmetry (pq|rs)=(rs|pq)
+    if (num_spin_species == 2) {
       for (std::size_t p = 0; p < n_spatial; ++p) {
         for (std::size_t q = 0; q < n_spatial; ++q) {
           for (std::size_t r = 0; r < n_spatial; ++r) {
@@ -495,18 +498,13 @@ MajoranaMapResult majorana_map_impl(
     }
   }
 
-  if (mapping.base_encoding() == "verstraete-cirac" && mapping.grid_nx() > 0 &&
-      mapping.grid_ny() > 0) {
-    std::uint64_t nx = mapping.grid_nx();
-    std::uint64_t ny = mapping.grid_ny();
-    std::uint64_t V = nx * ny;
-
+  if (!mapping.stabilizers().empty()) {
     double h1_sum = 0.0;
     for (std::size_t p = 0; p < n_spatial; ++p) {
       for (std::size_t q = 0; q < n_spatial; ++q) {
         h1_sum += std::abs(h1_alpha[p * n_spatial + q]);
         if (num_spin_species == 2) {
-          if (!use_spin_symmetric) {
+          if (!spin_symmetric) {
             h1_sum += std::abs(h1_beta[p * n_spatial + q]);
           } else {
             h1_sum += std::abs(h1_alpha[p * n_spatial + q]);
@@ -516,101 +514,13 @@ MajoranaMapResult majorana_map_impl(
     }
     double aux_ham_coefficient = 1.0 + h1_sum;
 
-    std::size_t num_modes = mapping.num_modes();
-    std::size_t base_modes = 2 * num_modes;
-    auto jw_base = MajoranaMapping::jordan_wigner(base_modes);
-    std::size_t num_spin_species = num_modes / V;
-
-    auto get_snake_coordinates =
-        [&](std::uint64_t index) -> std::pair<std::uint64_t, std::uint64_t> {
-      std::uint64_t row = index / nx;
-      std::uint64_t col;
-      if (row % 2 == 0) {
-        col = index % nx;
-      } else {
-        col = nx - 1 - (index % nx);
-      }
-      return {col, row};
-    };
-
-    auto get_snake_index = [&](std::uint64_t col,
-                               std::uint64_t row) -> std::uint64_t {
-      if (row % 2 == 0) {
-        return row * nx + col;
-      } else {
-        return (row + 1) * nx - 1 - col;
-      }
-    };
-
-    auto get_stabilizer = [&](std::size_t u, std::size_t v)
-        -> std::pair<std::complex<double>, PackedPauliWord<NW>> {
-      std::size_t s_u = (u - 1) / (2 * V);
-      std::size_t i = ((u - 1) / 2) % V;
-      std::size_t j = ((v - 1) / 2) % V;
-
-      std::size_t top = std::min(i, j);
-      std::size_t bot = std::max(i, j);
-      auto coord_top = get_snake_coordinates(top);
-      std::size_t col = coord_top.first;
-
-      std::size_t top_aux_mode = 2 * s_u * V + 2 * top + 1;
-      std::size_t bot_aux_mode = 2 * s_u * V + 2 * bot + 1;
-
-      std::size_t p, q;
-      if (col % 2 == 0) {
-        p = 2 * top_aux_mode;
-        q = 2 * bot_aux_mode + 1;
-      } else {
-        p = 2 * bot_aux_mode;
-        q = 2 * top_aux_mode + 1;
-      }
-
-      auto [coeff_stab, word_stab] = jw_base.bilinear(p, q);
-      return {coeff_stab, sparse_to_packed<NW>(word_stab)};
-    };
-
-    // Calculate number of plaquettes per spin sector: (nx - 1) * (ny - 1)
-    std::size_t num_plaquettes = (nx - 1) * (ny - 1);
-
     PackedPauliWord<NW> identity{};
     acc.accumulate(
-        identity,
-        std::complex<double>(
-            aux_ham_coefficient * num_plaquettes * num_spin_species, 0.0));
+        identity, std::complex<double>(
+                      aux_ham_coefficient * mapping.stabilizers().size(), 0.0));
 
-    for (std::size_t s = 0; s < num_spin_species; ++s) {
-      for (std::uint64_t k = 0; k < nx - 1; ++k) {
-        for (std::uint64_t l = 0; l < ny - 1; ++l) {
-          // Sites of the plaquette
-          std::uint64_t i00 = get_snake_index(k, l);
-          std::uint64_t i10 = get_snake_index(k + 1, l);
-          std::uint64_t i01 = get_snake_index(k, l + 1);
-          std::uint64_t i11 = get_snake_index(k + 1, l + 1);
-
-          // Expanded auxiliary modes
-          std::uint64_t u00 = 2 * s * V + 2 * i00 + 1;
-          std::uint64_t u10 = 2 * s * V + 2 * i10 + 1;
-          std::uint64_t u01 = 2 * s * V + 2 * i01 + 1;
-          std::uint64_t u11 = 2 * s * V + 2 * i11 + 1;
-
-          // Get the 4 link stabilizers
-          auto [c_v1, w_v1] = get_stabilizer(u00, u01);
-          auto [c_v2, w_v2] = get_stabilizer(u10, u11);
-          auto [c_h_bot, w_h_bot] = get_stabilizer(u00, u10);
-          auto [c_h_top, w_h_top] = get_stabilizer(u01, u11);
-
-          // Multiply them: plaquette = w_v1 * w_v2 * w_h_bot * w_h_top
-          auto [phase1, w_tmp1] = multiply_packed(w_v1, w_v2);
-          auto [phase2, w_tmp2] = multiply_packed(w_h_bot, w_h_top);
-          auto [phase3, w_final] = multiply_packed(w_tmp1, w_tmp2);
-
-          std::complex<double> coeff_final =
-              c_v1 * c_v2 * c_h_bot * c_h_top * apply_phase(phase1, 1.0) *
-              apply_phase(phase2, 1.0) * apply_phase(phase3, 1.0);
-
-          acc.accumulate(w_final, -aux_ham_coefficient * coeff_final);
-        }
-      }
+    for (const auto& [coeff, word] : mapping.stabilizers()) {
+      acc.accumulate(sparse_to_packed<NW>(word), -aux_ham_coefficient * coeff);
     }
   }
 

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -512,6 +512,9 @@ MajoranaMapResult majorana_map_impl(
         }
       }
     }
+    // If stabilizers are included in the mapping, our total Hamiltonian becomes
+    // H_total = H_physical + H_aux. We add H_aux = λ · Σ_i (I − S_i) to
+    // penalize unphysical codespace sectors.
     double aux_ham_coefficient = 1.0 + h1_sum;
 
     PackedPauliWord<NW> identity{};

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -2,12 +2,17 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
 
+#include <Eigen/Dense>
+#include <Eigen/Sparse>
 #include <array>
 #include <bit>
 #include <cmath>
 #include <complex>
 #include <cstddef>
 #include <cstdint>
+#include <qdk/chemistry/data/hamiltonian.hpp>
+#include <qdk/chemistry/data/hamiltonian_containers/cholesky.hpp>
+#include <qdk/chemistry/data/hamiltonian_containers/sparse.hpp>
 #include <qdk/chemistry/data/majorana_mapping.hpp>
 #include <qdk/chemistry/data/pauli_operator.hpp>
 #include <qdk/chemistry/utils/hash_context.hpp>
@@ -167,6 +172,248 @@ class PackedAccumulator {
       terms_;
 };
 
+// ─── EriProvider Architectures ──────────────────────────────────────
+
+class DenseEriProvider {
+ public:
+  static constexpr bool kSparse = false;
+  DenseEriProvider(const double* aaaa_ptr, const double* aabb_ptr,
+                   const double* bbbb_ptr, size_t n_spatial)
+      : aaaa_ptr_(aaaa_ptr),
+        aabb_ptr_(aabb_ptr),
+        bbbb_ptr_(bbbb_ptr),
+        n_spatial_(n_spatial) {}
+
+  void build_row_aaaa(size_t ij) { row_offset_ = ij * n_spatial_ * n_spatial_; }
+  void build_row_aabb(size_t ij) { row_offset_ = ij * n_spatial_ * n_spatial_; }
+  void build_row_bbbb(size_t ij) { row_offset_ = ij * n_spatial_ * n_spatial_; }
+
+  double aaaa(size_t kl) const { return aaaa_ptr_[row_offset_ + kl]; }
+  double aabb(size_t kl) const { return aabb_ptr_[row_offset_ + kl]; }
+  double bbbb(size_t kl) const { return bbbb_ptr_[row_offset_ + kl]; }
+
+  double get_element(size_t p, size_t q, size_t r, size_t s,
+                     SpinChannel channel) const {
+    size_t idx = ((p * n_spatial_ + q) * n_spatial_ + r) * n_spatial_ + s;
+    if (channel == SpinChannel::aaaa) return aaaa_ptr_[idx];
+    if (channel == SpinChannel::aabb) return aabb_ptr_[idx];
+    if (channel == SpinChannel::bbbb) return bbbb_ptr_[idx];
+    return 0.0;
+  }
+
+ private:
+  const double* aaaa_ptr_;
+  const double* aabb_ptr_;
+  const double* bbbb_ptr_;
+  size_t n_spatial_;
+  size_t row_offset_ = 0;
+};
+
+class CholeskyEriProvider {
+ public:
+  static constexpr bool kSparse = false;
+  CholeskyEriProvider(const Eigen::MatrixXd& L_alpha,
+                      const Eigen::MatrixXd& L_beta, size_t n_spatial,
+                      bool restricted)
+      : L_alpha_(L_alpha),
+        L_beta_(L_beta),
+        n_spatial_(n_spatial),
+        norb2_(n_spatial * n_spatial),
+        restricted_(restricted) {
+    aaaa_row_.resize(norb2_);
+    if (!restricted_) {
+      aabb_row_.resize(norb2_);
+      bbbb_row_.resize(norb2_);
+    }
+  }
+
+  void build_row_aaaa(size_t ij) {
+    if (ij == cached_aaaa_ij_) return;
+    build_row_impl(ij, aaaa_row_.data(), L_alpha_, L_alpha_);
+    cached_aaaa_ij_ = ij;
+  }
+
+  void build_row_aabb(size_t ij) {
+    if (restricted_) return;
+    if (ij == cached_aabb_ij_) return;
+    build_row_impl(ij, aabb_row_.data(), L_alpha_, L_beta_);
+    cached_aabb_ij_ = ij;
+  }
+
+  void build_row_bbbb(size_t ij) {
+    if (restricted_) return;
+    if (ij == cached_bbbb_ij_) return;
+    build_row_impl(ij, bbbb_row_.data(), L_beta_, L_beta_);
+    cached_bbbb_ij_ = ij;
+  }
+
+  double aaaa(size_t kl) const { return aaaa_row_[kl]; }
+  double aabb(size_t kl) const {
+    return restricted_ ? aaaa_row_[kl] : aabb_row_[kl];
+  }
+  double bbbb(size_t kl) const {
+    return restricted_ ? aaaa_row_[kl] : bbbb_row_[kl];
+  }
+
+  double get_element(size_t p, size_t q, size_t r, size_t s,
+                     SpinChannel channel) const {
+    size_t ij = p * n_spatial_ + q;
+    size_t kl = r * n_spatial_ + s;
+    if (restricted_) {
+      return L_alpha_.row(ij).dot(L_alpha_.row(kl));
+    }
+    if (channel == SpinChannel::aaaa) {
+      return L_alpha_.row(ij).dot(L_alpha_.row(kl));
+    } else if (channel == SpinChannel::bbbb) {
+      return L_beta_.row(ij).dot(L_beta_.row(kl));
+    } else if (channel == SpinChannel::aabb) {
+      return L_alpha_.row(ij).dot(L_beta_.row(kl));
+    }
+    return 0.0;
+  }
+
+ private:
+  void build_row_impl(size_t ij, double* out_buffer,
+                      const Eigen::MatrixXd& L_left,
+                      const Eigen::MatrixXd& L_right) {
+    Eigen::Map<Eigen::VectorXd> out_view(out_buffer, norb2_);
+    out_view.setZero();
+    size_t naux = L_right.cols();
+    for (size_t Q = 0; Q < naux; ++Q) {
+      double w = L_left(ij, Q);
+      if (std::abs(w) < 1e-15) continue;
+      Eigen::Map<const Eigen::VectorXd> col_view(L_right.data() + Q * norb2_,
+                                                 norb2_);
+      out_view += w * col_view;
+    }
+  }
+
+  const Eigen::MatrixXd& L_alpha_;
+  const Eigen::MatrixXd& L_beta_;
+  size_t n_spatial_;
+  size_t norb2_;
+  bool restricted_;
+  std::vector<double> aaaa_row_;
+  std::vector<double> aabb_row_;
+  std::vector<double> bbbb_row_;
+  size_t cached_aaaa_ij_ = -1;
+  size_t cached_aabb_ij_ = -1;
+  size_t cached_bbbb_ij_ = -1;
+};
+
+class SparseEriProvider {
+ public:
+  static constexpr bool kSparse = true;
+
+  struct Entry {
+    unsigned p, q, r, s;
+    double value;
+
+    bool operator<(const Entry& other) const {
+      if (p != other.p) return p < other.p;
+      if (q != other.q) return q < other.q;
+      if (r != other.r) return r < other.r;
+      return s < other.s;
+    }
+  };
+
+  SparseEriProvider(const SymmetryBlockedSparseMap<4>* two_body,
+                    size_t n_spatial)
+      : n_spatial_(n_spatial) {
+    if (two_body && two_body->num_blocks() > 0) {
+      const auto& block = two_body->block(
+          {axes::alpha(), axes::alpha(), axes::alpha(), axes::alpha()});
+
+      // Sort and deduplicate
+      std::map<Entry, double> sorted_entries;
+      for (const auto& [idx, val] : block) {
+        Entry e = canonicalize(idx[0], idx[1], idx[2], idx[3]);
+        sorted_entries[e] = val;
+      }
+
+      entries_.reserve(sorted_entries.size());
+      map_.reserve(sorted_entries.size());
+      for (const auto& [e, val] : sorted_entries) {
+        Entry full_entry = e;
+        full_entry.value = val;
+        entries_.push_back(full_entry);
+        uint64_t key = pack_key(e.p, e.q, e.r, e.s);
+        map_[key] = val;
+      }
+    }
+  }
+
+  const std::vector<Entry>& entries() const { return entries_; }
+
+  void build_row_aaaa(size_t ij) {
+    p_ = ij / n_spatial_;
+    q_ = ij % n_spatial_;
+  }
+  void build_row_aabb(size_t ij) { build_row_aaaa(ij); }
+  void build_row_bbbb(size_t ij) { build_row_aaaa(ij); }
+
+  double aaaa(size_t kl) const {
+    unsigned r = kl / n_spatial_;
+    unsigned s = kl % n_spatial_;
+    uint64_t key = canonical_key(p_, q_, r, s);
+    auto it = map_.find(key);
+    return it != map_.end() ? it->second : 0.0;
+  }
+
+  double aabb(size_t kl) const { return aaaa(kl); }
+  double bbbb(size_t kl) const { return aaaa(kl); }
+
+  double get_element(size_t p, size_t q, size_t r, size_t s,
+                     SpinChannel) const {
+    uint64_t key = canonical_key(p, q, r, s);
+    auto it = map_.find(key);
+    return it != map_.end() ? it->second : 0.0;
+  }
+
+ private:
+  static inline Entry canonicalize(unsigned p, unsigned q, unsigned r,
+                                   unsigned s) {
+    unsigned p_c = p;
+    unsigned q_c = q;
+    if (p_c < q_c) std::swap(p_c, q_c);
+    unsigned r_c = r;
+    unsigned s_c = s;
+    if (r_c < s_c) std::swap(r_c, s_c);
+    if (p_c < r_c || (p_c == r_c && q_c < s_c)) {
+      std::swap(p_c, r_c);
+      std::swap(q_c, s_c);
+    }
+    return Entry{p_c, q_c, r_c, s_c, 0.0};
+  }
+
+  static inline uint64_t canonical_key(unsigned p, unsigned q, unsigned r,
+                                       unsigned s) {
+    unsigned p_c = p;
+    unsigned q_c = q;
+    if (p_c < q_c) std::swap(p_c, q_c);
+    unsigned r_c = r;
+    unsigned s_c = s;
+    if (r_c < s_c) std::swap(r_c, s_c);
+    if (p_c < r_c || (p_c == r_c && q_c < s_c)) {
+      std::swap(p_c, r_c);
+      std::swap(q_c, s_c);
+    }
+    return pack_key(p_c, q_c, r_c, s_c);
+  }
+
+  static inline uint64_t pack_key(unsigned p, unsigned q, unsigned r,
+                                  unsigned s) {
+    return (static_cast<uint64_t>(p) << 48) | (static_cast<uint64_t>(q) << 32) |
+           (static_cast<uint64_t>(r) << 16) | (static_cast<uint64_t>(s));
+  }
+
+  size_t n_spatial_;
+  unsigned p_ = 0;
+  unsigned q_ = 0;
+  std::vector<Entry> entries_;
+  std::unordered_map<uint64_t, double> map_;
+};
+
 // ─── Engine implementation ─────────────────────────────────────────
 //
 // The standard non-relativistic electronic Hamiltonian is spin-free: it
@@ -191,12 +438,13 @@ class PackedAccumulator {
 //     cross-spin channels are related by Coulomb symmetry (pq|rs) =
 //     (rs|pq) and are handled in a single merged loop.
 
-template <std::size_t NW>
-MajoranaMapResult majorana_map_impl(
-    const MajoranaMapping& mapping, double core_energy, const double* h1_alpha,
-    const double* h1_beta, const double* eri_aaaa, const double* eri_aabb,
-    const double* eri_bbbb, std::size_t n_spatial, bool spin_symmetric,
-    double threshold, double integral_threshold) {
+template <std::size_t NW, typename TEriProvider>
+MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
+                                    double core_energy, const double* h1_alpha,
+                                    const double* h1_beta, TEriProvider& eri,
+                                    std::size_t n_spatial, bool spin_symmetric,
+                                    double threshold,
+                                    double integral_threshold) {
   if (mapping.num_modes() != 2 * n_spatial) {
     throw std::invalid_argument(
         "majorana_map_hamiltonian: mapping num_modes (" +
@@ -275,11 +523,6 @@ MajoranaMapResult majorana_map_impl(
     acc.accumulate(identity, std::complex<double>(core_energy, 0.0));
   }
 
-  auto idx4 = [n_spatial](std::size_t p, std::size_t q, std::size_t r,
-                          std::size_t s) -> std::size_t {
-    return ((p * n_spatial + q) * n_spatial + r) * n_spatial + s;
-  };
-
   // ─── One-body terms ──────────────────────────────────────────────
   std::vector<double> h1_eff_alpha(n_spatial * n_spatial);
   std::vector<double> h1_eff_beta(n_spatial * n_spatial);
@@ -290,7 +533,7 @@ MajoranaMapResult majorana_map_impl(
       if (spin_symmetric) {
         double delta_corr = 0.0;
         for (std::size_t q = 0; q < n_spatial; ++q) {
-          delta_corr += eri_aaaa[idx4(p, q, q, s)];
+          delta_corr += eri.get_element(p, q, q, s, SpinChannel::aaaa);
         }
         h_a -= 0.5 * delta_corr;
         h_b = h_a;
@@ -372,33 +615,69 @@ MajoranaMapResult majorana_map_impl(
       }
     }
 
-    for (std::size_t p = 0; p < n_spatial; ++p) {
-      for (std::size_t q = p; q < n_spatial; ++q) {
-        std::size_t pq_idx = sym_map[p * n_spatial + q];
-        const auto& s_pq = sym_e[pq_idx];
-        for (std::size_t r = 0; r < n_spatial; ++r) {
-          for (std::size_t s = r; s < n_spatial; ++s) {
-            std::size_t rs_idx = sym_map[r * n_spatial + s];
-            if (pq_idx > rs_idx) continue;
+    if constexpr (TEriProvider::kSparse) {
+      for (const auto& e : eri.entries()) {
+        std::size_t pq_idx = sym_map[e.p * n_spatial + e.q];
+        std::size_t rs_idx = sym_map[e.r * n_spatial + e.s];
+        std::size_t idx1 = pq_idx;
+        std::size_t idx2 = rs_idx;
+        if (idx1 > idx2) std::swap(idx1, idx2);
 
-            double eri = eri_aaaa[idx4(p, q, r, s)];
-            if (std::abs(eri) < integral_threshold) continue;
+        double val = e.value;
+        if (std::abs(val) < integral_threshold) continue;
 
-            const auto& s_rs = sym_e[rs_idx];
+        const auto& s_pq = sym_e[idx1];
+        const auto& s_rs = sym_e[idx2];
 
-            if (pq_idx == rs_idx) {
-              double half_eri = 0.5 * eri;
-              for (const auto& [c1, w1] : s_pq.terms) {
-                for (const auto& [c2, w2] : s_rs.terms) {
-                  acc.accumulate_product(w1, w2, half_eri * c1 * c2);
+        if (idx1 == idx2) {
+          double half_eri = 0.5 * val;
+          for (const auto& [c1, w1] : s_pq.terms) {
+            for (const auto& [c2, w2] : s_rs.terms) {
+              acc.accumulate_product(w1, w2, half_eri * c1 * c2);
+            }
+          }
+        } else {
+          double half_eri = 0.5 * val;
+          for (const auto& [c1, w1] : s_pq.terms) {
+            for (const auto& [c2, w2] : s_rs.terms) {
+              acc.accumulate_product(w1, w2, half_eri * c1 * c2);
+              acc.accumulate_product(w2, w1, half_eri * c2 * c1);
+            }
+          }
+        }
+      }
+    } else {
+      for (std::size_t p = 0; p < n_spatial; ++p) {
+        for (std::size_t q = p; q < n_spatial; ++q) {
+          std::size_t pq_idx = sym_map[p * n_spatial + q];
+          const auto& s_pq = sym_e[pq_idx];
+
+          eri.build_row_aaaa(p * n_spatial + q);
+
+          for (std::size_t r = 0; r < n_spatial; ++r) {
+            for (std::size_t s = r; s < n_spatial; ++s) {
+              std::size_t rs_idx = sym_map[r * n_spatial + s];
+              if (pq_idx > rs_idx) continue;
+
+              double val = eri.aaaa(r * n_spatial + s);
+              if (std::abs(val) < integral_threshold) continue;
+
+              const auto& s_rs = sym_e[rs_idx];
+
+              if (pq_idx == rs_idx) {
+                double half_eri = 0.5 * val;
+                for (const auto& [c1, w1] : s_pq.terms) {
+                  for (const auto& [c2, w2] : s_rs.terms) {
+                    acc.accumulate_product(w1, w2, half_eri * c1 * c2);
+                  }
                 }
-              }
-            } else {
-              double half_eri = 0.5 * eri;
-              for (const auto& [c1, w1] : s_pq.terms) {
-                for (const auto& [c2, w2] : s_rs.terms) {
-                  acc.accumulate_product(w1, w2, half_eri * c1 * c2);
-                  acc.accumulate_product(w2, w1, half_eri * c2 * c1);
+              } else {
+                double half_eri = 0.5 * val;
+                for (const auto& [c1, w1] : s_pq.terms) {
+                  for (const auto& [c2, w2] : s_rs.terms) {
+                    acc.accumulate_product(w1, w2, half_eri * c1 * c2);
+                    acc.accumulate_product(w2, w1, half_eri * c2 * c1);
+                  }
                 }
               }
             }
@@ -410,7 +689,7 @@ MajoranaMapResult majorana_map_impl(
   } else {
     auto accumulate_two_body_product =
         [&](std::size_t mode_p, std::size_t mode_q, std::size_t mode_r,
-            std::size_t mode_s, double eri) {
+            std::size_t mode_s, double eri_val) {
           bool pq_is_alpha = mode_p < n_spatial;
           bool rs_is_alpha = mode_r < n_spatial;
           auto& cache_pq = pq_is_alpha ? ppair_alpha : ppair_beta;
@@ -420,7 +699,7 @@ MajoranaMapResult majorana_map_impl(
           std::size_t br = rs_is_alpha ? mode_r : (mode_r - n_spatial);
           std::size_t bs = rs_is_alpha ? mode_s : (mode_s - n_spatial);
 
-          double half_eri = 0.5 * eri;
+          double half_eri = 0.5 * eri_val;
           for (int a = 0; a < 2; ++a) {
             for (int b = 0; b < 2; ++b) {
               const auto& [coeff1, w1] =
@@ -442,14 +721,15 @@ MajoranaMapResult majorana_map_impl(
     // αα channel
     for (std::size_t p = 0; p < n_spatial; ++p) {
       for (std::size_t q = 0; q < n_spatial; ++q) {
+        eri.build_row_aaaa(p * n_spatial + q);
         for (std::size_t r = 0; r < n_spatial; ++r) {
           for (std::size_t s = 0; s < n_spatial; ++s) {
-            double eri = eri_aaaa[idx4(p, q, r, s)];
-            if (std::abs(eri) < integral_threshold) continue;
+            double val = eri.aaaa(r * n_spatial + s);
+            if (std::abs(val) < integral_threshold) continue;
             accumulate_two_body_product(mode_alpha(p), mode_alpha(q),
-                                        mode_alpha(r), mode_alpha(s), eri);
+                                        mode_alpha(r), mode_alpha(s), val);
             if (q == r) {
-              accumulate_epq(mode_alpha(p), mode_alpha(s), -0.5 * eri);
+              accumulate_epq(mode_alpha(p), mode_alpha(s), -0.5 * val);
             }
           }
         }
@@ -459,14 +739,15 @@ MajoranaMapResult majorana_map_impl(
     // ββ channel
     for (std::size_t p = 0; p < n_spatial; ++p) {
       for (std::size_t q = 0; q < n_spatial; ++q) {
+        eri.build_row_bbbb(p * n_spatial + q);
         for (std::size_t r = 0; r < n_spatial; ++r) {
           for (std::size_t s = 0; s < n_spatial; ++s) {
-            double eri = eri_bbbb[idx4(p, q, r, s)];
-            if (std::abs(eri) < integral_threshold) continue;
+            double val = eri.bbbb(r * n_spatial + s);
+            if (std::abs(val) < integral_threshold) continue;
             accumulate_two_body_product(mode_beta(p), mode_beta(q),
-                                        mode_beta(r), mode_beta(s), eri);
+                                        mode_beta(r), mode_beta(s), val);
             if (q == r) {
-              accumulate_epq(mode_beta(p), mode_beta(s), -0.5 * eri);
+              accumulate_epq(mode_beta(p), mode_beta(s), -0.5 * val);
             }
           }
         }
@@ -476,14 +757,15 @@ MajoranaMapResult majorana_map_impl(
     // αβ + βα cross-spin channels, related by Coulomb symmetry (pq|rs)=(rs|pq)
     for (std::size_t p = 0; p < n_spatial; ++p) {
       for (std::size_t q = 0; q < n_spatial; ++q) {
+        eri.build_row_aabb(p * n_spatial + q);
         for (std::size_t r = 0; r < n_spatial; ++r) {
           for (std::size_t s = 0; s < n_spatial; ++s) {
-            double eri = eri_aabb[idx4(p, q, r, s)];
-            if (std::abs(eri) < integral_threshold) continue;
+            double val = eri.aabb(r * n_spatial + s);
+            if (std::abs(val) < integral_threshold) continue;
             accumulate_two_body_product(mode_alpha(p), mode_alpha(q),
-                                        mode_beta(r), mode_beta(s), eri);
+                                        mode_beta(r), mode_beta(s), val);
             accumulate_two_body_product(mode_beta(r), mode_beta(s),
-                                        mode_alpha(p), mode_alpha(q), eri);
+                                        mode_alpha(p), mode_alpha(q), val);
           }
         }
       }
@@ -533,27 +815,37 @@ MajoranaMapResult majorana_map_impl(
 }
 
 // Dispatch table: function pointer per NW, covering 1..16 (up to 1024 qubits).
-using DispatchFn = MajoranaMapResult (*)(const MajoranaMapping&, double,
-                                         const double*, const double*,
-                                         const double*, const double*,
-                                         const double*, std::size_t, bool,
-                                         double, double);
+template <typename TEriProvider>
+struct Dispatcher {
+  using Fn = MajoranaMapResult (*)(const MajoranaMapping&, double,
+                                   const double*, const double*, TEriProvider&,
+                                   std::size_t, bool, double, double);
 
-template <std::size_t... Is>
-constexpr std::array<DispatchFn, sizeof...(Is)> make_dispatch_table(
-    std::index_sequence<Is...>) {
-  return {{&majorana_map_impl<Is + 1>...}};
-}
+  template <std::size_t NW>
+  static MajoranaMapResult run(const MajoranaMapping& mapping,
+                               double core_energy, const double* h1_alpha,
+                               const double* h1_beta, TEriProvider& ERI,
+                               std::size_t n_spatial, bool spin_symmetric,
+                               double threshold, double integral_threshold) {
+    return majorana_map_impl<NW>(mapping, core_energy, h1_alpha, h1_beta, ERI,
+                                 n_spatial, spin_symmetric, threshold,
+                                 integral_threshold);
+  }
+
+  template <std::size_t... Is>
+  static constexpr std::array<Fn, sizeof...(Is)> make_table(
+      std::index_sequence<Is...>) {
+    return {{&run<Is + 1>...}};
+  }
+};
 
 constexpr std::size_t max_nw = 16;
 
-}  // namespace detail
-
-MajoranaMapResult majorana_map_hamiltonian(
+template <typename TEriProvider>
+MajoranaMapResult majorana_map_dispatch(
     const MajoranaMapping& mapping, double core_energy, const double* h1_alpha,
-    const double* h1_beta, const double* eri_aaaa, const double* eri_aabb,
-    const double* eri_bbbb, std::size_t n_spatial, bool spin_symmetric,
-    double threshold, double integral_threshold) {
+    const double* h1_beta, TEriProvider& ERI, std::size_t n_spatial,
+    bool spin_symmetric, double threshold, double integral_threshold) {
   const std::size_t num_qubits = mapping.num_qubits();
   if (num_qubits == 0) {
     throw std::invalid_argument(
@@ -562,18 +854,74 @@ MajoranaMapResult majorana_map_hamiltonian(
   }
   const std::size_t num_words = (num_qubits + 63) / 64;
 
-  if (num_words > detail::max_nw) {
+  if (num_words > max_nw) {
     throw std::invalid_argument(
         "majorana_map_hamiltonian: num_qubits=" + std::to_string(num_qubits) +
-        " exceeds the maximum of " + std::to_string(detail::max_nw * 64) +
-        " qubits.");
+        " exceeds the maximum of " + std::to_string(max_nw * 64) + " qubits.");
   }
 
-  static const auto table =
-      detail::make_dispatch_table(std::make_index_sequence<detail::max_nw>{});
-  return table[num_words - 1](mapping, core_energy, h1_alpha, h1_beta, eri_aaaa,
-                              eri_aabb, eri_bbbb, n_spatial, spin_symmetric,
-                              threshold, integral_threshold);
+  static constexpr auto table =
+      Dispatcher<TEriProvider>::make_table(std::make_index_sequence<max_nw>{});
+  return table[num_words - 1](mapping, core_energy, h1_alpha, h1_beta, ERI,
+                              n_spatial, spin_symmetric, threshold,
+                              integral_threshold);
+}
+
+}  // namespace detail
+
+MajoranaMapResult majorana_map_hamiltonian(
+    const MajoranaMapping& mapping, double core_energy, const double* h1_alpha,
+    const double* h1_beta, const double* eri_aaaa, const double* eri_aabb,
+    const double* eri_bbbb, std::size_t n_spatial, bool spin_symmetric,
+    double threshold, double integral_threshold) {
+  detail::DenseEriProvider dense_eri(eri_aaaa, eri_aabb, eri_bbbb, n_spatial);
+  return detail::majorana_map_dispatch(mapping, core_energy, h1_alpha, h1_beta,
+                                       dense_eri, n_spatial, spin_symmetric,
+                                       threshold, integral_threshold);
+}
+
+MajoranaMapResult majorana_map_hamiltonian(const MajoranaMapping& mapping,
+                                           const Hamiltonian& hamiltonian,
+                                           double threshold,
+                                           double integral_threshold) {
+  double core_energy = 0.0;  // Core energy constant is excluded from mapped
+                             // operator to match dense path contract
+  auto [h1_alpha, h1_beta] = hamiltonian.get_one_body_integrals();
+  const double* h1_alpha_ptr = h1_alpha.data();
+  const double* h1_beta_ptr = h1_beta.data();
+  size_t n_spatial = h1_alpha.rows();
+  bool spin_symmetric = hamiltonian.is_restricted();
+
+  std::string container_type = hamiltonian.get_container_type();
+  if (container_type == "cholesky") {
+    const auto& cholesky_container =
+        hamiltonian.get_container<CholeskyHamiltonianContainer>();
+    auto [L_alpha, L_beta] = cholesky_container.get_three_center_integrals();
+    detail::CholeskyEriProvider cholesky_eri(L_alpha, L_beta, n_spatial,
+                                             spin_symmetric);
+    return detail::majorana_map_dispatch(
+        mapping, core_energy, h1_alpha_ptr, h1_beta_ptr, cholesky_eri,
+        n_spatial, spin_symmetric, threshold, integral_threshold);
+  } else if (container_type == "sparse") {
+    const auto& sparse_container =
+        hamiltonian.get_container<SparseHamiltonianContainer>();
+    const SymmetryBlockedSparseMap<4>* two_body = nullptr;
+    if (sparse_container.has_two_body_integrals()) {
+      two_body = &sparse_container.two_body_integrals_sparse();
+    }
+    detail::SparseEriProvider sparse_eri(two_body, n_spatial);
+    return detail::majorana_map_dispatch(
+        mapping, core_energy, h1_alpha_ptr, h1_beta_ptr, sparse_eri, n_spatial,
+        spin_symmetric, threshold, integral_threshold);
+  } else {
+    // Fallback: dense path
+    auto [eri_aaaa, eri_aabb, eri_bbbb] = hamiltonian.get_two_body_integrals();
+    detail::DenseEriProvider dense_eri(eri_aaaa.data(), eri_aabb.data(),
+                                       eri_bbbb.data(), n_spatial);
+    return detail::majorana_map_dispatch(
+        mapping, core_energy, h1_alpha_ptr, h1_beta_ptr, dense_eri, n_spatial,
+        spin_symmetric, threshold, integral_threshold);
+  }
 }
 
 }  // namespace qdk::chemistry::data

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -197,9 +197,12 @@ MajoranaMapResult majorana_map_impl(
     const double* h1_beta, const double* eri_aaaa, const double* eri_aabb,
     const double* eri_bbbb, std::size_t n_spatial, bool spin_symmetric,
     double threshold, double integral_threshold) {
-  const std::size_t n_modes = 2 * n_spatial;
-  const std::size_t num_spin_species =
-      (mapping.num_modes() < 2 * n_spatial) ? 1 : 2;
+  if (mapping.num_modes() != 2 * n_spatial) {
+    throw std::invalid_argument(
+        "majorana_map_hamiltonian: mapping num_modes (" +
+        std::to_string(mapping.num_modes()) + ") must match 2 * n_spatial (" +
+        std::to_string(2 * n_spatial) + ")");
+  }
 
   PackedAccumulator<NW> acc;
 
@@ -235,10 +238,7 @@ MajoranaMapResult majorana_map_impl(
   };
 
   auto ppair_alpha = build_pair_cache(alpha_offset);
-  std::vector<PackedPairProduct> ppair_beta;
-  if (num_spin_species == 2) {
-    ppair_beta = build_pair_cache(beta_offset);
-  }
+  auto ppair_beta = build_pair_cache(beta_offset);
 
   auto alpha_pair = [&](std::size_t i,
                         std::size_t j) -> const PackedPairProduct& {
@@ -306,11 +306,9 @@ MajoranaMapResult majorana_map_impl(
       if (std::abs(h_pq_a) > integral_threshold) {
         accumulate_epq(mode_alpha(p), mode_alpha(q), h_pq_a);
       }
-      if (num_spin_species == 2) {
-        double h_pq_b = h1_eff_beta[p * n_spatial + q];
-        if (std::abs(h_pq_b) > integral_threshold) {
-          accumulate_epq(mode_beta(p), mode_beta(q), h_pq_b);
-        }
+      double h_pq_b = h1_eff_beta[p * n_spatial + q];
+      if (std::abs(h_pq_b) > integral_threshold) {
+        accumulate_epq(mode_beta(p), mode_beta(q), h_pq_b);
       }
     }
   }
@@ -331,11 +329,9 @@ MajoranaMapResult majorana_map_impl(
             const auto& [coeff_a, word_a] = alpha_pair(2 * p + a, 2 * q + b);
             sse.terms.emplace_back(coeff_a * 0.25 * excitation_coeff[a][b],
                                    word_a);
-            if (num_spin_species == 2) {
-              const auto& [coeff_b, word_b] = beta_pair(2 * p + a, 2 * q + b);
-              sse.terms.emplace_back(coeff_b * 0.25 * excitation_coeff[a][b],
-                                     word_b);
-            }
+            const auto& [coeff_b, word_b] = beta_pair(2 * p + a, 2 * q + b);
+            sse.terms.emplace_back(coeff_b * 0.25 * excitation_coeff[a][b],
+                                   word_b);
           }
         }
       }
@@ -461,18 +457,16 @@ MajoranaMapResult majorana_map_impl(
     }
 
     // ββ channel
-    if (num_spin_species == 2) {
-      for (std::size_t p = 0; p < n_spatial; ++p) {
-        for (std::size_t q = 0; q < n_spatial; ++q) {
-          for (std::size_t r = 0; r < n_spatial; ++r) {
-            for (std::size_t s = 0; s < n_spatial; ++s) {
-              double eri = eri_bbbb[idx4(p, q, r, s)];
-              if (std::abs(eri) < integral_threshold) continue;
-              accumulate_two_body_product(mode_beta(p), mode_beta(q),
-                                          mode_beta(r), mode_beta(s), eri);
-              if (q == r) {
-                accumulate_epq(mode_beta(p), mode_beta(s), -0.5 * eri);
-              }
+    for (std::size_t p = 0; p < n_spatial; ++p) {
+      for (std::size_t q = 0; q < n_spatial; ++q) {
+        for (std::size_t r = 0; r < n_spatial; ++r) {
+          for (std::size_t s = 0; s < n_spatial; ++s) {
+            double eri = eri_bbbb[idx4(p, q, r, s)];
+            if (std::abs(eri) < integral_threshold) continue;
+            accumulate_two_body_product(mode_beta(p), mode_beta(q),
+                                        mode_beta(r), mode_beta(s), eri);
+            if (q == r) {
+              accumulate_epq(mode_beta(p), mode_beta(s), -0.5 * eri);
             }
           }
         }
@@ -480,18 +474,16 @@ MajoranaMapResult majorana_map_impl(
     }
 
     // αβ + βα cross-spin channels, related by Coulomb symmetry (pq|rs)=(rs|pq)
-    if (num_spin_species == 2) {
-      for (std::size_t p = 0; p < n_spatial; ++p) {
-        for (std::size_t q = 0; q < n_spatial; ++q) {
-          for (std::size_t r = 0; r < n_spatial; ++r) {
-            for (std::size_t s = 0; s < n_spatial; ++s) {
-              double eri = eri_aabb[idx4(p, q, r, s)];
-              if (std::abs(eri) < integral_threshold) continue;
-              accumulate_two_body_product(mode_alpha(p), mode_alpha(q),
-                                          mode_beta(r), mode_beta(s), eri);
-              accumulate_two_body_product(mode_beta(r), mode_beta(s),
-                                          mode_alpha(p), mode_alpha(q), eri);
-            }
+    for (std::size_t p = 0; p < n_spatial; ++p) {
+      for (std::size_t q = 0; q < n_spatial; ++q) {
+        for (std::size_t r = 0; r < n_spatial; ++r) {
+          for (std::size_t s = 0; s < n_spatial; ++s) {
+            double eri = eri_aabb[idx4(p, q, r, s)];
+            if (std::abs(eri) < integral_threshold) continue;
+            accumulate_two_body_product(mode_alpha(p), mode_alpha(q),
+                                        mode_beta(r), mode_beta(s), eri);
+            accumulate_two_body_product(mode_beta(r), mode_beta(s),
+                                        mode_alpha(p), mode_alpha(q), eri);
           }
         }
       }
@@ -503,12 +495,10 @@ MajoranaMapResult majorana_map_impl(
     for (std::size_t p = 0; p < n_spatial; ++p) {
       for (std::size_t q = 0; q < n_spatial; ++q) {
         h1_sum += std::abs(h1_alpha[p * n_spatial + q]);
-        if (num_spin_species == 2) {
-          if (!spin_symmetric) {
-            h1_sum += std::abs(h1_beta[p * n_spatial + q]);
-          } else {
-            h1_sum += std::abs(h1_alpha[p * n_spatial + q]);
-          }
+        if (!spin_symmetric) {
+          h1_sum += std::abs(h1_beta[p * n_spatial + q]);
+        } else {
+          h1_sum += std::abs(h1_alpha[p * n_spatial + q]);
         }
       }
     }

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -232,8 +232,14 @@ MajoranaMapResult majorana_map_impl(
     return cache;
   };
 
+  const std::size_t num_spin_species = (mapping.num_modes() < 2 * n_spatial) ? 1 : 2;
+  const bool use_spin_symmetric = spin_symmetric && (num_spin_species == 2);
+
   auto ppair_alpha = build_pair_cache(alpha_offset);
-  auto ppair_beta = build_pair_cache(beta_offset);
+  std::vector<PackedPairProduct> ppair_beta;
+  if (num_spin_species == 2) {
+    ppair_beta = build_pair_cache(beta_offset);
+  }
 
   auto alpha_pair = [&](std::size_t i,
                         std::size_t j) -> const PackedPairProduct& {
@@ -281,8 +287,8 @@ MajoranaMapResult majorana_map_impl(
   for (std::size_t p = 0; p < n_spatial; ++p) {
     for (std::size_t s = 0; s < n_spatial; ++s) {
       double h_a = h1_alpha[p * n_spatial + s];
-      double h_b = spin_symmetric ? h_a : h1_beta[p * n_spatial + s];
-      if (spin_symmetric) {
+      double h_b = use_spin_symmetric ? h_a : h1_beta[p * n_spatial + s];
+      if (use_spin_symmetric) {
         double delta_corr = 0.0;
         for (std::size_t q = 0; q < n_spatial; ++q) {
           delta_corr += eri_aaaa[idx4(p, q, q, s)];
@@ -301,16 +307,18 @@ MajoranaMapResult majorana_map_impl(
       if (std::abs(h_pq_a) > integral_threshold) {
         accumulate_epq(mode_alpha(p), mode_alpha(q), h_pq_a);
       }
-      double h_pq_b = h1_eff_beta[p * n_spatial + q];
-      if (std::abs(h_pq_b) > integral_threshold) {
-        accumulate_epq(mode_beta(p), mode_beta(q), h_pq_b);
+      if (num_spin_species == 2) {
+        double h_pq_b = h1_eff_beta[p * n_spatial + q];
+        if (std::abs(h_pq_b) > integral_threshold) {
+          accumulate_epq(mode_beta(p), mode_beta(q), h_pq_b);
+        }
       }
     }
   }
 
   // ─── Two-body terms ───────────────────────────────────────────────
 
-  if (spin_symmetric) {
+  if (use_spin_symmetric) {
     struct SpinSummedE {
       std::vector<std::pair<std::complex<double>, PackedPauliWord<NW>>> terms;
     };
@@ -451,35 +459,156 @@ MajoranaMapResult majorana_map_impl(
       }
     }
 
-    // ββ channel
-    for (std::size_t p = 0; p < n_spatial; ++p) {
-      for (std::size_t q = 0; q < n_spatial; ++q) {
-        for (std::size_t r = 0; r < n_spatial; ++r) {
-          for (std::size_t s = 0; s < n_spatial; ++s) {
-            double eri = eri_bbbb[idx4(p, q, r, s)];
-            if (std::abs(eri) < integral_threshold) continue;
-            accumulate_two_body_product(mode_beta(p), mode_beta(q),
-                                        mode_beta(r), mode_beta(s), eri);
-            if (q == r) {
-              accumulate_epq(mode_beta(p), mode_beta(s), -0.5 * eri);
+    if (num_spin_species == 2) {
+      // ββ channel
+      for (std::size_t p = 0; p < n_spatial; ++p) {
+        for (std::size_t q = 0; q < n_spatial; ++q) {
+          for (std::size_t r = 0; r < n_spatial; ++r) {
+            for (std::size_t s = 0; s < n_spatial; ++s) {
+              double eri = eri_bbbb[idx4(p, q, r, s)];
+              if (std::abs(eri) < integral_threshold) continue;
+              accumulate_two_body_product(mode_beta(p), mode_beta(q),
+                                          mode_beta(r), mode_beta(s), eri);
+              if (q == r) {
+                accumulate_epq(mode_beta(p), mode_beta(s), -0.5 * eri);
+              }
+            }
+          }
+        }
+      }
+
+      // αβ + βα cross-spin channels, related by Coulomb symmetry (pq|rs)=(rs|pq)
+      for (std::size_t p = 0; p < n_spatial; ++p) {
+        for (std::size_t q = 0; q < n_spatial; ++q) {
+          for (std::size_t r = 0; r < n_spatial; ++r) {
+            for (std::size_t s = 0; s < n_spatial; ++s) {
+              double eri = eri_aabb[idx4(p, q, r, s)];
+              if (std::abs(eri) < integral_threshold) continue;
+              accumulate_two_body_product(mode_alpha(p), mode_alpha(q),
+                                          mode_beta(r), mode_beta(s), eri);
+              accumulate_two_body_product(mode_beta(r), mode_beta(s),
+                                          mode_alpha(p), mode_alpha(q), eri);
             }
           }
         }
       }
     }
+  }
 
-    // αβ + βα cross-spin channels, related by Coulomb symmetry (pq|rs)=(rs|pq)
+  if (mapping.base_encoding() == "verstraete-cirac" && mapping.grid_nx() > 0 &&
+      mapping.grid_ny() > 0) {
+    std::uint64_t nx = mapping.grid_nx();
+    std::uint64_t ny = mapping.grid_ny();
+    std::uint64_t V = nx * ny;
+
+    double h1_sum = 0.0;
     for (std::size_t p = 0; p < n_spatial; ++p) {
       for (std::size_t q = 0; q < n_spatial; ++q) {
-        for (std::size_t r = 0; r < n_spatial; ++r) {
-          for (std::size_t s = 0; s < n_spatial; ++s) {
-            double eri = eri_aabb[idx4(p, q, r, s)];
-            if (std::abs(eri) < integral_threshold) continue;
-            accumulate_two_body_product(mode_alpha(p), mode_alpha(q),
-                                        mode_beta(r), mode_beta(s), eri);
-            accumulate_two_body_product(mode_beta(r), mode_beta(s),
-                                        mode_alpha(p), mode_alpha(q), eri);
+        h1_sum += std::abs(h1_alpha[p * n_spatial + q]);
+        if (num_spin_species == 2) {
+          if (!use_spin_symmetric) {
+            h1_sum += std::abs(h1_beta[p * n_spatial + q]);
+          } else {
+            h1_sum += std::abs(h1_alpha[p * n_spatial + q]);
           }
+        }
+      }
+    }
+    double aux_ham_coefficient = 1.0 + h1_sum;
+
+    std::size_t num_modes = mapping.num_modes();
+    std::size_t base_modes = 2 * num_modes;
+    auto jw_base = MajoranaMapping::jordan_wigner(base_modes);
+    std::size_t num_spin_species = num_modes / V;
+
+    auto get_snake_coordinates =
+        [&](std::uint64_t index) -> std::pair<std::uint64_t, std::uint64_t> {
+      std::uint64_t row = index / nx;
+      std::uint64_t col;
+      if (row % 2 == 0) {
+        col = index % nx;
+      } else {
+        col = nx - 1 - (index % nx);
+      }
+      return {col, row};
+    };
+
+    auto get_snake_index = [&](std::uint64_t col,
+                               std::uint64_t row) -> std::uint64_t {
+      if (row % 2 == 0) {
+        return row * nx + col;
+      } else {
+        return (row + 1) * nx - 1 - col;
+      }
+    };
+
+    auto get_stabilizer = [&](std::size_t u, std::size_t v)
+        -> std::pair<std::complex<double>, PackedPauliWord<NW>> {
+      std::size_t s_u = (u - 1) / (2 * V);
+      std::size_t i = ((u - 1) / 2) % V;
+      std::size_t j = ((v - 1) / 2) % V;
+
+      std::size_t top = std::min(i, j);
+      std::size_t bot = std::max(i, j);
+      auto coord_top = get_snake_coordinates(top);
+      std::size_t col = coord_top.first;
+
+      std::size_t top_aux_mode = 2 * s_u * V + 2 * top + 1;
+      std::size_t bot_aux_mode = 2 * s_u * V + 2 * bot + 1;
+
+      std::size_t p, q;
+      if (col % 2 == 0) {
+        p = 2 * top_aux_mode;
+        q = 2 * bot_aux_mode + 1;
+      } else {
+        p = 2 * bot_aux_mode;
+        q = 2 * top_aux_mode + 1;
+      }
+
+      auto [coeff_stab, word_stab] = jw_base.bilinear(p, q);
+      return {coeff_stab, sparse_to_packed<NW>(word_stab)};
+    };
+
+    // Calculate number of plaquettes per spin sector: (nx - 1) * (ny - 1)
+    std::size_t num_plaquettes = (nx - 1) * (ny - 1);
+
+    PackedPauliWord<NW> identity{};
+    acc.accumulate(
+        identity,
+        std::complex<double>(
+            aux_ham_coefficient * num_plaquettes * num_spin_species, 0.0));
+
+    for (std::size_t s = 0; s < num_spin_species; ++s) {
+      for (std::uint64_t k = 0; k < nx - 1; ++k) {
+        for (std::uint64_t l = 0; l < ny - 1; ++l) {
+          // Sites of the plaquette
+          std::uint64_t i00 = get_snake_index(k, l);
+          std::uint64_t i10 = get_snake_index(k + 1, l);
+          std::uint64_t i01 = get_snake_index(k, l + 1);
+          std::uint64_t i11 = get_snake_index(k + 1, l + 1);
+
+          // Expanded auxiliary modes
+          std::uint64_t u00 = 2 * s * V + 2 * i00 + 1;
+          std::uint64_t u10 = 2 * s * V + 2 * i10 + 1;
+          std::uint64_t u01 = 2 * s * V + 2 * i01 + 1;
+          std::uint64_t u11 = 2 * s * V + 2 * i11 + 1;
+
+          // Get the 4 link stabilizers
+          auto [c_v1, w_v1] = get_stabilizer(u00, u01);
+          auto [c_v2, w_v2] = get_stabilizer(u10, u11);
+          auto [c_h_bot, w_h_bot] = get_stabilizer(u00, u10);
+          auto [c_h_top, w_h_top] = get_stabilizer(u01, u11);
+
+          // Multiply them: plaquette = w_v1 * w_v2 * w_h_bot * w_h_top
+          auto [phase1, w_tmp1] = multiply_packed(w_v1, w_v2);
+          auto [phase2, w_tmp2] = multiply_packed(w_h_bot, w_h_top);
+          auto [phase3, w_final] = multiply_packed(w_tmp1, w_tmp2);
+
+          std::complex<double> coeff_final =
+              c_v1 * c_v2 * c_h_bot * c_h_top * apply_phase(phase1, 1.0) *
+              apply_phase(phase2, 1.0) * apply_phase(phase3, 1.0);
+
+          acc.accumulate(w_final, -aux_ham_coefficient * coeff_final);
         }
       }
     }

--- a/cpp/src/qdk/chemistry/data/majorana_mapping.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping.cpp
@@ -40,7 +40,7 @@ MajoranaMapping::MajoranaMapping(
     std::vector<std::pair<std::complex<double>, SparsePauliWord>> bilinears,
     std::string name, std::size_t num_modes, std::size_t num_qubits,
     std::string base_encoding, std::optional<TaperingSpecification> tapering,
-    std::size_t grid_nx, std::size_t grid_ny)
+    std::vector<std::pair<std::complex<double>, SparsePauliWord>> stabilizers)
     : table_(std::move(table)),
       bilinears_(std::move(bilinears)),
       name_(std::move(name)),
@@ -49,8 +49,7 @@ MajoranaMapping::MajoranaMapping(
       num_qubits_(num_qubits),
       majorana_atomic_(!table_.empty()),
       tapering_(std::move(tapering)),
-      grid_nx_(grid_nx),
-      grid_ny_(grid_ny) {
+      stabilizers_(std::move(stabilizers)) {
   if (base_encoding_.empty()) {
     base_encoding_ = name_;
   }
@@ -168,8 +167,8 @@ MajoranaMapping::bilinear(std::size_t j, std::size_t k) const {
 
 MajoranaMapping MajoranaMapping::without_tapering() const {
   return MajoranaMapping(table_, bilinears_, base_encoding_, num_modes_,
-                         num_qubits_, base_encoding_, std::nullopt, grid_nx_,
-                         grid_ny_);
+                         num_qubits_, base_encoding_, std::nullopt,
+                         stabilizers_);
 }
 
 std::string MajoranaMapping::get_summary() const {
@@ -179,8 +178,8 @@ std::string MajoranaMapping::get_summary() const {
     ss << " '" << name_ << "'";
   }
   ss << "\n  Modes: " << num_modes_ << "\n  Qubits: " << num_qubits_;
-  if (grid_nx_ > 0 || grid_ny_ > 0) {
-    ss << "\n  Grid: " << grid_nx_ << "x" << grid_ny_;
+  if (!stabilizers_.empty()) {
+    ss << "\n  Stabilizers: " << stabilizers_.size();
   }
   if (tapering_) {
     ss << "\n  Tapered qubits: " << tapering_->num_tapered();
@@ -196,9 +195,13 @@ nlohmann::json MajoranaMapping::to_json() const {
   if (tapering_) {
     data["tapering"] = tapering_->to_json();
   }
-  if (grid_nx_ > 0 || grid_ny_ > 0) {
-    data["grid_nx"] = grid_nx_;
-    data["grid_ny"] = grid_ny_;
+  if (!stabilizers_.empty()) {
+    nlohmann::json stab_array = nlohmann::json::array();
+    for (const auto& [coeff, word] : stabilizers_) {
+      stab_array.push_back(
+          {{"real", coeff.real()}, {"imag", coeff.imag()}, {"word", word}});
+    }
+    data["stabilizers"] = stab_array;
   }
   // Bilinear-only mappings: persist the bilinear entries so the mapping can
   // round-trip even when the Majorana table is empty.
@@ -233,8 +236,16 @@ MajoranaMapping MajoranaMapping::from_json(const nlohmann::json& data) {
   if (data.contains("tapering") && !data.at("tapering").is_null()) {
     tapering = TaperingSpecification::from_json(data.at("tapering"));
   }
-  std::size_t grid_nx = data.value("grid_nx", 0);
-  std::size_t grid_ny = data.value("grid_ny", 0);
+  std::vector<std::pair<std::complex<double>, SparsePauliWord>> stabilizers;
+  if (data.contains("stabilizers") && !data.at("stabilizers").is_null()) {
+    for (const auto& entry : data.at("stabilizers")) {
+      double real = entry.at("real").get<double>();
+      double imag = entry.at("imag").get<double>();
+      auto word = entry.at("word").get<SparsePauliWord>();
+      stabilizers.emplace_back(std::complex<double>(real, imag),
+                               std::move(word));
+    }
+  }
 
   // Bilinear-only mapping: table is empty, bilinears stored explicitly.
   if (table.empty() && data.contains("bilinears")) {
@@ -251,14 +262,14 @@ MajoranaMapping MajoranaMapping::from_json(const nlohmann::json& data) {
     return MajoranaMapping(mapping.table_, mapping.bilinears_, std::move(name),
                            mapping.num_modes_, mapping.num_qubits_,
                            std::move(base_encoding), std::move(tapering),
-                           grid_nx, grid_ny);
+                           std::move(stabilizers));
   }
 
   auto mapping = MajoranaMapping::from_table(std::move(table), base_encoding);
   return MajoranaMapping(mapping.table_, mapping.bilinears_, std::move(name),
                          mapping.num_modes_, mapping.num_qubits_,
-                         std::move(base_encoding), std::move(tapering), grid_nx,
-                         grid_ny);
+                         std::move(base_encoding), std::move(tapering),
+                         std::move(stabilizers));
 }
 
 void MajoranaMapping::to_json_file(const std::string& filename) const {

--- a/cpp/src/qdk/chemistry/data/majorana_mapping.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping.cpp
@@ -16,6 +16,35 @@
 #include <vector>
 
 namespace qdk::chemistry::data {
+namespace detail {
+
+nlohmann::json stabilizers_to_json(
+    const std::vector<std::pair<std::complex<double>, SparsePauliWord>>&
+        stabilizers) {
+  nlohmann::json stab_array = nlohmann::json::array();
+  for (const auto& [coeff, word] : stabilizers) {
+    stab_array.push_back(
+        {{"real", coeff.real()}, {"imag", coeff.imag()}, {"word", word}});
+  }
+  return stab_array;
+}
+
+std::vector<std::pair<std::complex<double>, SparsePauliWord>>
+stabilizers_from_json(const nlohmann::json& data) {
+  std::vector<std::pair<std::complex<double>, SparsePauliWord>> stabilizers;
+  if (data.is_array()) {
+    for (const auto& entry : data) {
+      double real = entry.at("real").get<double>();
+      double imag = entry.at("imag").get<double>();
+      auto word = entry.at("word").get<SparsePauliWord>();
+      stabilizers.emplace_back(std::complex<double>(real, imag),
+                               std::move(word));
+    }
+  }
+  return stabilizers;
+}
+
+}  // namespace detail
 
 static void hash_sparse_pauli_word(qdk::chemistry::utils::HashContext& ctx,
                                    const SparsePauliWord& word) {
@@ -196,12 +225,7 @@ nlohmann::json MajoranaMapping::to_json() const {
     data["tapering"] = tapering_->to_json();
   }
   if (!stabilizers_.empty()) {
-    nlohmann::json stab_array = nlohmann::json::array();
-    for (const auto& [coeff, word] : stabilizers_) {
-      stab_array.push_back(
-          {{"real", coeff.real()}, {"imag", coeff.imag()}, {"word", word}});
-    }
-    data["stabilizers"] = stab_array;
+    data["stabilizers"] = detail::stabilizers_to_json(stabilizers_);
   }
   // Bilinear-only mappings: persist the bilinear entries so the mapping can
   // round-trip even when the Majorana table is empty.
@@ -238,13 +262,7 @@ MajoranaMapping MajoranaMapping::from_json(const nlohmann::json& data) {
   }
   std::vector<std::pair<std::complex<double>, SparsePauliWord>> stabilizers;
   if (data.contains("stabilizers") && !data.at("stabilizers").is_null()) {
-    for (const auto& entry : data.at("stabilizers")) {
-      double real = entry.at("real").get<double>();
-      double imag = entry.at("imag").get<double>();
-      auto word = entry.at("word").get<SparsePauliWord>();
-      stabilizers.emplace_back(std::complex<double>(real, imag),
-                               std::move(word));
-    }
+    stabilizers = detail::stabilizers_from_json(data.at("stabilizers"));
   }
 
   // Bilinear-only mapping: table is empty, bilinears stored explicitly.
@@ -259,6 +277,9 @@ MajoranaMapping MajoranaMapping::from_json(const nlohmann::json& data) {
     }
     auto mapping = MajoranaMapping::from_bilinears(
         num_modes, std::move(bilinears), base_encoding);
+    if (name == base_encoding && !tapering && stabilizers.empty()) {
+      return mapping;
+    }
     return MajoranaMapping(mapping.table_, mapping.bilinears_, std::move(name),
                            mapping.num_modes_, mapping.num_qubits_,
                            std::move(base_encoding), std::move(tapering),
@@ -266,6 +287,9 @@ MajoranaMapping MajoranaMapping::from_json(const nlohmann::json& data) {
   }
 
   auto mapping = MajoranaMapping::from_table(std::move(table), base_encoding);
+  if (name == base_encoding && !tapering && stabilizers.empty()) {
+    return mapping;
+  }
   return MajoranaMapping(mapping.table_, mapping.bilinears_, std::move(name),
                          mapping.num_modes_, mapping.num_qubits_,
                          std::move(base_encoding), std::move(tapering),

--- a/cpp/src/qdk/chemistry/data/majorana_mapping.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping.cpp
@@ -39,7 +39,8 @@ MajoranaMapping::MajoranaMapping(
     std::vector<SparsePauliWord> table,
     std::vector<std::pair<std::complex<double>, SparsePauliWord>> bilinears,
     std::string name, std::size_t num_modes, std::size_t num_qubits,
-    std::string base_encoding, std::optional<TaperingSpecification> tapering)
+    std::string base_encoding, std::optional<TaperingSpecification> tapering,
+    std::size_t grid_nx, std::size_t grid_ny)
     : table_(std::move(table)),
       bilinears_(std::move(bilinears)),
       name_(std::move(name)),
@@ -47,7 +48,9 @@ MajoranaMapping::MajoranaMapping(
       num_modes_(num_modes),
       num_qubits_(num_qubits),
       majorana_atomic_(!table_.empty()),
-      tapering_(std::move(tapering)) {
+      tapering_(std::move(tapering)),
+      grid_nx_(grid_nx),
+      grid_ny_(grid_ny) {
   if (base_encoding_.empty()) {
     base_encoding_ = name_;
   }
@@ -165,7 +168,8 @@ MajoranaMapping::bilinear(std::size_t j, std::size_t k) const {
 
 MajoranaMapping MajoranaMapping::without_tapering() const {
   return MajoranaMapping(table_, bilinears_, base_encoding_, num_modes_,
-                         num_qubits_, base_encoding_);
+                         num_qubits_, base_encoding_, std::nullopt, grid_nx_,
+                         grid_ny_);
 }
 
 std::string MajoranaMapping::get_summary() const {
@@ -175,6 +179,9 @@ std::string MajoranaMapping::get_summary() const {
     ss << " '" << name_ << "'";
   }
   ss << "\n  Modes: " << num_modes_ << "\n  Qubits: " << num_qubits_;
+  if (grid_nx_ > 0 || grid_ny_ > 0) {
+    ss << "\n  Grid: " << grid_nx_ << "x" << grid_ny_;
+  }
   if (tapering_) {
     ss << "\n  Tapered qubits: " << tapering_->num_tapered();
   }
@@ -188,6 +195,10 @@ nlohmann::json MajoranaMapping::to_json() const {
                       {"base_encoding", base_encoding_}};
   if (tapering_) {
     data["tapering"] = tapering_->to_json();
+  }
+  if (grid_nx_ > 0 || grid_ny_ > 0) {
+    data["grid_nx"] = grid_nx_;
+    data["grid_ny"] = grid_ny_;
   }
   // Bilinear-only mappings: persist the bilinear entries so the mapping can
   // round-trip even when the Majorana table is empty.
@@ -222,6 +233,8 @@ MajoranaMapping MajoranaMapping::from_json(const nlohmann::json& data) {
   if (data.contains("tapering") && !data.at("tapering").is_null()) {
     tapering = TaperingSpecification::from_json(data.at("tapering"));
   }
+  std::size_t grid_nx = data.value("grid_nx", 0);
+  std::size_t grid_ny = data.value("grid_ny", 0);
 
   // Bilinear-only mapping: table is empty, bilinears stored explicitly.
   if (table.empty() && data.contains("bilinears")) {
@@ -235,21 +248,17 @@ MajoranaMapping MajoranaMapping::from_json(const nlohmann::json& data) {
     }
     auto mapping = MajoranaMapping::from_bilinears(
         num_modes, std::move(bilinears), base_encoding);
-    if (name == base_encoding && !tapering) {
-      return mapping;
-    }
     return MajoranaMapping(mapping.table_, mapping.bilinears_, std::move(name),
                            mapping.num_modes_, mapping.num_qubits_,
-                           std::move(base_encoding), std::move(tapering));
+                           std::move(base_encoding), std::move(tapering),
+                           grid_nx, grid_ny);
   }
 
   auto mapping = MajoranaMapping::from_table(std::move(table), base_encoding);
-  if (name == base_encoding && !tapering) {
-    return mapping;
-  }
   return MajoranaMapping(mapping.table_, mapping.bilinears_, std::move(name),
                          mapping.num_modes_, mapping.num_qubits_,
-                         std::move(base_encoding), std::move(tapering));
+                         std::move(base_encoding), std::move(tapering), grid_nx,
+                         grid_ny);
 }
 
 void MajoranaMapping::to_json_file(const std::string& filename) const {

--- a/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
@@ -3,7 +3,9 @@
 // license information.
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
+#include <qdk/chemistry/data/lattice_graph.hpp>
 #include <qdk/chemistry/data/majorana_mapping.hpp>
 #include <qdk/chemistry/data/tapering.hpp>
 #include <stdexcept>
@@ -331,6 +333,163 @@ MajoranaMapping MajoranaMapping::symmetry_conserving_bravyi_kitaev(
                          "symmetry-conserving-bravyi-kitaev", base.num_modes_,
                          base.num_qubits_, "bravyi-kitaev-tree",
                          std::move(tapering));
+}
+
+namespace detail {
+
+std::pair<std::uint64_t, std::uint64_t> snake_coordinates(std::uint64_t index,
+                                                          std::uint64_t nx,
+                                                          std::uint64_t ny) {
+  std::uint64_t row = index / nx;
+  std::uint64_t col;
+  if (row % 2 == 0) {
+    col = index % nx;
+  } else {
+    col = nx - 1 - (index % nx);
+  }
+  return {col, row};
+}
+
+bool is_vertical_edge(std::uint64_t i, std::uint64_t j, std::uint64_t nx,
+                      std::uint64_t ny) {
+  auto [ix, iy] = snake_coordinates(i, nx, ny);
+  auto [jx, jy] = snake_coordinates(j, nx, ny);
+  return (ix == jx && (iy + 1 == jy || jy + 1 == iy));
+}
+
+}  // namespace detail
+
+MajoranaMapping MajoranaMapping::verstraete_cirac(
+    const LatticeGraph& lattice, std::size_t num_spin_species) {
+  if (num_spin_species == 0) {
+    throw std::invalid_argument(
+        "verstraete_cirac requires num_spin_species > 0");
+  }
+
+  std::uint64_t V = lattice.num_sites();
+  std::uint64_t E = lattice.num_edges();
+
+  // Solve: nx * ny = V, nx + ny = 2V - E
+  double b = double(2 * V - E);
+  double c = double(V);
+  double disc = b * b - 4.0 * c;
+  if (disc < 0) {
+    throw std::invalid_argument(
+        "Lattice graph is not a 2D square lattice with open boundaries");
+  }
+  double r1 = 0.5 * (b - std::sqrt(disc));
+  double r2 = 0.5 * (b + std::sqrt(disc));
+  std::uint64_t nx1 = std::round(r1);
+  std::uint64_t nx2 = std::round(r2);
+
+  auto check_nx = [&](std::uint64_t nx) -> bool {
+    if (nx == 0 || V % nx != 0) return false;
+    std::uint64_t ny = V / nx;
+    std::uint64_t count = 0;
+    const auto& adj = lattice.sparse_adjacency_matrix();
+    for (int k = 0; k < adj.outerSize(); ++k) {
+      for (Eigen::SparseMatrix<double>::InnerIterator it(adj, k); it; ++it) {
+        std::uint64_t i = it.row();
+        std::uint64_t j = it.col();
+        if (i >= j) continue;
+        if (std::abs(int(i - j)) == 1) {
+          if (std::min(i, j) % nx == nx - 1) return false;
+          count++;
+        } else if (std::abs(int(i - j)) == nx) {
+          count++;
+        } else {
+          return false;
+        }
+      }
+    }
+    return count == E;
+  };
+
+  std::uint64_t nx = 0, ny = 0;
+  if (check_nx(nx1)) {
+    nx = nx1;
+    ny = V / nx1;
+  } else if (check_nx(nx2)) {
+    nx = nx2;
+    ny = V / nx2;
+  } else {
+    throw std::invalid_argument(
+        "Lattice graph is not a 2D square lattice with open boundaries");
+  }
+
+  if (nx < 2 || ny < 2) {
+    throw std::invalid_argument(
+        "verstraete_cirac requires a 2D grid of size at least 2x2");
+  }
+
+  std::size_t num_modes = num_spin_species * V;
+  // Combined system has 2 * num_modes modes.
+  std::size_t base_modes = 2 * num_modes;
+  auto jw_base = MajoranaMapping::jordan_wigner(base_modes);
+
+  // Construct upper triangle of bilinears: M * (M - 1) / 2 entries, where M = 2
+  // * num_modes.
+  std::size_t M = 2 * num_modes;
+  std::vector<std::pair<std::complex<double>, SparsePauliWord>> upper_triangle;
+  upper_triangle.reserve(M * (M - 1) / 2);
+
+  for (std::size_t u = 0; u < M; ++u) {
+    for (std::size_t v = u + 1; v < M; ++v) {
+      std::size_t u_mode = u / 2;
+      std::size_t v_mode = v / 2;
+      std::size_t s_u = u_mode / V;
+      std::size_t s_v = v_mode / V;
+      std::size_t i = u_mode % V;
+      std::size_t j = v_mode % V;
+      std::size_t a = u % 2;
+      std::size_t b_idx = v % 2;
+
+      if (s_u == s_v && detail::is_vertical_edge(i, j, nx, ny)) {
+        // Vertical edge: multiply by stabilizer
+        std::uint64_t top = std::min(i, j);
+        std::uint64_t bot = std::max(i, j);
+        auto coord_top = detail::snake_coordinates(top, nx, ny);
+        std::uint64_t col = coord_top.first;
+
+        std::size_t top_aux_mode = 2 * s_u * V + 2 * top + 1;
+        std::size_t bot_aux_mode = 2 * s_u * V + 2 * bot + 1;
+
+        std::size_t p, q;
+        if (col % 2 == 0) {
+          p = 2 * top_aux_mode;
+          q = 2 * bot_aux_mode + 1;
+        } else {
+          p = 2 * bot_aux_mode;
+          q = 2 * top_aux_mode + 1;
+        }
+
+        // Stabilizer S = i * gamma_p * gamma_q
+        auto [coeff_stab, word_stab] = jw_base.bilinear(p, q);
+
+        // System modes:
+        std::size_t r = 2 * (2 * s_u * V + 2 * i) + a;
+        std::size_t s_jw = 2 * (2 * s_v * V + 2 * j) + b_idx;
+        auto [coeff_sys, word_sys] = jw_base.bilinear(r, s_jw);
+
+        auto [phase, word_final] =
+            PauliTermAccumulator::multiply_uncached(word_sys, word_stab);
+        std::complex<double> coeff_final = coeff_sys * coeff_stab * phase;
+
+        upper_triangle.emplace_back(coeff_final, std::move(word_final));
+      } else {
+        // Not a vertical edge
+        std::size_t r = 2 * (2 * s_u * V + 2 * i) + a;
+        std::size_t s_jw = 2 * (2 * s_v * V + 2 * j) + b_idx;
+        auto [coeff, word] = jw_base.bilinear(r, s_jw);
+        upper_triangle.emplace_back(coeff, word);
+      }
+    }
+  }
+
+  return MajoranaMapping(std::vector<SparsePauliWord>{},
+                         std::move(upper_triangle), "verstraete-cirac",
+                         num_modes, 2 * num_modes, "verstraete-cirac",
+                         std::nullopt, nx, ny);
 }
 
 }  // namespace qdk::chemistry::data

--- a/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
@@ -8,6 +8,7 @@
 #include <qdk/chemistry/data/lattice_graph.hpp>
 #include <qdk/chemistry/data/majorana_mapping.hpp>
 #include <qdk/chemistry/data/tapering.hpp>
+#include <queue>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -108,6 +109,39 @@ SparsePauliWord build_sorted_word(
 constexpr std::uint8_t op_x = 1;
 constexpr std::uint8_t op_y = 2;
 constexpr std::uint8_t op_z = 3;
+
+bool find_hamiltonian_path_dfs(
+    std::uint64_t curr, const std::vector<std::vector<std::uint64_t>>& adj,
+    std::vector<bool>& visited, std::vector<std::uint64_t>& path) {
+  path.push_back(curr);
+  if (path.size() == adj.size()) {
+    return true;
+  }
+  visited[curr] = true;
+  for (std::uint64_t neighbor : adj[curr]) {
+    if (!visited[neighbor]) {
+      if (find_hamiltonian_path_dfs(neighbor, adj, visited, path)) {
+        return true;
+      }
+    }
+  }
+  visited[curr] = false;
+  path.pop_back();
+  return false;
+}
+
+std::vector<std::uint64_t> find_hamiltonian_path(
+    const std::vector<std::vector<std::uint64_t>>& adj) {
+  std::uint64_t V = adj.size();
+  std::vector<bool> visited(V, false);
+  std::vector<std::uint64_t> path;
+  for (std::uint64_t start = 0; start < V; ++start) {
+    if (find_hamiltonian_path_dfs(start, adj, visited, path)) {
+      return path;
+    }
+  }
+  return {};
+}
 
 }  // namespace detail
 
@@ -335,101 +369,133 @@ MajoranaMapping MajoranaMapping::symmetry_conserving_bravyi_kitaev(
                          std::move(tapering));
 }
 
-namespace detail {
-
-std::pair<std::uint64_t, std::uint64_t> snake_coordinates(std::uint64_t index,
-                                                          std::uint64_t nx,
-                                                          std::uint64_t ny) {
-  std::uint64_t row = index / nx;
-  std::uint64_t col;
-  if (row % 2 == 0) {
-    col = index % nx;
-  } else {
-    col = nx - 1 - (index % nx);
-  }
-  return {col, row};
-}
-
-bool is_vertical_edge(std::uint64_t i, std::uint64_t j, std::uint64_t nx,
-                      std::uint64_t ny) {
-  auto [ix, iy] = snake_coordinates(i, nx, ny);
-  auto [jx, jy] = snake_coordinates(j, nx, ny);
-  return (ix == jx && (iy + 1 == jy || jy + 1 == iy));
-}
-
-}  // namespace detail
+// ── Factory: Verstraete-Cirac ──────────────────────────────────────────
 
 MajoranaMapping MajoranaMapping::verstraete_cirac(
     const LatticeGraph& lattice, std::size_t num_spin_species) {
+  using namespace detail;
+  const std::string name = "verstraete-cirac";
   if (num_spin_species == 0) {
-    throw std::invalid_argument(
-        "verstraete_cirac requires num_spin_species > 0");
+    throw std::invalid_argument(name + " requires num_spin_species > 0");
   }
-
   std::uint64_t V = lattice.num_sites();
-  std::uint64_t E = lattice.num_edges();
-
-  // Solve: nx * ny = V, nx + ny = 2V - E
-  double b = double(2 * V - E);
-  double c = double(V);
-  double disc = b * b - 4.0 * c;
-  if (disc < 0) {
+  if (V < 3) {
     throw std::invalid_argument(
-        "Lattice graph is not a 2D square lattice with open boundaries");
+        name + " requires a lattice graph with at least 3 sites");
   }
-  double r1 = 0.5 * (b - std::sqrt(disc));
-  double r2 = 0.5 * (b + std::sqrt(disc));
-  std::uint64_t nx1 = std::round(r1);
-  std::uint64_t nx2 = std::round(r2);
 
-  auto check_nx = [&](std::uint64_t nx) -> bool {
-    if (nx == 0 || V % nx != 0) return false;
-    std::uint64_t ny = V / nx;
-    std::uint64_t count = 0;
-    const auto& adj = lattice.sparse_adjacency_matrix();
-    for (int k = 0; k < adj.outerSize(); ++k) {
-      for (Eigen::SparseMatrix<double>::InnerIterator it(adj, k); it; ++it) {
-        std::uint64_t i = it.row();
-        std::uint64_t j = it.col();
-        if (i >= j) continue;
-        if (std::abs(int(i - j)) == 1) {
-          if (std::min(i, j) % nx == nx - 1) return false;
-          count++;
-        } else if (std::abs(int(i - j)) == nx) {
-          count++;
-        } else {
-          return false;
-        }
+  // Find all edges in the lattice (upper triangle of adjacency matrix)
+  std::vector<std::vector<std::uint64_t>> adj_list(V);
+  const auto& adj = lattice.sparse_adjacency_matrix();
+  for (int k = 0; k < adj.outerSize(); ++k) {
+    for (Eigen::SparseMatrix<double>::InnerIterator it(adj, k); it; ++it) {
+      std::uint64_t u = it.row();
+      std::uint64_t v = it.col();
+      if (u != v) {
+        adj_list[u].push_back(v);
       }
     }
-    return count == E;
-  };
-
-  std::uint64_t nx = 0, ny = 0;
-  if (check_nx(nx1)) {
-    nx = nx1;
-    ny = V / nx1;
-  } else if (check_nx(nx2)) {
-    nx = nx2;
-    ny = V / nx2;
-  } else {
-    throw std::invalid_argument(
-        "Lattice graph is not a 2D square lattice with open boundaries");
   }
 
-  if (nx < 2 || ny < 2) {
+  // Find Hamiltonian path dynamically directly from the graph adjacency
+  std::vector<std::uint64_t> snake_path = find_hamiltonian_path(adj_list);
+  if (snake_path.empty()) {
     throw std::invalid_argument(
-        "verstraete_cirac requires a 2D grid of size at least 2x2");
+        name +
+        ": No Hamiltonian path found in the lattice graph. A Hamiltonian path "
+        "is required to construct commuting stabilizers.");
+  }
+
+  // Maps row-major site index to its position in the snake path (system mode
+  // order)
+  std::vector<std::uint64_t> rm_to_snake(V);
+  for (std::uint64_t k = 0; k < V; ++k) {
+    rm_to_snake[snake_path[k]] = k;
   }
 
   std::size_t num_modes = num_spin_species * V;
-  // Combined system has 2 * num_modes modes.
   std::size_t base_modes = 2 * num_modes;
+  std::size_t M = 2 * num_modes;
   auto jw_base = MajoranaMapping::jordan_wigner(base_modes);
 
-  // Construct upper triangle of bilinears: M * (M - 1) / 2 entries, where M = 2
-  // * num_modes.
-  std::size_t M = 2 * num_modes;
+  auto get_sys_majorana = [&](std::uint64_t site, std::size_t spin,
+                              std::size_t a) -> std::size_t {
+    std::size_t snake_idx = rm_to_snake[site];
+    return 2 * (2 * (spin * V + snake_idx)) + a;
+  };
+
+  auto get_aux_majorana = [&](std::uint64_t site, std::size_t spin,
+                              std::size_t a) -> std::size_t {
+    std::size_t snake_idx = rm_to_snake[site];
+    return 2 * (2 * (spin * V + snake_idx) + 1) + a;
+  };
+
+  auto get_bilinear =
+      [&](std::size_t p,
+          std::size_t q) -> std::pair<std::complex<double>, SparsePauliWord> {
+    if (p < q) {
+      auto b = jw_base.bilinear(p, q);
+      return {b.first, b.second};
+    } else {
+      auto b = jw_base.bilinear(q, p);
+      return {-b.first, b.second};
+    }
+  };
+
+  // Find all non-path edges incident to each vertex.
+  // An edge (u, v) is a non-path edge if |rm_to_snake[u] - rm_to_snake[v]| > 1.
+  std::vector<std::vector<std::uint64_t>> non_path_incident(V);
+  for (std::uint64_t u = 0; u < V; ++u) {
+    for (std::uint64_t v : adj_list[u]) {
+      if (u < v) {
+        std::size_t s_u = rm_to_snake[u];
+        std::size_t s_v = rm_to_snake[v];
+        std::size_t diff = (s_u > s_v) ? (s_u - s_v) : (s_v - s_u);
+        if (diff > 1) {
+          non_path_incident[u].push_back(v);
+          non_path_incident[v].push_back(u);
+        }
+      }
+    }
+  }
+
+  // Ensure that no vertex has more than 2 non-path edges (auxiliary space
+  // limit)
+  for (std::uint64_t u = 0; u < V; ++u) {
+    if (non_path_incident[u].size() > 2) {
+      throw std::invalid_argument(name + ": Vertex has " +
+                                  std::to_string(non_path_incident[u].size()) +
+                                  " non-path edges, which exceeds the "
+                                  "2-auxiliary-Majorana limit of the mapping.");
+    }
+  }
+
+  std::vector<std::pair<std::complex<double>, SparsePauliWord>> stabilizers;
+  std::vector<std::map<std::pair<std::uint64_t, std::uint64_t>, std::size_t>>
+      edge_to_stab_idx(num_spin_species);
+
+  for (std::size_t spin = 0; spin < num_spin_species; ++spin) {
+    for (std::uint64_t u = 0; u < V; ++u) {
+      for (std::uint64_t v : non_path_incident[u]) {
+        if (u < v) {
+          auto it_u = std::find(non_path_incident[u].begin(),
+                                non_path_incident[u].end(), v);
+          auto it_v = std::find(non_path_incident[v].begin(),
+                                non_path_incident[v].end(), u);
+          std::size_t a = std::distance(non_path_incident[u].begin(), it_u);
+          std::size_t b = std::distance(non_path_incident[v].begin(), it_v);
+
+          std::size_t p = get_aux_majorana(u, spin, a);
+          std::size_t q = get_aux_majorana(v, spin, b);
+
+          auto [coeff, word] = get_bilinear(p, q);
+          edge_to_stab_idx[spin][{u, v}] = stabilizers.size();
+          stabilizers.emplace_back(coeff, std::move(word));
+        }
+      }
+    }
+  }
+
   std::vector<std::pair<std::complex<double>, SparsePauliWord>> upper_triangle;
   upper_triangle.reserve(M * (M - 1) / 2);
 
@@ -444,52 +510,41 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
       std::size_t a = u % 2;
       std::size_t b_idx = v % 2;
 
-      if (s_u == s_v && detail::is_vertical_edge(i, j, nx, ny)) {
-        // Vertical edge: multiply by stabilizer
-        std::uint64_t top = std::min(i, j);
-        std::uint64_t bot = std::max(i, j);
-        auto coord_top = detail::snake_coordinates(top, nx, ny);
-        std::uint64_t col = coord_top.first;
+      bool connected = (s_u == s_v) && lattice.are_connected(i, j);
 
-        std::size_t top_aux_mode = 2 * s_u * V + 2 * top + 1;
-        std::size_t bot_aux_mode = 2 * s_u * V + 2 * bot + 1;
+      if (connected) {
+        std::size_t snake_i = rm_to_snake[i];
+        std::size_t snake_j = rm_to_snake[j];
+        std::size_t snake_min = std::min(snake_i, snake_j);
+        std::size_t snake_max = std::max(snake_i, snake_j);
 
-        std::size_t p, q;
-        if (col % 2 == 0) {
-          p = 2 * top_aux_mode;
-          q = 2 * bot_aux_mode + 1;
-        } else {
-          p = 2 * bot_aux_mode;
-          q = 2 * top_aux_mode + 1;
+        std::size_t p = get_sys_majorana(i, s_u, a);
+        std::size_t q = get_sys_majorana(j, s_v, b_idx);
+        auto [coeff, word] = get_bilinear(p, q);
+
+        if (snake_max - snake_min > 1) {
+          auto key = std::make_pair(std::min(i, j), std::max(i, j));
+          std::size_t stab_idx = edge_to_stab_idx[s_u].at(key);
+          const auto& stab = stabilizers[stab_idx];
+          auto [phase, new_word] =
+              PauliTermAccumulator::multiply_uncached(word, stab.second);
+          coeff *= stab.first * phase;
+          word = std::move(new_word);
         }
 
-        // Stabilizer S = i * gamma_p * gamma_q
-        auto [coeff_stab, word_stab] = jw_base.bilinear(p, q);
-
-        // System modes:
-        std::size_t r = 2 * (2 * s_u * V + 2 * i) + a;
-        std::size_t s_jw = 2 * (2 * s_v * V + 2 * j) + b_idx;
-        auto [coeff_sys, word_sys] = jw_base.bilinear(r, s_jw);
-
-        auto [phase, word_final] =
-            PauliTermAccumulator::multiply_uncached(word_sys, word_stab);
-        std::complex<double> coeff_final = coeff_sys * coeff_stab * phase;
-
-        upper_triangle.emplace_back(coeff_final, std::move(word_final));
+        upper_triangle.emplace_back(coeff, std::move(word));
       } else {
-        // Not a vertical edge
-        std::size_t r = 2 * (2 * s_u * V + 2 * i) + a;
-        std::size_t s_jw = 2 * (2 * s_v * V + 2 * j) + b_idx;
-        auto [coeff, word] = jw_base.bilinear(r, s_jw);
-        upper_triangle.emplace_back(coeff, word);
+        std::size_t p = get_sys_majorana(i, s_u, a);
+        std::size_t q = get_sys_majorana(j, s_v, b_idx);
+        auto [coeff, word] = get_bilinear(p, q);
+        upper_triangle.emplace_back(coeff, std::move(word));
       }
     }
   }
 
   return MajoranaMapping(std::vector<SparsePauliWord>{},
-                         std::move(upper_triangle), "verstraete-cirac",
-                         num_modes, 2 * num_modes, "verstraete-cirac",
-                         std::nullopt, nx, ny);
+                         std::move(upper_triangle), name, num_modes, base_modes,
+                         name, std::nullopt, std::move(stabilizers));
 }
 
 }  // namespace qdk::chemistry::data

--- a/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
@@ -8,7 +8,6 @@
 #include <qdk/chemistry/data/lattice_graph.hpp>
 #include <qdk/chemistry/data/majorana_mapping.hpp>
 #include <qdk/chemistry/data/tapering.hpp>
-#include <queue>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -110,16 +109,20 @@ constexpr std::uint8_t op_x = 1;
 constexpr std::uint8_t op_y = 2;
 constexpr std::uint8_t op_z = 3;
 
-bool find_hamiltonian_path_dfs(
-    std::uint64_t curr, const std::vector<std::vector<std::uint64_t>>& adj,
-    std::vector<bool>& visited, std::vector<std::uint64_t>& path) {
+bool find_hamiltonian_path_dfs(std::uint64_t curr,
+                               const Eigen::SparseMatrix<double>& adj,
+                               std::vector<bool>& visited,
+                               std::vector<std::uint64_t>& path) {
   path.push_back(curr);
-  if (path.size() == adj.size()) {
+  if (path.size() == static_cast<std::size_t>(adj.rows())) {
     return true;
   }
   visited[curr] = true;
-  for (std::uint64_t neighbor : adj[curr]) {
-    if (!visited[neighbor]) {
+
+  // Iterate directly over the sparse matrix columns/rows for neighbors
+  for (Eigen::SparseMatrix<double>::InnerIterator it(adj, curr); it; ++it) {
+    std::uint64_t neighbor = it.row();
+    if (neighbor != curr && !visited[neighbor]) {
       if (find_hamiltonian_path_dfs(neighbor, adj, visited, path)) {
         return true;
       }
@@ -131,8 +134,8 @@ bool find_hamiltonian_path_dfs(
 }
 
 std::vector<std::uint64_t> find_hamiltonian_path(
-    const std::vector<std::vector<std::uint64_t>>& adj) {
-  std::uint64_t V = adj.size();
+    const Eigen::SparseMatrix<double>& adj) {
+  std::uint64_t V = adj.rows();
   std::vector<bool> visited(V, false);
   std::vector<std::uint64_t> path;
   for (std::uint64_t start = 0; start < V; ++start) {
@@ -375,61 +378,52 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
     const LatticeGraph& lattice, std::size_t num_spin_species) {
   using namespace detail;
   const std::string name = "verstraete-cirac";
-  if (num_spin_species == 0) {
-    throw std::invalid_argument(name + " requires num_spin_species > 0");
+
+  // Support spinless or fermions with spin-½
+  if (num_spin_species != 1 && num_spin_species != 2) {
+    throw std::invalid_argument(name +
+                                " requires num_spin_species to be 1 or 2.");
   }
+
   std::uint64_t V = lattice.num_sites();
   if (V < 3) {
     throw std::invalid_argument(
         name + " requires a lattice graph with at least 3 sites");
   }
 
-  // Find all edges in the lattice (upper triangle of adjacency matrix)
-  std::vector<std::vector<std::uint64_t>> adj_list(V);
+  // Construct a Hamiltonian path from the graph adjacency matrix
   const auto& adj = lattice.sparse_adjacency_matrix();
-  for (int k = 0; k < adj.outerSize(); ++k) {
-    for (Eigen::SparseMatrix<double>::InnerIterator it(adj, k); it; ++it) {
-      std::uint64_t u = it.row();
-      std::uint64_t v = it.col();
-      if (u != v) {
-        adj_list[u].push_back(v);
-      }
-    }
-  }
-
-  // Find Hamiltonian path dynamically directly from the graph adjacency
-  std::vector<std::uint64_t> snake_path = find_hamiltonian_path(adj_list);
-  if (snake_path.empty()) {
-    throw std::invalid_argument(
+  std::vector<std::uint64_t> hamiltonian_path = find_hamiltonian_path(adj);
+  if (hamiltonian_path.empty()) {
+    throw std::runtime_error(
         name +
         ": No Hamiltonian path found in the lattice graph. A Hamiltonian path "
         "is required to construct commuting stabilizers.");
   }
 
-  // Maps row-major site index to its position in the snake path (system mode
-  // order)
-  std::vector<std::uint64_t> rm_to_snake(V);
+  // Map row-major site index to its position in the Hamiltonian path
+  std::vector<std::uint64_t> site_to_path_idx(V);
   for (std::uint64_t k = 0; k < V; ++k) {
-    rm_to_snake[snake_path[k]] = k;
+    site_to_path_idx[hamiltonian_path[k]] = k;
   }
 
   std::size_t num_modes = num_spin_species * V;
   std::size_t base_modes = 2 * num_modes;
-  std::size_t M = 2 * num_modes;
   auto jw_base = MajoranaMapping::jordan_wigner(base_modes);
 
   auto get_sys_majorana = [&](std::uint64_t site, std::size_t spin,
-                              std::size_t a) -> std::size_t {
-    std::size_t snake_idx = rm_to_snake[site];
-    return 2 * (2 * (spin * V + snake_idx)) + a;
+                              std::size_t offset) -> std::size_t {
+    std::size_t path_idx = site_to_path_idx[site];
+    return 2 * (2 * (spin * V + path_idx)) + offset;
   };
 
   auto get_aux_majorana = [&](std::uint64_t site, std::size_t spin,
-                              std::size_t a) -> std::size_t {
-    std::size_t snake_idx = rm_to_snake[site];
-    return 2 * (2 * (spin * V + snake_idx) + 1) + a;
+                              std::size_t offset) -> std::size_t {
+    std::size_t path_idx = site_to_path_idx[site];
+    return 2 * (2 * (spin * V + path_idx) + 1) + offset;
   };
 
+  // Get a Pauli representation of the antisymmetric Majorana bilinear iγ_pγ_q
   auto get_bilinear =
       [&](std::size_t p,
           std::size_t q) -> std::pair<std::complex<double>, SparsePauliWord> {
@@ -442,14 +436,16 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
     }
   };
 
-  // Find all non-path edges incident to each vertex.
-  // An edge (u, v) is a non-path edge if |rm_to_snake[u] - rm_to_snake[v]| > 1.
+  // Find all non-path edges incident to each vertex
   std::vector<std::vector<std::uint64_t>> non_path_incident(V);
-  for (std::uint64_t u = 0; u < V; ++u) {
-    for (std::uint64_t v : adj_list[u]) {
+  for (int k = 0; k < adj.outerSize(); ++k) {
+    for (Eigen::SparseMatrix<double>::InnerIterator it(adj, k); it; ++it) {
+      std::uint64_t u = it.row();
+      std::uint64_t v = it.col();
+      // Since the matrix is symmetric, only process the upper-triangle
       if (u < v) {
-        std::size_t s_u = rm_to_snake[u];
-        std::size_t s_v = rm_to_snake[v];
+        std::size_t s_u = site_to_path_idx[u];
+        std::size_t s_v = site_to_path_idx[v];
         std::size_t diff = (s_u > s_v) ? (s_u - s_v) : (s_v - s_u);
         if (diff > 1) {
           non_path_incident[u].push_back(v);
@@ -459,14 +455,13 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
     }
   }
 
-  // Ensure that no vertex has more than 2 non-path edges (auxiliary space
-  // limit)
+  // Ensure that we have no more than 1 aux Majorana mode per sys mode
   for (std::uint64_t u = 0; u < V; ++u) {
     if (non_path_incident[u].size() > 2) {
-      throw std::invalid_argument(name + ": Vertex has " +
-                                  std::to_string(non_path_incident[u].size()) +
-                                  " non-path edges, which exceeds the "
-                                  "2-auxiliary-Majorana limit of the mapping.");
+      throw std::runtime_error(name + ": Vertex has " +
+                               std::to_string(non_path_incident[u].size()) +
+                               " non-path edges, which exceeds the "
+                               "2-auxiliary-Majorana limit of the mapping.");
     }
   }
 
@@ -475,6 +470,7 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
       edge_to_stab_idx(num_spin_species);
 
   for (std::size_t spin = 0; spin < num_spin_species; ++spin) {
+    // Add 2-body link stabilizers for non-path edges on the lattice
     for (std::uint64_t u = 0; u < V; ++u) {
       for (std::uint64_t v : non_path_incident[u]) {
         if (u < v) {
@@ -490,17 +486,39 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
 
           auto [coeff, word] = get_bilinear(p, q);
           edge_to_stab_idx[spin][{u, v}] = stabilizers.size();
+          edge_to_stab_idx[spin][{v, u}] = stabilizers.size();
           stabilizers.emplace_back(coeff, std::move(word));
         }
+      }
+    }
+
+    // Identify and pair up any remaining unused aux Majorana modes to
+    // lift boundary/corner codespace degeneracy
+    std::vector<std::size_t> unpaired_modes;
+    for (std::uint64_t u = 0; u < V; ++u) {
+      if (non_path_incident[u].size() == 1) {
+        unpaired_modes.push_back(get_aux_majorana(u, spin, 1));
+      } else if (non_path_incident[u].size() == 0) {
+        unpaired_modes.push_back(get_aux_majorana(u, spin, 0));
+        unpaired_modes.push_back(get_aux_majorana(u, spin, 1));
+      }
+    }
+
+    // Unused aux Majorana modes become trivial stabilizers
+    for (std::size_t i = 0; i < unpaired_modes.size(); i += 2) {
+      if (i + 1 < unpaired_modes.size()) {
+        auto [coeff, word] =
+            get_bilinear(unpaired_modes[i], unpaired_modes[i + 1]);
+        stabilizers.emplace_back(coeff, std::move(word));
       }
     }
   }
 
   std::vector<std::pair<std::complex<double>, SparsePauliWord>> upper_triangle;
-  upper_triangle.reserve(M * (M - 1) / 2);
+  upper_triangle.reserve(base_modes * (base_modes - 1) / 2);
 
-  for (std::size_t u = 0; u < M; ++u) {
-    for (std::size_t v = u + 1; v < M; ++v) {
+  for (std::size_t u = 0; u < base_modes; ++u) {
+    for (std::size_t v = u + 1; v < base_modes; ++v) {
       std::size_t u_mode = u / 2;
       std::size_t v_mode = v / 2;
       std::size_t s_u = u_mode / V;
@@ -513,22 +531,26 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
       bool connected = (s_u == s_v) && lattice.are_connected(i, j);
 
       if (connected) {
-        std::size_t snake_i = rm_to_snake[i];
-        std::size_t snake_j = rm_to_snake[j];
-        std::size_t snake_min = std::min(snake_i, snake_j);
-        std::size_t snake_max = std::max(snake_i, snake_j);
+        std::size_t path_i = site_to_path_idx[i];
+        std::size_t path_j = site_to_path_idx[j];
+        std::size_t path_min = std::min(path_i, path_j);
+        std::size_t path_max = std::max(path_i, path_j);
 
         std::size_t p = get_sys_majorana(i, s_u, a);
         std::size_t q = get_sys_majorana(j, s_v, b_idx);
         auto [coeff, word] = get_bilinear(p, q);
 
-        if (snake_max - snake_min > 1) {
+        // For non-local paths, the raw JW bilinear iγ_pγ_q loses its long
+        // Z-string by multiplying by edge stabilizer iγ̃_aγ̃_b
+        if (path_max - path_min > 1) {
           auto key = std::make_pair(std::min(i, j), std::max(i, j));
+          // Fetch the coefficient and Pauli word for the edge
           std::size_t stab_idx = edge_to_stab_idx[s_u].at(key);
-          const auto& stab = stabilizers[stab_idx];
+          const auto& [b_coeff, b_word] = stabilizers[stab_idx];
+
           auto [phase, new_word] =
-              PauliTermAccumulator::multiply_uncached(word, stab.second);
-          coeff *= stab.first * phase;
+              PauliTermAccumulator::multiply_uncached(word, b_word);
+          coeff *= b_coeff * phase;
           word = std::move(new_word);
         }
 

--- a/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
@@ -455,13 +455,14 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
     }
   }
 
-  // Ensure that we have no more than 1 aux Majorana mode per sys mode
+  // Ensure that we have no more than 2 aux Majorana modes per site
   for (std::uint64_t u = 0; u < V; ++u) {
     if (non_path_incident[u].size() > 2) {
-      throw std::runtime_error(name + ": Vertex has " +
-                               std::to_string(non_path_incident[u].size()) +
-                               " non-path edges, which exceeds the "
-                               "2-auxiliary-Majorana limit of the mapping.");
+      throw std::runtime_error(
+          name +
+          " requires no more than 2 aux Majorana modes per "
+          "site. Found vertex with " +
+          std::to_string(non_path_incident[u].size()) + " non-path edges.");
     }
   }
 
@@ -514,6 +515,8 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
     }
   }
 
+  // Build a lookup table of VC bilinears by dressing non-local JW bilinears
+  // with their stabilizer to make everything local.
   std::vector<std::pair<std::complex<double>, SparsePauliWord>> upper_triangle;
   upper_triangle.reserve(base_modes * (base_modes - 1) / 2);
 
@@ -544,7 +547,6 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
         // Z-string by multiplying by edge stabilizer iγ̃_aγ̃_b
         if (path_max - path_min > 1) {
           auto key = std::make_pair(std::min(i, j), std::max(i, j));
-          // Fetch the coefficient and Pauli word for the edge
           std::size_t stab_idx = edge_to_stab_idx[s_u].at(key);
           const auto& [b_coeff, b_word] = stabilizers[stab_idx];
 

--- a/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
@@ -374,16 +374,9 @@ MajoranaMapping MajoranaMapping::symmetry_conserving_bravyi_kitaev(
 
 // ── Factory: Verstraete-Cirac ──────────────────────────────────────────
 
-MajoranaMapping MajoranaMapping::verstraete_cirac(
-    const LatticeGraph& lattice, std::size_t num_spin_species) {
+MajoranaMapping MajoranaMapping::verstraete_cirac(const LatticeGraph& lattice) {
   using namespace detail;
   const std::string name = "verstraete-cirac";
-
-  // Support spinless or fermions with spin-½
-  if (num_spin_species != 1 && num_spin_species != 2) {
-    throw std::invalid_argument(name +
-                                " requires num_spin_species to be 1 or 2.");
-  }
 
   std::uint64_t V = lattice.num_sites();
   if (V < 3) {
@@ -407,35 +400,6 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
     site_to_path_idx[hamiltonian_path[k]] = k;
   }
 
-  std::size_t num_modes = num_spin_species * V;
-  std::size_t base_modes = 2 * num_modes;
-  auto jw_base = MajoranaMapping::jordan_wigner(base_modes);
-
-  auto get_sys_majorana = [&](std::uint64_t site, std::size_t spin,
-                              std::size_t offset) -> std::size_t {
-    std::size_t path_idx = site_to_path_idx[site];
-    return 2 * (2 * (spin * V + path_idx)) + offset;
-  };
-
-  auto get_aux_majorana = [&](std::uint64_t site, std::size_t spin,
-                              std::size_t offset) -> std::size_t {
-    std::size_t path_idx = site_to_path_idx[site];
-    return 2 * (2 * (spin * V + path_idx) + 1) + offset;
-  };
-
-  // Get a Pauli representation of the antisymmetric Majorana bilinear iγ_pγ_q
-  auto get_bilinear =
-      [&](std::size_t p,
-          std::size_t q) -> std::pair<std::complex<double>, SparsePauliWord> {
-    if (p < q) {
-      auto b = jw_base.bilinear(p, q);
-      return {b.first, b.second};
-    } else {
-      auto b = jw_base.bilinear(q, p);
-      return {-b.first, b.second};
-    }
-  };
-
   // Find all non-path edges incident to each vertex
   std::vector<std::vector<std::uint64_t>> non_path_incident(V);
   for (int k = 0; k < adj.outerSize(); ++k) {
@@ -455,22 +419,64 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
     }
   }
 
-  // Ensure that we have no more than 2 aux Majorana modes per site
+  // Count aux fermionic modes per site
+  std::vector<std::size_t> n_aux(V);
+  std::size_t total_n_aux = 0;
   for (std::uint64_t u = 0; u < V; ++u) {
-    if (non_path_incident[u].size() > 2) {
-      throw std::runtime_error(
-          name +
-          " requires no more than 2 aux Majorana modes per "
-          "site. Found vertex with " +
-          std::to_string(non_path_incident[u].size()) + " non-path edges.");
-    }
+    n_aux[u] = (non_path_incident[u].size() + 1) / 2;
+    total_n_aux += n_aux[u];
   }
+
+  std::size_t modes_per_spin = V + total_n_aux;
+  std::size_t num_modes = 2 * V;                 // 2 spin species
+  std::size_t base_qubits = 2 * modes_per_spin;  // total qubits in jw_base
+  std::size_t base_modes = 2 * base_qubits;      // total Majoranas in jw_base
+
+  auto jw_base = MajoranaMapping::jordan_wigner(base_qubits);
+
+  // Precompute mode offsets along the Hamiltonian path
+  std::vector<std::size_t> path_idx_to_mode_offset(V);
+  path_idx_to_mode_offset[0] = 0;
+  for (std::size_t k = 1; k < V; ++k) {
+    std::uint64_t prev_site = hamiltonian_path[k - 1];
+    path_idx_to_mode_offset[k] =
+        path_idx_to_mode_offset[k - 1] + 1 + n_aux[prev_site];
+  }
+
+  auto get_sys_majorana = [&](std::uint64_t site, std::size_t spin,
+                              std::size_t offset) -> std::size_t {
+    std::size_t path_idx = site_to_path_idx[site];
+    std::size_t mode_idx =
+        spin * modes_per_spin + path_idx_to_mode_offset[path_idx];
+    return 2 * mode_idx + offset;
+  };
+
+  auto get_aux_majorana = [&](std::uint64_t site, std::size_t spin,
+                              std::size_t offset) -> std::size_t {
+    std::size_t path_idx = site_to_path_idx[site];
+    std::size_t mode_idx =
+        spin * modes_per_spin + path_idx_to_mode_offset[path_idx];
+    return 2 * (mode_idx + 1) + offset;
+  };
+
+  // Get a Pauli representation of the antisymmetric Majorana bilinear iγ_pγ_q
+  auto get_bilinear =
+      [&](std::size_t p,
+          std::size_t q) -> std::pair<std::complex<double>, SparsePauliWord> {
+    if (p < q) {
+      auto b = jw_base.bilinear(p, q);
+      return {b.first, b.second};
+    } else {
+      auto b = jw_base.bilinear(q, p);
+      return {-b.first, b.second};
+    }
+  };
 
   std::vector<std::pair<std::complex<double>, SparsePauliWord>> stabilizers;
   std::vector<std::map<std::pair<std::uint64_t, std::uint64_t>, std::size_t>>
-      edge_to_stab_idx(num_spin_species);
+      edge_to_stab_idx(2);
 
-  for (std::size_t spin = 0; spin < num_spin_species; ++spin) {
+  for (std::size_t spin = 0; spin < 2; ++spin) {
     // Add 2-body link stabilizers for non-path edges on the lattice
     for (std::uint64_t u = 0; u < V; ++u) {
       for (std::uint64_t v : non_path_incident[u]) {
@@ -497,15 +503,14 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
     // lift boundary/corner codespace degeneracy
     std::vector<std::size_t> unpaired_modes;
     for (std::uint64_t u = 0; u < V; ++u) {
-      if (non_path_incident[u].size() == 1) {
-        unpaired_modes.push_back(get_aux_majorana(u, spin, 1));
-      } else if (non_path_incident[u].size() == 0) {
-        unpaired_modes.push_back(get_aux_majorana(u, spin, 0));
-        unpaired_modes.push_back(get_aux_majorana(u, spin, 1));
+      std::size_t A_u = non_path_incident[u].size();
+      if (A_u % 2 != 0) {
+        unpaired_modes.push_back(get_aux_majorana(u, spin, A_u));
       }
     }
 
     // Unused aux Majorana modes become trivial stabilizers
+    // (we are guaranteed an even number due to the handshaking lemma)
     for (std::size_t i = 0; i < unpaired_modes.size(); i += 2) {
       if (i + 1 < unpaired_modes.size()) {
         auto [coeff, word] =
@@ -516,12 +521,15 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
   }
 
   // Build a lookup table of VC bilinears by dressing non-local JW bilinears
-  // with their stabilizer to make everything local.
+  // with their stabilizer to make everything local
+  std::size_t num_physical_modes = 2 * V;
+  std::size_t num_physical_majoranas = 2 * num_physical_modes;
   std::vector<std::pair<std::complex<double>, SparsePauliWord>> upper_triangle;
-  upper_triangle.reserve(base_modes * (base_modes - 1) / 2);
+  upper_triangle.reserve(num_physical_majoranas * (num_physical_majoranas - 1) /
+                         2);
 
-  for (std::size_t u = 0; u < base_modes; ++u) {
-    for (std::size_t v = u + 1; v < base_modes; ++v) {
+  for (std::size_t u = 0; u < num_physical_majoranas; ++u) {
+    for (std::size_t v = u + 1; v < num_physical_majoranas; ++v) {
       std::size_t u_mode = u / 2;
       std::size_t v_mode = v / 2;
       std::size_t s_u = u_mode / V;
@@ -529,7 +537,7 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
       std::size_t i = u_mode % V;
       std::size_t j = v_mode % V;
       std::size_t a = u % 2;
-      std::size_t b_idx = v % 2;
+      std::size_t b = v % 2;
 
       bool connected = (s_u == s_v) && lattice.are_connected(i, j);
 
@@ -540,7 +548,7 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
         std::size_t path_max = std::max(path_i, path_j);
 
         std::size_t p = get_sys_majorana(i, s_u, a);
-        std::size_t q = get_sys_majorana(j, s_v, b_idx);
+        std::size_t q = get_sys_majorana(j, s_v, b);
         auto [coeff, word] = get_bilinear(p, q);
 
         // For non-local paths, the raw JW bilinear iγ_pγ_q loses its long
@@ -559,7 +567,7 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
         upper_triangle.emplace_back(coeff, std::move(word));
       } else {
         std::size_t p = get_sys_majorana(i, s_u, a);
-        std::size_t q = get_sys_majorana(j, s_v, b_idx);
+        std::size_t q = get_sys_majorana(j, s_v, b);
         auto [coeff, word] = get_bilinear(p, q);
         upper_triangle.emplace_back(coeff, std::move(word));
       }
@@ -567,8 +575,9 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(
   }
 
   return MajoranaMapping(std::vector<SparsePauliWord>{},
-                         std::move(upper_triangle), name, num_modes, base_modes,
-                         name, std::nullopt, std::move(stabilizers));
+                         std::move(upper_triangle), name, num_physical_modes,
+                         base_qubits, name, std::nullopt,
+                         std::move(stabilizers));
 }
 
 }  // namespace qdk::chemistry::data

--- a/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_mapping_factories.cpp
@@ -109,43 +109,6 @@ constexpr std::uint8_t op_x = 1;
 constexpr std::uint8_t op_y = 2;
 constexpr std::uint8_t op_z = 3;
 
-bool find_hamiltonian_path_dfs(std::uint64_t curr,
-                               const Eigen::SparseMatrix<double>& adj,
-                               std::vector<bool>& visited,
-                               std::vector<std::uint64_t>& path) {
-  path.push_back(curr);
-  if (path.size() == static_cast<std::size_t>(adj.rows())) {
-    return true;
-  }
-  visited[curr] = true;
-
-  // Iterate directly over the sparse matrix columns/rows for neighbors
-  for (Eigen::SparseMatrix<double>::InnerIterator it(adj, curr); it; ++it) {
-    std::uint64_t neighbor = it.row();
-    if (neighbor != curr && !visited[neighbor]) {
-      if (find_hamiltonian_path_dfs(neighbor, adj, visited, path)) {
-        return true;
-      }
-    }
-  }
-  visited[curr] = false;
-  path.pop_back();
-  return false;
-}
-
-std::vector<std::uint64_t> find_hamiltonian_path(
-    const Eigen::SparseMatrix<double>& adj) {
-  std::uint64_t V = adj.rows();
-  std::vector<bool> visited(V, false);
-  std::vector<std::uint64_t> path;
-  for (std::uint64_t start = 0; start < V; ++start) {
-    if (find_hamiltonian_path_dfs(start, adj, visited, path)) {
-      return path;
-    }
-  }
-  return {};
-}
-
 }  // namespace detail
 
 // ── Factory: Jordan-Wigner ───────────────────────────────────────────
@@ -384,36 +347,21 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(const LatticeGraph& lattice) {
         name + " requires a lattice graph with at least 3 sites");
   }
 
-  // Construct a Hamiltonian path from the graph adjacency matrix
+  // Since the lattice graph is pre-ordered optimally (if requested) or
+  // processed in default ordering, the node sequence/path is simply 0, 1, ...,
+  // V-1. Identify all non-adjacent edges incident to each vertex.
   const auto& adj = lattice.sparse_adjacency_matrix();
-  std::vector<std::uint64_t> hamiltonian_path = find_hamiltonian_path(adj);
-  if (hamiltonian_path.empty()) {
-    throw std::runtime_error(
-        name +
-        ": No Hamiltonian path found in the lattice graph. A Hamiltonian path "
-        "is required to construct commuting stabilizers.");
-  }
-
-  // Map row-major site index to its position in the Hamiltonian path
-  std::vector<std::uint64_t> site_to_path_idx(V);
-  for (std::uint64_t k = 0; k < V; ++k) {
-    site_to_path_idx[hamiltonian_path[k]] = k;
-  }
-
-  // Find all non-path edges incident to each vertex
-  std::vector<std::vector<std::uint64_t>> non_path_incident(V);
+  std::vector<std::vector<std::uint64_t>> non_adjacent_incident(V);
   for (int k = 0; k < adj.outerSize(); ++k) {
     for (Eigen::SparseMatrix<double>::InnerIterator it(adj, k); it; ++it) {
       std::uint64_t u = it.row();
       std::uint64_t v = it.col();
-      // Since the matrix is symmetric, only process the upper-triangle
+      // Since the matrix is symmetric, only process the upper-triangle (u < v)
       if (u < v) {
-        std::size_t s_u = site_to_path_idx[u];
-        std::size_t s_v = site_to_path_idx[v];
-        std::size_t diff = (s_u > s_v) ? (s_u - s_v) : (s_v - s_u);
+        std::size_t diff = v - u;
         if (diff > 1) {
-          non_path_incident[u].push_back(v);
-          non_path_incident[v].push_back(u);
+          non_adjacent_incident[u].push_back(v);
+          non_adjacent_incident[v].push_back(u);
         }
       }
     }
@@ -423,7 +371,7 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(const LatticeGraph& lattice) {
   std::vector<std::size_t> n_aux(V);
   std::size_t total_n_aux = 0;
   for (std::uint64_t u = 0; u < V; ++u) {
-    n_aux[u] = (non_path_incident[u].size() + 1) / 2;
+    n_aux[u] = (non_adjacent_incident[u].size() + 1) / 2;
     total_n_aux += n_aux[u];
   }
 
@@ -434,28 +382,23 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(const LatticeGraph& lattice) {
 
   auto jw_base = MajoranaMapping::jordan_wigner(base_qubits);
 
-  // Precompute mode offsets along the Hamiltonian path
-  std::vector<std::size_t> path_idx_to_mode_offset(V);
-  path_idx_to_mode_offset[0] = 0;
+  // Precompute mode offsets along the sequence of sites
+  std::vector<std::size_t> site_to_mode_offset(V);
+  site_to_mode_offset[0] = 0;
   for (std::size_t k = 1; k < V; ++k) {
-    std::uint64_t prev_site = hamiltonian_path[k - 1];
-    path_idx_to_mode_offset[k] =
-        path_idx_to_mode_offset[k - 1] + 1 + n_aux[prev_site];
+    std::uint64_t prev_site = k - 1;
+    site_to_mode_offset[k] = site_to_mode_offset[k - 1] + 1 + n_aux[prev_site];
   }
 
   auto get_sys_majorana = [&](std::uint64_t site, std::size_t spin,
                               std::size_t offset) -> std::size_t {
-    std::size_t path_idx = site_to_path_idx[site];
-    std::size_t mode_idx =
-        spin * modes_per_spin + path_idx_to_mode_offset[path_idx];
+    std::size_t mode_idx = spin * modes_per_spin + site_to_mode_offset[site];
     return 2 * mode_idx + offset;
   };
 
   auto get_aux_majorana = [&](std::uint64_t site, std::size_t spin,
                               std::size_t offset) -> std::size_t {
-    std::size_t path_idx = site_to_path_idx[site];
-    std::size_t mode_idx =
-        spin * modes_per_spin + path_idx_to_mode_offset[path_idx];
+    std::size_t mode_idx = spin * modes_per_spin + site_to_mode_offset[site];
     return 2 * (mode_idx + 1) + offset;
   };
 
@@ -477,16 +420,16 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(const LatticeGraph& lattice) {
       edge_to_stab_idx(2);
 
   for (std::size_t spin = 0; spin < 2; ++spin) {
-    // Add 2-body link stabilizers for non-path edges on the lattice
+    // Add 2-body link stabilizers for non-adjacent edges on the lattice
     for (std::uint64_t u = 0; u < V; ++u) {
-      for (std::uint64_t v : non_path_incident[u]) {
+      for (std::uint64_t v : non_adjacent_incident[u]) {
         if (u < v) {
-          auto it_u = std::find(non_path_incident[u].begin(),
-                                non_path_incident[u].end(), v);
-          auto it_v = std::find(non_path_incident[v].begin(),
-                                non_path_incident[v].end(), u);
-          std::size_t a = std::distance(non_path_incident[u].begin(), it_u);
-          std::size_t b = std::distance(non_path_incident[v].begin(), it_v);
+          auto it_u = std::find(non_adjacent_incident[u].begin(),
+                                non_adjacent_incident[u].end(), v);
+          auto it_v = std::find(non_adjacent_incident[v].begin(),
+                                non_adjacent_incident[v].end(), u);
+          std::size_t a = std::distance(non_adjacent_incident[u].begin(), it_u);
+          std::size_t b = std::distance(non_adjacent_incident[v].begin(), it_v);
 
           std::size_t p = get_aux_majorana(u, spin, a);
           std::size_t q = get_aux_majorana(v, spin, b);
@@ -503,7 +446,7 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(const LatticeGraph& lattice) {
     // lift boundary/corner codespace degeneracy
     std::vector<std::size_t> unpaired_modes;
     for (std::uint64_t u = 0; u < V; ++u) {
-      std::size_t A_u = non_path_incident[u].size();
+      std::size_t A_u = non_adjacent_incident[u].size();
       if (A_u % 2 != 0) {
         unpaired_modes.push_back(get_aux_majorana(u, spin, A_u));
       }
@@ -542,10 +485,8 @@ MajoranaMapping MajoranaMapping::verstraete_cirac(const LatticeGraph& lattice) {
       bool connected = (s_u == s_v) && lattice.are_connected(i, j);
 
       if (connected) {
-        std::size_t path_i = site_to_path_idx[i];
-        std::size_t path_j = site_to_path_idx[j];
-        std::size_t path_min = std::min(path_i, path_j);
-        std::size_t path_max = std::max(path_i, path_j);
+        std::size_t path_min = std::min(i, j);
+        std::size_t path_max = std::max(i, j);
 
         std::size_t p = get_sys_majorana(i, s_u, a);
         std::size_t q = get_sys_majorana(j, s_v, b);

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -611,3 +611,24 @@
     year={1992},
     doi={10.1016/0375-9601(92)90335-J}
 }
+@article{Verstraete2005,
+    title={Mapping local {Hamiltonians} of fermions onto local {Hamiltonians} of spins},
+    author={F. Verstraete and J. I. Cirac},
+    journal={Journal of Statistical Mechanics: Theory and Experiment},
+    volume={2005},
+    number={09},
+    pages={P09012},
+    year={2005},
+    doi={10.1088/1742-5468/2005/09/P09012}
+}
+@article{Whitfield2016,
+    title={Local spin operators for fermion simulations},
+    author={James D. Whitfield and Vojt{\v{e}}ch Havl{\'i}{\v{c}}ek and Matthias Troyer},
+    journal={Physical Review A},
+    volume={94},
+    number={3},
+    pages={030301},
+    year={2016},
+    doi={10.1103/PhysRevA.94.030301},
+    url={https://arxiv.org/abs/1605.09789}
+}

--- a/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
+++ b/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
@@ -55,7 +55,7 @@ Bravyi-Kitaev tree :cite:`Havlicek2017`
 .. _encoding-verstraete-cirac:
 
 Verstraete-Cirac :cite:`Verstraete2005`
-   An auxiliary-qubit encoding designed for 2D lattices. It eliminates non-local Z-strings by introducing flag qubits that locally track parity. Max Pauli weight of nearest-neighbor hops remains constant regardless of lattice size. Use :meth:`~qdk_chemistry.data.MajoranaMapping.verstraete_cirac` with a :class:`~qdk_chemistry.data.LatticeGraph`.
+   An auxiliary-qubit encoding that operates on a general connected :class:`~qdk_chemistry.data.LatticeGraph` that admits a Hamiltonian path. It eliminates non-local Z-strings by introducing auxiliary qubits that locally track parity. For 2D square grids, the maximum Pauli weight of nearest-neighbor hopping terms remains constant regardless of the grid size. Use :meth:`~qdk_chemistry.data.MajoranaMapping.verstraete_cirac` with a :class:`~qdk_chemistry.data.LatticeGraph`.
 
 Using the QubitMapper
 ---------------------

--- a/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
+++ b/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
@@ -52,6 +52,10 @@ Symmetry-conserving Bravyi-Kitaev :cite:`Bravyi2017tapering`
 Bravyi-Kitaev tree :cite:`Havlicek2017`
    A tree-based variant of the Bravyi-Kitaev transformation that uses a different qubit indexing strategy.
 
+.. _encoding-verstraete-cirac:
+
+Verstraete-Cirac :cite:`Verstraete2005`
+   An auxiliary-qubit encoding designed for 2D lattices. It eliminates non-local Z-strings by introducing flag qubits that locally track parity. Max Pauli weight of nearest-neighbor hops remains constant regardless of lattice size. Use :meth:`~qdk_chemistry.data.MajoranaMapping.verstraete_cirac` with a :class:`~qdk_chemistry.data.LatticeGraph`.
 
 Using the QubitMapper
 ---------------------
@@ -188,7 +192,7 @@ This is a **table-driven** backend: it reads the Pauli-string table from the :cl
 Any valid ``MajoranaMapping`` works — factory-produced or custom user-defined tables.
 The mapping's ``name`` and ``base_encoding`` are used only for metadata on the output, not to select a transform.
 
-Supported encodings: :ref:`Jordan-Wigner <encoding-jordan-wigner>`, :ref:`Bravyi-Kitaev <encoding-bravyi-kitaev>`, :ref:`Bravyi-Kitaev tree <encoding-bk-tree>`, :ref:`Parity <encoding-parity>`, :ref:`SCBK <encoding-scbk>`, and any custom encoding
+Supported encodings: :ref:`Jordan-Wigner <encoding-jordan-wigner>`, :ref:`Bravyi-Kitaev <encoding-bravyi-kitaev>`, :ref:`Bravyi-Kitaev tree <encoding-bk-tree>`, :ref:`Parity <encoding-parity>`, :ref:`SCBK <encoding-scbk>`, :ref:`Verstraete-Cirac <encoding-verstraete-cirac>`, and any custom encoding
 
 The native mapper uses blocked spin-orbital ordering internally (alpha orbitals first, then beta orbitals).
 Use ``QubitHamiltonian.to_interleaved()`` for alternative qubit orderings if needed.

--- a/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
+++ b/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
@@ -199,6 +199,10 @@ Use ``QubitHamiltonian.to_interleaved()`` for alternative qubit orderings if nee
 
 Both restricted (RHF) and unrestricted (UHF) Hamiltonians are supported.
 
+.. note::
+   **Fast paths for factorized/sparse Hamiltonians:**
+   When running the ``"qdk"`` mapper, passing a :class:`~qdk_chemistry.data.Hamiltonian` object wrapping a :class:`~qdk_chemistry.data.CholeskyHamiltonianContainer` or a :class:`~qdk_chemistry.data.SparseHamiltonianContainer` triggers container-aware fast paths. These paths bypass full materialization of dense :math:`N^4` two-body integral tensors, saving significant memory and runtime while producing numerically identical results.
+
 Custom encodings can be defined by constructing a :class:`~qdk_chemistry.data.MajoranaMapping` from a Pauli-string table.
 
 .. rubric:: Settings

--- a/python/src/pybind11/data/lattice_graph.cpp
+++ b/python/src/pybind11/data/lattice_graph.cpp
@@ -295,7 +295,8 @@ Examples:
     >>> ring = LatticeGraph.chain(6, periodic=True)
 )",
                            py::arg("n"), py::arg("periodic") = false,
-                           py::arg("t") = 1.0);
+                           py::arg("t") = 1.0,
+                           py::arg("optimal_ordering") = false);
 
   lattice_graph.def_static("square", &LatticeGraph::square, R"(
 Create a two-dimensional square lattice.
@@ -332,9 +333,11 @@ Raises:
 )",
                            py::arg("nx"), py::arg("ny"),
                            py::arg("periodic_x") = false,
-                           py::arg("periodic_y") = false, py::arg("t") = 1.0);
+                           py::arg("periodic_y") = false, py::arg("t") = 1.0,
+                           py::arg("optimal_ordering") = false);
 
-  lattice_graph.def_static("triangular", &LatticeGraph::triangular, R"(
+  lattice_graph.def_static(
+      "triangular", &LatticeGraph::triangular, R"(
 Create a two-dimensional triangular lattice.
 
 Sites are indexed in row-major order: site index = y * nx + x.
@@ -371,10 +374,9 @@ Returns:
 Raises:
     ValueError: If nx or ny is 0.
 )",
-                           py::arg("nx"), py::arg("ny"),
-                           py::arg("periodic_x") = false,
-                           py::arg("periodic_y") = false, py::arg("t") = 1.0,
-                           py::arg("coloring_seed") = 0);
+      py::arg("nx"), py::arg("ny"), py::arg("periodic_x") = false,
+      py::arg("periodic_y") = false, py::arg("t") = 1.0,
+      py::arg("coloring_seed") = 0, py::arg("optimal_ordering") = false);
 
   lattice_graph.def_static("honeycomb", &LatticeGraph::honeycomb, R"(
 Create a two-dimensional honeycomb lattice.
@@ -417,9 +419,11 @@ Raises:
 )",
                            py::arg("nx"), py::arg("ny"),
                            py::arg("periodic_x") = false,
-                           py::arg("periodic_y") = false, py::arg("t") = 1.0);
+                           py::arg("periodic_y") = false, py::arg("t") = 1.0,
+                           py::arg("optimal_ordering") = false);
 
-  lattice_graph.def_static("kagome", &LatticeGraph::kagome, R"(
+  lattice_graph.def_static(
+      "kagome", &LatticeGraph::kagome, R"(
 Create a two-dimensional kagome lattice.
 
 The kagome lattice has three sites per unit cell, arranged as
@@ -467,10 +471,9 @@ Returns:
 Raises:
     ValueError: If nx or ny is 0.
 )",
-                           py::arg("nx"), py::arg("ny"),
-                           py::arg("periodic_x") = false,
-                           py::arg("periodic_y") = false, py::arg("t") = 1.0,
-                           py::arg("coloring_seed") = 0);
+      py::arg("nx"), py::arg("ny"), py::arg("periodic_x") = false,
+      py::arg("periodic_y") = false, py::arg("t") = 1.0,
+      py::arg("coloring_seed") = 0, py::arg("optimal_ordering") = false);
 
   lattice_graph.def("__repr__", [](const LatticeGraph &self) {
     return "<LatticeGraph sites=" + std::to_string(self.num_sites()) +

--- a/python/src/pybind11/data/majorana_mapping.cpp
+++ b/python/src/pybind11/data/majorana_mapping.cpp
@@ -8,6 +8,7 @@
 #include <pybind11/stl.h>
 
 #include <nlohmann/json.hpp>
+#include <qdk/chemistry/data/lattice_graph.hpp>
 #include <qdk/chemistry/data/majorana_mapping.hpp>
 #include <qdk/chemistry/data/pauli_operator.hpp>
 #include <qdk/chemistry/data/tapering.hpp>
@@ -145,6 +146,8 @@ bilinear(j, k) is available on both forms.
       .def_property_readonly("num_qubits", &MajoranaMapping::num_qubits)
       .def_property_readonly("name", &MajoranaMapping::name)
       .def_property_readonly("base_encoding", &MajoranaMapping::base_encoding)
+      .def_property_readonly("grid_nx", &MajoranaMapping::grid_nx)
+      .def_property_readonly("grid_ny", &MajoranaMapping::grid_ny)
       .def_property_readonly("table", &MajoranaMapping::table)
       .def_property_readonly("tapering",
                              [](const MajoranaMapping& self)
@@ -198,6 +201,9 @@ bilinear(j, k) is available on both forms.
       });
 
   mapping
+      .def_static("verstraete_cirac", &MajoranaMapping::verstraete_cirac,
+                  py::arg("lattice"), py::arg("num_spin_species") = 2,
+                  "Construct a Verstraete-Cirac encoding.")
       .def_static("jordan_wigner", &MajoranaMapping::jordan_wigner,
                   py::arg("num_modes"), "Construct a Jordan-Wigner encoding.")
       .def_static("bravyi_kitaev", &MajoranaMapping::bravyi_kitaev,

--- a/python/src/pybind11/data/majorana_mapping.cpp
+++ b/python/src/pybind11/data/majorana_mapping.cpp
@@ -233,8 +233,7 @@ bilinear(j, k) is available on both forms.
           py::arg("num_modes"), py::arg("symmetries"),
           "Construct a symmetry-conserving Bravyi-Kitaev encoding.")
       .def_static("verstraete_cirac", &MajoranaMapping::verstraete_cirac,
-                  py::arg("lattice"),
-                  "Construct a Verstraete-Cirac encoding.");
+                  py::arg("lattice"), "Construct a Verstraete-Cirac encoding.");
 
   mapping
       .def(

--- a/python/src/pybind11/data/majorana_mapping.cpp
+++ b/python/src/pybind11/data/majorana_mapping.cpp
@@ -233,7 +233,7 @@ bilinear(j, k) is available on both forms.
           py::arg("num_modes"), py::arg("symmetries"),
           "Construct a symmetry-conserving Bravyi-Kitaev encoding.")
       .def_static("verstraete_cirac", &MajoranaMapping::verstraete_cirac,
-                  py::arg("lattice"), py::arg("num_spin_species") = 2,
+                  py::arg("lattice"),
                   "Construct a Verstraete-Cirac encoding.");
 
   mapping

--- a/python/src/pybind11/data/majorana_mapping.cpp
+++ b/python/src/pybind11/data/majorana_mapping.cpp
@@ -8,6 +8,7 @@
 #include <pybind11/stl.h>
 
 #include <nlohmann/json.hpp>
+#include <qdk/chemistry/data/hamiltonian.hpp>
 #include <qdk/chemistry/data/lattice_graph.hpp>
 #include <qdk/chemistry/data/majorana_mapping.hpp>
 #include <qdk/chemistry/data/pauli_operator.hpp>
@@ -330,5 +331,21 @@ handles each spin channel independently (unrestricted orbitals).
 
 Returns ``(words, coefficients)`` where ``words`` is a list of sparse
 Pauli words.
+)");
+
+  data.def(
+      "majorana_map_hamiltonian",
+      [](const MajoranaMapping& mapping, const Hamiltonian& hamiltonian,
+         double threshold, double integral_threshold) -> py::tuple {
+        auto result = majorana_map_hamiltonian(mapping, hamiltonian, threshold,
+                                               integral_threshold);
+        return py::make_tuple(py::cast(result.words),
+                              py::cast(result.coefficients));
+      },
+      py::arg("mapping"), py::arg("hamiltonian"), py::arg("threshold"),
+      py::arg("integral_threshold"),
+      R"(
+Map a fermionic Hamiltonian object directly to qubit Pauli terms.
+By passing the Hamiltonian directly, the mapping engine can exploit sparse/factorized ERI structures.
 )");
 }

--- a/python/src/pybind11/data/majorana_mapping.cpp
+++ b/python/src/pybind11/data/majorana_mapping.cpp
@@ -146,14 +146,13 @@ bilinear(j, k) is available on both forms.
       .def_property_readonly("num_qubits", &MajoranaMapping::num_qubits)
       .def_property_readonly("name", &MajoranaMapping::name)
       .def_property_readonly("base_encoding", &MajoranaMapping::base_encoding)
-      .def_property_readonly("grid_nx", &MajoranaMapping::grid_nx)
-      .def_property_readonly("grid_ny", &MajoranaMapping::grid_ny)
       .def_property_readonly("table", &MajoranaMapping::table)
       .def_property_readonly("tapering",
                              [](const MajoranaMapping& self)
                                  -> std::optional<TaperingSpecification> {
                                return self.tapering();
                              })
+      .def_property_readonly("stabilizers", &MajoranaMapping::stabilizers)
       .def_property_readonly("is_majorana_atomic",
                              &MajoranaMapping::is_majorana_atomic)
       .def(
@@ -201,9 +200,6 @@ bilinear(j, k) is available on both forms.
       });
 
   mapping
-      .def_static("verstraete_cirac", &MajoranaMapping::verstraete_cirac,
-                  py::arg("lattice"), py::arg("num_spin_species") = 2,
-                  "Construct a Verstraete-Cirac encoding.")
       .def_static("jordan_wigner", &MajoranaMapping::jordan_wigner,
                   py::arg("num_modes"), "Construct a Jordan-Wigner encoding.")
       .def_static("bravyi_kitaev", &MajoranaMapping::bravyi_kitaev,
@@ -235,7 +231,10 @@ bilinear(j, k) is available on both forms.
                 num_modes, n_alpha, n_beta);
           },
           py::arg("num_modes"), py::arg("symmetries"),
-          "Construct a symmetry-conserving Bravyi-Kitaev encoding.");
+          "Construct a symmetry-conserving Bravyi-Kitaev encoding.")
+      .def_static("verstraete_cirac", &MajoranaMapping::verstraete_cirac,
+                  py::arg("lattice"), py::arg("num_spin_species") = 2,
+                  "Construct a Verstraete-Cirac encoding.");
 
   mapping
       .def(

--- a/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
+++ b/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
@@ -143,10 +143,14 @@ class QdkQubitMapper(QubitMapper):
         n_spin_orbitals = 2 * n_spatial
         spin_symmetric = hamiltonian.get_orbitals().is_restricted()
 
-        if base_mapping.num_modes not in (n_spatial, n_spin_orbitals):
+        allowed_modes: tuple[int, ...] = (
+            (n_spin_orbitals,) if hamiltonian.has_two_body_integrals() else (n_spatial, n_spin_orbitals)
+        )
+
+        if base_mapping.num_modes not in allowed_modes:
             raise ValueError(
                 f"MajoranaMapping has {base_mapping.num_modes} modes but the Hamiltonian has "
-                f"{n_spatial} spatial orbitals (which requires either {n_spatial} or {n_spin_orbitals} modes). "
+                f"{n_spatial} spatial orbitals (which requires one of {allowed_modes} modes). "
                 f"Use MajoranaMapping.jordan_wigner(num_modes={n_spin_orbitals}) or equivalent."
             )
 

--- a/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
+++ b/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
@@ -138,7 +138,6 @@ class QdkQubitMapper(QubitMapper):
         integral_threshold = float(self.settings().get("integral_threshold"))
 
         h1_alpha, h1_beta = hamiltonian.get_one_body_integrals()
-        h2_aaaa, h2_aabb, h2_bbbb = hamiltonian.get_two_body_integrals()
         n_spatial = h1_alpha.shape[0]
         n_spin_orbitals = 2 * n_spatial
         spin_symmetric = hamiltonian.get_orbitals().is_restricted()
@@ -154,25 +153,35 @@ class QdkQubitMapper(QubitMapper):
                 f"Use MajoranaMapping.jordan_wigner(num_modes={n_spin_orbitals}) or equivalent."
             )
 
-        h1_a_flat = np.ascontiguousarray(h1_alpha).ravel()
-        h1_b_flat = h1_a_flat if spin_symmetric else np.ascontiguousarray(h1_beta).ravel()
-        h2_aaaa_flat = np.ascontiguousarray(h2_aaaa).ravel()
-        h2_aabb_flat = h2_aaaa_flat if spin_symmetric else np.ascontiguousarray(h2_aabb).ravel()
-        h2_bbbb_flat = h2_aaaa_flat if spin_symmetric else np.ascontiguousarray(h2_bbbb).ravel()
+        container_type = hamiltonian.get_container_type()
+        if container_type in ("cholesky", "sparse"):
+            words, coefficients = majorana_map_hamiltonian(
+                base_mapping,
+                hamiltonian,
+                threshold,
+                integral_threshold,
+            )
+        else:
+            h1_a_flat = np.ascontiguousarray(h1_alpha).ravel()
+            h1_b_flat = h1_a_flat if spin_symmetric else np.ascontiguousarray(h1_beta).ravel()
+            h2_aaaa, h2_aabb, h2_bbbb = hamiltonian.get_two_body_integrals()
+            h2_aaaa_flat = np.ascontiguousarray(h2_aaaa).ravel()
+            h2_aabb_flat = h2_aaaa_flat if spin_symmetric else np.ascontiguousarray(h2_aabb).ravel()
+            h2_bbbb_flat = h2_aaaa_flat if spin_symmetric else np.ascontiguousarray(h2_bbbb).ravel()
 
-        words, coefficients = majorana_map_hamiltonian(
-            base_mapping,
-            0.0,
-            h1_a_flat,
-            h1_b_flat,
-            h2_aaaa_flat,
-            h2_aabb_flat,
-            h2_bbbb_flat,
-            n_spatial,
-            spin_symmetric,
-            threshold,
-            integral_threshold,
-        )
+            words, coefficients = majorana_map_hamiltonian(
+                base_mapping,
+                0.0,
+                h1_a_flat,
+                h1_b_flat,
+                h2_aaaa_flat,
+                h2_aabb_flat,
+                h2_bbbb_flat,
+                n_spatial,
+                spin_symmetric,
+                threshold,
+                integral_threshold,
+            )
 
         n_qubits = base_mapping.num_qubits
         pauli_strings = [sparse_pauli_word_to_label(word, n_qubits) for word in words]

--- a/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
+++ b/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
@@ -143,10 +143,10 @@ class QdkQubitMapper(QubitMapper):
         n_spin_orbitals = 2 * n_spatial
         spin_symmetric = hamiltonian.get_orbitals().is_restricted()
 
-        if base_mapping.num_modes != n_spin_orbitals:
+        if base_mapping.num_modes not in (n_spatial, n_spin_orbitals):
             raise ValueError(
                 f"MajoranaMapping has {base_mapping.num_modes} modes but the Hamiltonian has "
-                f"{n_spin_orbitals} spin-orbitals (2 x {n_spatial} spatial orbitals). "
+                f"{n_spatial} spatial orbitals (which requires either {n_spatial} or {n_spin_orbitals} modes). "
                 f"Use MajoranaMapping.jordan_wigner(num_modes={n_spin_orbitals}) or equivalent."
             )
 

--- a/python/tests/test_qdk_qubit_mapper_factorized.py
+++ b/python/tests/test_qdk_qubit_mapper_factorized.py
@@ -1,0 +1,288 @@
+"""Tests for specialized fast mapping paths (Cholesky, Sparse) in QdkQubitMapper."""
+
+import numpy as np
+import pytest
+
+from qdk_chemistry.algorithms import create
+from qdk_chemistry.data import (
+    CanonicalFourCenterHamiltonianContainer,
+    CholeskyHamiltonianContainer,
+    Hamiltonian,
+    LatticeGraph,
+    MajoranaMapping,
+    Orbitals,
+    QubitHamiltonian,
+)
+from qdk_chemistry.utils.model_hamiltonians import (
+    create_hubbard_hamiltonian,
+    create_ppp_hamiltonian,
+    ohno_potential,
+)
+from .test_helpers import create_test_basis_set
+
+
+def assert_qubit_hamiltonians_equal(qh1: QubitHamiltonian, qh2: QubitHamiltonian, atol: float = 1e-12):
+    """Compare two QubitHamiltonians term-by-term within absolute tolerance."""
+    dict1 = {k: v for k, v in zip(qh1.pauli_strings, qh1.coefficients) if abs(v) > atol}
+    dict2 = {k: v for k, v in zip(qh2.pauli_strings, qh2.coefficients) if abs(v) > atol}
+
+    keys1 = set(dict1.keys())
+    keys2 = set(dict2.keys())
+
+    # Ensure all significantly large coefficients are present in both
+    missing_in_2 = keys1 - keys2
+    missing_in_1 = keys2 - keys1
+
+    for k in missing_in_2:
+        assert abs(dict1[k]) < 1e-11, f"Term {k} is missing in dense path but present in fast path with value {dict1[k]}"
+    for k in missing_in_1:
+        assert abs(dict2[k]) < 1e-11, f"Term {k} is missing in fast path but present in dense path with value {dict2[k]}"
+
+    # Check overlapping keys
+    for k in keys1.intersection(keys2):
+        val1 = dict1[k]
+        val2 = dict2[k]
+        assert np.isclose(val1, val2, atol=atol, rtol=1e-8), f"Coefficients mismatch for term {k}: fast={val1}, dense={val2}"
+
+
+def make_dense_counterpart(h_fast: Hamiltonian) -> Hamiltonian:
+    """Reconstruct a dense CanonicalFourCenterHamiltonianContainer from the fast one."""
+    h1_alpha, h1_beta = h_fast.get_one_body_integrals()
+    h2_aaaa, h2_aabb, h2_bbbb = h_fast.get_two_body_integrals()
+    orbitals = h_fast.get_orbitals()
+    core_energy = h_fast.get_core_energy()
+    norb = h1_alpha.shape[0]
+
+    if orbitals.is_restricted():
+        fock = np.zeros((norb, norb))
+        container_dense = CanonicalFourCenterHamiltonianContainer(
+            h1_alpha, h2_aaaa, orbitals, core_energy, fock
+        )
+    else:
+        fock_a = np.zeros((norb, norb))
+        fock_b = np.zeros((norb, norb))
+        container_dense = CanonicalFourCenterHamiltonianContainer(
+            h1_alpha, h1_beta,
+            h2_aaaa, h2_aabb, h2_bbbb,
+            orbitals, core_energy, fock_a, fock_b
+        )
+    return Hamiltonian(container_dense)
+
+
+def make_random_restricted_cholesky(norb: int, naux: int = 15, seed: int = 42):
+    """Construct a mock restricted Cholesky Hamiltonian."""
+    rng = np.random.default_rng(seed)
+
+    one_body = rng.standard_normal((norb, norb))
+    one_body = 0.5 * (one_body + one_body.T)
+
+    three_center = rng.standard_normal((norb * norb, naux))
+
+    coeffs = np.eye(norb)
+    basis_set = create_test_basis_set(norb, f"test-restricted-{norb}")
+    orbitals = Orbitals(coeffs, None, None, basis_set)
+
+    fock = rng.standard_normal((norb, norb))
+    fock = 0.5 * (fock + fock.T)
+
+    container = CholeskyHamiltonianContainer(
+        one_body, three_center, orbitals, 1.5, fock
+    )
+    return Hamiltonian(container)
+
+
+def make_random_unrestricted_cholesky(norb: int, naux: int = 15, seed: int = 42):
+    """Construct a mock unrestricted Cholesky Hamiltonian."""
+    rng = np.random.default_rng(seed)
+
+    one_body_a = rng.standard_normal((norb, norb))
+    one_body_a = 0.5 * (one_body_a + one_body_a.T)
+    one_body_b = rng.standard_normal((norb, norb))
+    one_body_b = 0.5 * (one_body_b + one_body_b.T)
+
+    three_center_aa = rng.standard_normal((norb * norb, naux))
+    three_center_bb = rng.standard_normal((norb * norb, naux))
+
+    coeffs_alpha = np.eye(norb)
+    coeffs_beta = np.eye(norb)
+    if norb >= 2:
+        coeffs_beta[0, 0] = 0.8
+        coeffs_beta[0, 1] = 0.6
+        coeffs_beta[1, 0] = 0.6
+        coeffs_beta[1, 1] = -0.8
+
+    basis_set = create_test_basis_set(norb, f"test-unrestricted-{norb}")
+    orbitals = Orbitals(coeffs_alpha, coeffs_beta, None, None, None, basis_set)
+
+    fock_a = rng.standard_normal((norb, norb))
+    fock_a = 0.5 * (fock_a + fock_a.T)
+    fock_b = rng.standard_normal((norb, norb))
+    fock_b = 0.5 * (fock_b + fock_b.T)
+
+    container = CholeskyHamiltonianContainer(
+        one_body_a, one_body_b,
+        three_center_aa, three_center_bb,
+        orbitals, 2.0, fock_a, fock_b
+    )
+    return Hamiltonian(container)
+
+
+# Sweeps: systems H2 (norb=2), H2O (norb=7), N2 (norb=14)
+def test_cholesky_fast_path():
+    """Verify the Cholesky fast path matches the dense counterpart term-by-term."""
+    for norb in [2, 7, 14]:
+        for is_restricted in [True, False]:
+            for encoding in ["jordan_wigner", "bravyi_kitaev", "parity"]:
+                # Construct the Cholesky Hamiltonian
+                if is_restricted:
+                    h_fast = make_random_restricted_cholesky(norb)
+                else:
+                    h_fast = make_random_unrestricted_cholesky(norb)
+
+                # Get mapping
+                num_modes = 2 * norb
+                if encoding == "jordan_wigner":
+                    mapping = MajoranaMapping.jordan_wigner(num_modes)
+                elif encoding == "bravyi_kitaev":
+                    mapping = MajoranaMapping.bravyi_kitaev(num_modes)
+                else:
+                    mapping = MajoranaMapping.parity(num_modes)
+
+                # Map with fast path
+                mapper = create("qubit_mapper", "qdk")
+                qh_fast = mapper.run(h_fast, mapping)
+
+                # Map with dense fallback
+                h_dense = make_dense_counterpart(h_fast)
+                qh_dense = mapper.run(h_dense, mapping)
+
+                # Assert equivalence
+                assert_qubit_hamiltonians_equal(qh_fast, qh_dense, atol=1e-12)
+
+
+# Sweeps: 2x2 Hubbard, 1x4 Hubbard, PPP chain
+def test_sparse_fast_path():
+    """Verify the Sparse fast path matches the dense counterpart term-by-term."""
+    for model_name in ["hubbard_2x2", "hubbard_1x4", "ppp_chain"]:
+        for encoding in ["jordan_wigner", "bravyi_kitaev", "parity"]:
+            # Construct the Lattice Graph and Hamiltonian
+            if model_name == "hubbard_2x2":
+                lattice = LatticeGraph.square(2, 2)
+                h_fast = create_hubbard_hamiltonian(lattice, epsilon=-0.5, t=1.0, U=0.3)
+            elif model_name == "hubbard_1x4":
+                lattice = LatticeGraph.chain(4)
+                h_fast = create_hubbard_hamiltonian(lattice, epsilon=-0.5, t=1.0, U=0.3)
+            else:
+                # PPP chain
+                n = 4
+                epsilon_r = 0.9
+                u_val = 0.4
+                r_val = 1.2
+                lattice = LatticeGraph.chain(n)
+                v = ohno_potential(lattice, U=u_val, R=r_val, epsilon_r=epsilon_r)
+                epsilon_vec = np.zeros(n)
+                t_mat = np.ones((n, n))
+                u_vec = np.full(n, u_val)
+                z_vec = np.ones(n)
+                h_fast = create_ppp_hamiltonian(lattice, epsilon=epsilon_vec, t=t_mat, U=u_vec, V=v, z=z_vec)
+
+            norb = lattice.num_sites
+            num_modes = 2 * norb
+
+            # Get mapping
+            if encoding == "jordan_wigner":
+                mapping = MajoranaMapping.jordan_wigner(num_modes)
+            elif encoding == "bravyi_kitaev":
+                mapping = MajoranaMapping.bravyi_kitaev(num_modes)
+            else:
+                mapping = MajoranaMapping.parity(num_modes)
+
+            # Map with fast path
+            mapper = create("qubit_mapper", "qdk")
+            qh_fast = mapper.run(h_fast, mapping)
+
+            # Map with dense fallback
+            h_dense = make_dense_counterpart(h_fast)
+            qh_dense = mapper.run(h_dense, mapping)
+
+            # Assert equivalence
+            assert_qubit_hamiltonians_equal(qh_fast, qh_dense, atol=1e-12)
+
+
+# ─── PySCF-based molecular test suite ─────────────────────────────────────
+
+try:
+    import pyscf
+    import pyscf.ao2mo
+    import pyscf.gto
+    import pyscf.scf
+    PYSCF_AVAILABLE = True
+except ImportError:
+    PYSCF_AVAILABLE = False
+
+MOLECULES = [
+    ("h2_sto3g", "H 0 0 0; H 0 0 0.74", "sto-3g"),
+    ("h2o_sto3g", "O 0 0 0; H 0 0.757 0.587; H 0 -0.757 0.587", "sto-3g"),
+    ("n2_sto3g", "N 0 0 0; N 0 0 1.10", "sto-3g"),
+]
+
+
+def _molecular_cholesky_pair(atom: str, basis: str):
+    """Build a restricted Cholesky Hamiltonian using PySCF."""
+    mol = pyscf.gto.M(atom=atom, basis=basis, verbose=0)
+    mf = pyscf.scf.RHF(mol)
+    mf.conv_tol = 1e-12
+    mf.kernel()
+    assert mf.converged, f"SCF did not converge for {atom} / {basis}"
+
+    coeff = mf.mo_coeff
+    norb = coeff.shape[1]
+    h1 = coeff.T @ mf.get_hcore() @ coeff
+
+    # Reconstruct two-body integrals using eigh Cholesky-like decomposition
+    eri_mo = pyscf.ao2mo.restore(1, pyscf.ao2mo.kernel(mol, coeff), norb)
+    pair_matrix = eri_mo.reshape(norb * norb, norb * norb)
+    pair_matrix = 0.5 * (pair_matrix + pair_matrix.T)
+    eigvals, eigvecs = np.linalg.eigh(pair_matrix)
+    keep = eigvals > 1e-12
+    factors = eigvecs[:, keep] * np.sqrt(eigvals[keep])  # (norb^2, naux)
+
+    three_center = np.ascontiguousarray(factors)
+    orbitals = create_test_basis_set(norb, f"test-pyscf-{norb}")
+    # Wrap in Orbitals class
+    coeffs = np.eye(norb)
+    mo_orbitals = Orbitals(coeffs, None, None, orbitals)
+    fock = np.zeros((norb, norb))
+
+    h_fast = Hamiltonian(
+        CholeskyHamiltonianContainer(
+            h1, three_center, mo_orbitals, float(mf.energy_nuc()), fock
+        )
+    )
+    return h_fast, norb
+
+
+@pytest.mark.skipif(not PYSCF_AVAILABLE, reason="PySCF not installed")
+def test_cholesky_molecular_fast_path():
+    """Verify that molecular Cholesky matches dense mapped version on real orbitals."""
+    for name, atom, basis in MOLECULES:
+        for encoding in ["jordan_wigner", "bravyi_kitaev", "parity"]:
+            h_fast, norb = _molecular_cholesky_pair(atom, basis)
+            num_modes = 2 * norb
+
+            if encoding == "jordan_wigner":
+                mapping = MajoranaMapping.jordan_wigner(num_modes)
+            elif encoding == "bravyi_kitaev":
+                mapping = MajoranaMapping.bravyi_kitaev(num_modes)
+            else:
+                mapping = MajoranaMapping.parity(num_modes)
+
+            mapper = create("qubit_mapper", "qdk")
+            qh_fast = mapper.run(h_fast, mapping)
+
+            h_dense = make_dense_counterpart(h_fast)
+            qh_dense = mapper.run(h_dense, mapping)
+
+            assert_qubit_hamiltonians_equal(qh_fast, qh_dense, atol=1e-12)
+
+

--- a/python/tests/test_qdk_qubit_mapper_factorized.py
+++ b/python/tests/test_qdk_qubit_mapper_factorized.py
@@ -1,5 +1,10 @@
 """Tests for specialized fast mapping paths (Cholesky, Sparse) in QdkQubitMapper."""
 
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
 import numpy as np
 import pytest
 
@@ -18,13 +23,14 @@ from qdk_chemistry.utils.model_hamiltonians import (
     create_ppp_hamiltonian,
     ohno_potential,
 )
+
 from .test_helpers import create_test_basis_set
 
 
 def assert_qubit_hamiltonians_equal(qh1: QubitHamiltonian, qh2: QubitHamiltonian, atol: float = 1e-12):
     """Compare two QubitHamiltonians term-by-term within absolute tolerance."""
-    dict1 = {k: v for k, v in zip(qh1.pauli_strings, qh1.coefficients) if abs(v) > atol}
-    dict2 = {k: v for k, v in zip(qh2.pauli_strings, qh2.coefficients) if abs(v) > atol}
+    dict1 = {k: v for k, v in zip(qh1.pauli_strings, qh1.coefficients, strict=False) if abs(v) > atol}
+    dict2 = {k: v for k, v in zip(qh2.pauli_strings, qh2.coefficients, strict=False) if abs(v) > atol}
 
     keys1 = set(dict1.keys())
     keys2 = set(dict2.keys())
@@ -34,15 +40,21 @@ def assert_qubit_hamiltonians_equal(qh1: QubitHamiltonian, qh2: QubitHamiltonian
     missing_in_1 = keys2 - keys1
 
     for k in missing_in_2:
-        assert abs(dict1[k]) < 1e-11, f"Term {k} is missing in dense path but present in fast path with value {dict1[k]}"
+        assert abs(dict1[k]) < 1e-11, (
+            f"Term {k} is missing in dense path but present in fast path with value {dict1[k]}"
+        )
     for k in missing_in_1:
-        assert abs(dict2[k]) < 1e-11, f"Term {k} is missing in fast path but present in dense path with value {dict2[k]}"
+        assert abs(dict2[k]) < 1e-11, (
+            f"Term {k} is missing in fast path but present in dense path with value {dict2[k]}"
+        )
 
     # Check overlapping keys
     for k in keys1.intersection(keys2):
         val1 = dict1[k]
         val2 = dict2[k]
-        assert np.isclose(val1, val2, atol=atol, rtol=1e-8), f"Coefficients mismatch for term {k}: fast={val1}, dense={val2}"
+        assert np.isclose(val1, val2, atol=atol, rtol=1e-8), (
+            f"Coefficients mismatch for term {k}: fast={val1}, dense={val2}"
+        )
 
 
 def make_dense_counterpart(h_fast: Hamiltonian) -> Hamiltonian:
@@ -55,16 +67,12 @@ def make_dense_counterpart(h_fast: Hamiltonian) -> Hamiltonian:
 
     if orbitals.is_restricted():
         fock = np.zeros((norb, norb))
-        container_dense = CanonicalFourCenterHamiltonianContainer(
-            h1_alpha, h2_aaaa, orbitals, core_energy, fock
-        )
+        container_dense = CanonicalFourCenterHamiltonianContainer(h1_alpha, h2_aaaa, orbitals, core_energy, fock)
     else:
         fock_a = np.zeros((norb, norb))
         fock_b = np.zeros((norb, norb))
         container_dense = CanonicalFourCenterHamiltonianContainer(
-            h1_alpha, h1_beta,
-            h2_aaaa, h2_aabb, h2_bbbb,
-            orbitals, core_energy, fock_a, fock_b
+            h1_alpha, h1_beta, h2_aaaa, h2_aabb, h2_bbbb, orbitals, core_energy, fock_a, fock_b
         )
     return Hamiltonian(container_dense)
 
@@ -85,9 +93,7 @@ def make_random_restricted_cholesky(norb: int, naux: int = 15, seed: int = 42):
     fock = rng.standard_normal((norb, norb))
     fock = 0.5 * (fock + fock.T)
 
-    container = CholeskyHamiltonianContainer(
-        one_body, three_center, orbitals, 1.5, fock
-    )
+    container = CholeskyHamiltonianContainer(one_body, three_center, orbitals, 1.5, fock)
     return Hamiltonian(container)
 
 
@@ -120,9 +126,7 @@ def make_random_unrestricted_cholesky(norb: int, naux: int = 15, seed: int = 42)
     fock_b = 0.5 * (fock_b + fock_b.T)
 
     container = CholeskyHamiltonianContainer(
-        one_body_a, one_body_b,
-        three_center_aa, three_center_bb,
-        orbitals, 2.0, fock_a, fock_b
+        one_body_a, one_body_b, three_center_aa, three_center_bb, orbitals, 2.0, fock_a, fock_b
     )
     return Hamiltonian(container)
 
@@ -216,6 +220,7 @@ try:
     import pyscf.ao2mo
     import pyscf.gto
     import pyscf.scf
+
     PYSCF_AVAILABLE = True
 except ImportError:
     PYSCF_AVAILABLE = False
@@ -254,18 +259,14 @@ def _molecular_cholesky_pair(atom: str, basis: str):
     mo_orbitals = Orbitals(coeffs, None, None, orbitals)
     fock = np.zeros((norb, norb))
 
-    h_fast = Hamiltonian(
-        CholeskyHamiltonianContainer(
-            h1, three_center, mo_orbitals, float(mf.energy_nuc()), fock
-        )
-    )
+    h_fast = Hamiltonian(CholeskyHamiltonianContainer(h1, three_center, mo_orbitals, float(mf.energy_nuc()), fock))
     return h_fast, norb
 
 
 @pytest.mark.skipif(not PYSCF_AVAILABLE, reason="PySCF not installed")
 def test_cholesky_molecular_fast_path():
     """Verify that molecular Cholesky matches dense mapped version on real orbitals."""
-    for name, atom, basis in MOLECULES:
+    for _, atom, basis in MOLECULES:
         for encoding in ["jordan_wigner", "bravyi_kitaev", "parity"]:
             h_fast, norb = _molecular_cholesky_pair(atom, basis)
             num_modes = 2 * norb
@@ -284,5 +285,3 @@ def test_cholesky_molecular_fast_path():
             qh_dense = mapper.run(h_dense, mapping)
 
             assert_qubit_hamiltonians_equal(qh_fast, qh_dense, atol=1e-12)
-
-

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -43,19 +43,35 @@ class TestVerstraeteCiracMapping:
         mapping_4x4 = MajoranaMapping.verstraete_cirac(lattice_4x4)
         assert len(mapping_4x4.stabilizers) > 0
 
-        # Invalid spin species count should raise ValueError / invalid_argument
-        with pytest.raises(ValueError, match="spin"):
-            MajoranaMapping.verstraete_cirac(lattice_2x2, num_spin_species=0)
-
     def test_general_lattices(self) -> None:
-        """Verify that QubitMapper consumes VC mapping for general 2D lattices."""
+        """Verify that QubitMapper consumes VC mapping for general lattices."""
         mapper = create("qubit_mapper", "qdk")
-        for nx, ny in [(2, 2), (2, 3), (3, 3), (4, 4)]:
-            lattice = LatticeGraph.square(nx, ny)
+        lattices = [
+            LatticeGraph.square(2, 2),
+            LatticeGraph.square(3, 3),
+            LatticeGraph.honeycomb(2, 2, periodic_x=True, periodic_y=True),
+            LatticeGraph.triangular(2, 2),
+        ]
+        for lattice in lattices:
             ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
-            mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=1)
+            mapping = MajoranaMapping.verstraete_cirac(lattice)
             qh = mapper.run(ham, mapping)
-            assert qh.num_qubits == 2 * nx * ny
+            assert qh.num_qubits == mapping.num_qubits
+            assert mapping.num_qubits - len(mapping.stabilizers) == 2 * lattice.num_sites
+
+    def test_honeycomb_and_higher_connectivity(self) -> None:
+        """Verify honeycomb (degree 3) and triangular/kagome (higher degree up to 6) lattices work."""
+        lattice_honeycomb = LatticeGraph.honeycomb(2, 2, periodic_x=True, periodic_y=True)
+        mapping_honeycomb = MajoranaMapping.verstraete_cirac(lattice_honeycomb)
+        assert len(mapping_honeycomb.stabilizers) > 0
+        
+        lattice_triangular = LatticeGraph.triangular(2, 2)
+        mapping_triangular = MajoranaMapping.verstraete_cirac(lattice_triangular)
+        assert len(mapping_triangular.stabilizers) > 0
+
+        lattice_kagome = LatticeGraph.kagome(2, 2, periodic_x=True, periodic_y=True)
+        mapping_kagome = MajoranaMapping.verstraete_cirac(lattice_kagome)
+        assert len(mapping_kagome.stabilizers) > 0
 
     def test_majorana_raises_error(self) -> None:
         """Verstraete-Cirac mapping is bilinear-only and majorana(k) should raise ValueError."""
@@ -134,28 +150,26 @@ class TestVerstraeteCiracMapping:
             lattice = LatticeGraph.square(nx, ny)
             ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
 
-            # Verify stabilizer properties for both spinless (nss=1) and spinful (nss=2) cases
-            for nss in [1, 2]:
-                mapping = MajoranaMapping.verstraete_cirac(lattice, nss)
-                assert len(mapping.stabilizers) == nss * nx * ny
+            mapping = MajoranaMapping.verstraete_cirac(lattice)
+            assert mapping.num_qubits - len(mapping.stabilizers) == 2 * lattice.num_sites
 
-                qh_vc = mapper.run(ham, mapping)
+            qh_vc = mapper.run(ham, mapping)
 
-                # Convert stabilizers to Pauli labels
-                stabs = []
-                for _, word in mapping.stabilizers:
-                    label = sparse_pauli_word_to_label(word, qh_vc.num_qubits)
-                    stabs.append(label)
+            # Convert stabilizers to Pauli labels
+            stabs = []
+            for _, word in mapping.stabilizers:
+                label = sparse_pauli_word_to_label(word, qh_vc.num_qubits)
+                stabs.append(label)
 
-                # Check mutual commutation of stabilizers: [S_i, S_j] = 0
-                for i in range(len(stabs)):
-                    for j in range(i + 1, len(stabs)):
-                        assert commute(stabs[i], stabs[j]), f"Stabilizers {i} and {j} do not commute!"
+            # Check mutual commutation of stabilizers: [S_i, S_j] = 0
+            for i in range(len(stabs)):
+                for j in range(i + 1, len(stabs)):
+                    assert commute(stabs[i], stabs[j]), f"Stabilizers {i} and {j} do not commute!"
 
-                # Check commutation with Hamiltonian: [H, S_i] = 0
-                for i, stab in enumerate(stabs):
-                    for p_term in qh_vc.pauli_strings:
-                        assert commute(stab, p_term), f"Stabilizer {i} does not commute with Hamiltonian term {p_term}!"
+            # Check commutation with Hamiltonian: [H, S_i] = 0
+            for i, stab in enumerate(stabs):
+                for p_term in qh_vc.pauli_strings:
+                    assert commute(stab, p_term), f"Stabilizer {i} does not commute with Hamiltonian term {p_term}!"
 
     def test_pauli_weight_scaling(self) -> None:
         """Check nearest-neighbor hopping terms in the mapped qubit Hamiltonian.
@@ -204,7 +218,7 @@ class TestVerstraeteCiracSpectral:
         Model parameters: t = 1.0, U = 4.0, half-filling (epsilon = -U/2 = -2.0).
         """
         lattice = LatticeGraph.square(2, 2, periodic_x=True)
-        n_modes = 8  # 4 spatial sites * 2 spin species
+        n_modes = 8  # 4 spatial sites * 2 spins
         hamiltonian = create_hubbard_hamiltonian(lattice, epsilon=-2.0, t=1.0, U=4.0)
         mapper = create("qubit_mapper", "qdk")
 
@@ -214,11 +228,11 @@ class TestVerstraeteCiracSpectral:
         eigs_jw, _ = eigsh(h_jw, k=10, which="SA")
         unique_jw = np.unique(np.round(np.sort(eigs_jw), 6))
 
-        vc_mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=2)
+        vc_mapping = MajoranaMapping.verstraete_cirac(lattice)
         qh_vc = mapper.run(hamiltonian, vc_mapping)
 
         # Verify system size and extract lowest unique eigenvalues
-        assert qh_vc.num_qubits == 2 * n_modes
+        assert qh_vc.num_qubits == vc_mapping.num_qubits
         h_vc = qh_vc.to_matrix(sparse=True)
         eigs_vc, _ = eigsh(h_vc, k=10, which="SA")
         unique_vc = np.unique(np.round(np.sort(eigs_vc), 6))
@@ -226,14 +240,14 @@ class TestVerstraeteCiracSpectral:
         # Ensure lowest physical energy levels match baseline
         np.testing.assert_allclose(unique_vc[:2], unique_jw[:2], atol=1e-10)
 
-    def test_spectral_validation_3x3_huckel(self) -> None:
-        """Compare eigenvalues of 3x3 Hückel model under VC and JW mappings.
+    def test_spectral_validation_3x2_huckel(self) -> None:
+        """Compare eigenvalues of 3x2 Hückel model under VC and JW mappings.
 
         Validates that the lowest eigenstates of the penalized Hamiltonian are
         in the +1 codespace sector of the generated loop-plaquette stabilizers.
         """
-        lattice = LatticeGraph.square(3, 3)
-        n_modes = 9  # 9 spatial sites * 1 spin species (spinless)
+        lattice = LatticeGraph.square(3, 2)
+        n_modes = 12  # 6 spatial sites * 2 spins
         hamiltonian = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
         mapper = create("qubit_mapper", "qdk")
 
@@ -243,11 +257,11 @@ class TestVerstraeteCiracSpectral:
         eigs_jw, _ = eigsh(h_jw, k=10, which="SA")
         unique_jw = np.unique(np.round(np.sort(eigs_jw), 6))
 
-        vc_mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=1)
+        vc_mapping = MajoranaMapping.verstraete_cirac(lattice)
         qh_vc = mapper.run(hamiltonian, vc_mapping)
 
         # Extract lowest eigenstates and their respective eigenstates
-        assert qh_vc.num_qubits == 2 * n_modes
+        assert qh_vc.num_qubits == vc_mapping.num_qubits
         h_vc = qh_vc.to_matrix(sparse=True)
         eigs_vc, vecs_vc = eigsh(h_vc, k=10, which="SA")
 

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -43,36 +43,6 @@ class TestVerstraeteCiracMapping:
         mapping_4x4 = MajoranaMapping.verstraete_cirac(lattice_4x4)
         assert len(mapping_4x4.stabilizers) > 0
 
-    def test_general_lattices(self) -> None:
-        """Verify that QubitMapper consumes VC mapping for general lattices."""
-        mapper = create("qubit_mapper", "qdk")
-        lattices = [
-            LatticeGraph.square(2, 2),
-            LatticeGraph.square(3, 3),
-            LatticeGraph.honeycomb(2, 2, periodic_x=True, periodic_y=True),
-            LatticeGraph.triangular(2, 2),
-        ]
-        for lattice in lattices:
-            ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
-            mapping = MajoranaMapping.verstraete_cirac(lattice)
-            qh = mapper.run(ham, mapping)
-            assert qh.num_qubits == mapping.num_qubits
-            assert mapping.num_qubits - len(mapping.stabilizers) == 2 * lattice.num_sites
-
-    def test_honeycomb_and_higher_connectivity(self) -> None:
-        """Verify honeycomb (degree 3) and triangular/kagome (higher degree up to 6) lattices work."""
-        lattice_honeycomb = LatticeGraph.honeycomb(2, 2, periodic_x=True, periodic_y=True)
-        mapping_honeycomb = MajoranaMapping.verstraete_cirac(lattice_honeycomb)
-        assert len(mapping_honeycomb.stabilizers) > 0
-
-        lattice_triangular = LatticeGraph.triangular(2, 2)
-        mapping_triangular = MajoranaMapping.verstraete_cirac(lattice_triangular)
-        assert len(mapping_triangular.stabilizers) > 0
-
-        lattice_kagome = LatticeGraph.kagome(2, 2, periodic_x=True, periodic_y=True)
-        mapping_kagome = MajoranaMapping.verstraete_cirac(lattice_kagome)
-        assert len(mapping_kagome.stabilizers) > 0
-
     def test_majorana_raises_error(self) -> None:
         """Verstraete-Cirac mapping is bilinear-only and majorana(k) should raise ValueError."""
         lattice = LatticeGraph.square(2, 2)
@@ -135,7 +105,7 @@ class TestVerstraeteCiracMapping:
             assert np.isclose(c_orig, c_h5, atol=1e-10)
 
     def test_stabilizers_and_commutation(self) -> None:
-        """Verify that stabilizers mutually commute and commute with mapped H."""
+        """Verify that stabilizers mutually commute and commute with mapped H for various lattices."""
 
         def commute(p1: str, p2: str) -> bool:
             assert len(p1) == len(p2)
@@ -146,14 +116,25 @@ class TestVerstraeteCiracMapping:
             return (anti_commutes % 2) == 0
 
         mapper = create("qubit_mapper", "qdk")
-        for nx, ny in [(2, 2), (3, 3), (3, 4)]:
-            lattice = LatticeGraph.square(nx, ny)
-            ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
+        lattices = [
+            LatticeGraph.square(2, 2),
+            LatticeGraph.square(3, 3),
+            LatticeGraph.square(3, 4),
+            LatticeGraph.honeycomb(2, 2, periodic_x=True, periodic_y=True),
+            LatticeGraph.triangular(2, 2),
+            LatticeGraph.kagome(2, 2, periodic_x=True, periodic_y=True),
+            LatticeGraph.kagome(3, 3),
+        ]
 
+        for lattice in lattices:
+            ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
             mapping = MajoranaMapping.verstraete_cirac(lattice)
+
             assert mapping.num_qubits - len(mapping.stabilizers) == 2 * lattice.num_sites
+            assert len(mapping.stabilizers) > 0
 
             qh_vc = mapper.run(ham, mapping)
+            assert qh_vc.num_qubits == mapping.num_qubits
 
             # Convert stabilizers to Pauli labels
             stabs = []
@@ -183,7 +164,7 @@ class TestVerstraeteCiracMapping:
 
         max_weights = []
         for grid_length in [2, 3, 4]:
-            lattice = LatticeGraph.square(grid_length, grid_length)
+            lattice = LatticeGraph.square(grid_length, grid_length, optimal_ordering=True)
             # Create a simple hopping-only Hamiltonian (U=0) on the L x L lattice
             ham = create_hubbard_hamiltonian(lattice, epsilon=0.0, t=1.0, U=0.0)
 
@@ -217,7 +198,7 @@ class TestVerstraeteCiracSpectral:
 
         Model parameters: t = 1.0, U = 4.0, half-filling (epsilon = -U/2 = -2.0).
         """
-        lattice = LatticeGraph.square(2, 2, periodic_x=True)
+        lattice = LatticeGraph.square(2, 2, periodic_x=True, optimal_ordering=True)
         n_modes = 8  # 4 spatial sites * 2 spins
         hamiltonian = create_hubbard_hamiltonian(lattice, epsilon=-2.0, t=1.0, U=4.0)
         mapper = create("qubit_mapper", "qdk")
@@ -246,7 +227,7 @@ class TestVerstraeteCiracSpectral:
         Validates that the lowest eigenstates of the penalized Hamiltonian are
         in the +1 codespace sector of the generated loop-plaquette stabilizers.
         """
-        lattice = LatticeGraph.square(3, 2)
+        lattice = LatticeGraph.square(3, 2, optimal_ordering=True)
         n_modes = 12  # 6 spatial sites * 2 spins
         hamiltonian = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
         mapper = create("qubit_mapper", "qdk")

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -1,0 +1,195 @@
+"""Tests for Verstraete-Cirac fermion-to-qubit mapping."""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import tempfile
+
+import h5py
+import numpy as np
+import pytest
+from scipy.sparse.linalg import eigsh
+
+from qdk_chemistry.algorithms import create
+from qdk_chemistry.data import LatticeGraph, MajoranaMapping, QubitHamiltonian
+from qdk_chemistry.utils.model_hamiltonians import create_hubbard_hamiltonian, create_huckel_hamiltonian
+
+
+class TestVerstraeteCiracMapping:
+    """Tests covering the Verstraete-Cirac mapping factory, dimensions, and properties."""
+
+    def test_factory_and_dimensions(self) -> None:
+        """Test that VC factory accepts correct grid dimensions and rejects invalid ones."""
+        # Valid even x_dimension grids
+        lattice_2x2 = LatticeGraph.square(2, 2)
+        mapping_2x2 = MajoranaMapping.verstraete_cirac(lattice_2x2)
+        assert mapping_2x2.grid_nx == 2
+        assert mapping_2x2.grid_ny == 2
+        assert mapping_2x2.name == "verstraete-cirac"
+        assert mapping_2x2.base_encoding == "verstraete-cirac"
+        assert not mapping_2x2.is_majorana_atomic
+
+        lattice_2x3 = LatticeGraph.square(2, 3)
+        mapping_2x3 = MajoranaMapping.verstraete_cirac(lattice_2x3)
+        assert mapping_2x3.grid_nx == 2
+        assert mapping_2x3.grid_ny == 3
+
+        lattice_4x4 = LatticeGraph.square(4, 4)
+        mapping_4x4 = MajoranaMapping.verstraete_cirac(lattice_4x4)
+        assert mapping_4x4.grid_nx == 4
+        assert mapping_4x4.grid_ny == 4
+
+        lattice_3x3 = LatticeGraph.square(3, 3)
+        mapping_3x3 = MajoranaMapping.verstraete_cirac(lattice_3x3)
+        assert mapping_3x3.grid_nx == 3
+        assert mapping_3x3.grid_ny == 3
+
+        # Invalid spin species count should raise ValueError / invalid_argument
+        with pytest.raises(ValueError, match="spin"):
+            MajoranaMapping.verstraete_cirac(lattice_2x2, num_spin_species=0)
+
+    def test_general_lattices_single_spin(self) -> None:
+        """Verify that QubitMapper consumes VC mapping for general 2D lattices with single spin species."""
+        mapper = create("qubit_mapper", "qdk")
+        for nx, ny in [(2, 2), (2, 3), (3, 3), (4, 4)]:
+            lattice = LatticeGraph.square(nx, ny)
+            ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
+            mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=1)
+            qh = mapper.run(ham, mapping)
+            assert qh.num_qubits == 2 * nx * ny
+
+    def test_majorana_raises_error(self) -> None:
+        """Verstraete-Cirac mapping is bilinear-only and majorana(k) should raise ValueError."""
+        lattice = LatticeGraph.square(2, 2)
+        mapping = MajoranaMapping.verstraete_cirac(lattice)
+        with pytest.raises(ValueError, match="bilinear-only"):
+            mapping.majorana(0)
+
+    def test_without_tapering(self) -> None:
+        """without_tapering should return the mapping itself (as it has no tapering)."""
+        lattice = LatticeGraph.square(2, 2)
+        mapping = MajoranaMapping.verstraete_cirac(lattice)
+        base = mapping.without_tapering()
+        assert base.grid_nx == 2
+        assert base.grid_ny == 2
+        assert base.name == "verstraete-cirac"
+
+    def test_serialization_round_trip(self) -> None:
+        """Verify that Verstraete-Cirac mapping survives JSON and HDF5 serialization round-trips."""
+        lattice = LatticeGraph.square(2, 2)
+        mapping = MajoranaMapping.verstraete_cirac(lattice)
+
+        # JSON Round-trip
+        json_data = mapping.to_json()
+        loaded_json = MajoranaMapping.from_json(json_data)
+        assert loaded_json.name == mapping.name
+        assert loaded_json.grid_nx == mapping.grid_nx
+        assert loaded_json.grid_ny == mapping.grid_ny
+        assert loaded_json.num_modes == mapping.num_modes
+        assert loaded_json.num_qubits == mapping.num_qubits
+        assert not loaded_json.is_majorana_atomic
+
+        # HDF5 Round-trip
+        with tempfile.NamedTemporaryFile(suffix=".h5") as f:
+            with h5py.File(f.name, "w") as hf:
+                mapping.to_hdf5(hf)
+            with h5py.File(f.name, "r") as hf:
+                loaded_hdf5 = MajoranaMapping.from_hdf5(hf)
+        assert loaded_hdf5.name == mapping.name
+        assert loaded_hdf5.grid_nx == mapping.grid_nx
+        assert loaded_hdf5.grid_ny == mapping.grid_ny
+        assert loaded_hdf5.num_modes == mapping.num_modes
+        assert loaded_hdf5.num_qubits == mapping.num_qubits
+        assert not loaded_hdf5.is_majorana_atomic
+
+
+class TestVerstraeteCiracHubbardSpectral:
+    """Spectral validation of Verstraete-Cirac mapping for Fermi-Hubbard model."""
+
+    def test_spectral_validation_2x2_hubbard(self) -> None:
+        """Compare eigenvalues of 2x2 Hubbard model under VC and Jordan-Wigner mappings.
+
+        Model parameters: t = 1.0, U = 4.0, half-filling (epsilon = -U/2 = -2.0).
+        """
+        # 1. Construct 2x2 square lattice
+        lattice = LatticeGraph.square(2, 2)
+        # 4 sites in lattice, each with 2 spin species -> 8 spin-orbitals / modes
+        n_modes = 8
+
+        # 2. Construct Hubbard Hamiltonian
+        hubbard_ham = create_hubbard_hamiltonian(lattice, epsilon=-2.0, t=1.0, U=4.0)
+
+        # 3. Map using Jordan-Wigner (JW)
+        mapper = create("qubit_mapper", "qdk")
+        jw_mapping = MajoranaMapping.jordan_wigner(num_modes=n_modes)
+        qh_jw = mapper.run(hubbard_ham, jw_mapping)
+
+        # Solve JW eigenvalues using sparse solver
+        h_jw = qh_jw.to_matrix(sparse=True)
+        eigs_jw, _ = eigsh(h_jw, k=10, which="SA")
+        eigs_jw = np.sort(eigs_jw)
+        unique_jw = np.unique(np.round(eigs_jw, 6))
+
+        # 4. Map using Verstraete-Cirac (VC)
+        vc_mapping = MajoranaMapping.verstraete_cirac(lattice)
+        qh_vc = mapper.run(hubbard_ham, vc_mapping)
+
+        # Verify VC number of qubits.
+        assert qh_vc.num_qubits == 2 * n_modes
+
+        # Solve VC eigenvalues using sparse solver
+        h_vc = qh_vc.to_matrix(sparse=True)
+        # Solve for 128 eigenvalues to cover the 64-fold degeneracy of the ground state and first excited state
+        eigs_vc, _ = eigsh(h_vc, k=128, which="SA")
+        eigs_vc = np.sort(eigs_vc)
+        unique_vc = np.unique(np.round(eigs_vc, 6))
+
+        # The unique lowest eigenvalues in the code space of VC must match the unique lowest eigenvalues of JW.
+        # We check the 2 lowest unique eigenvalues.
+        np.testing.assert_allclose(unique_vc[:2], unique_jw[:2], atol=1e-10)
+
+        # Test serialization of the resulting QubitHamiltonian
+        qh_json = qh_vc.to_json()
+        qh_loaded = QubitHamiltonian.from_json(qh_json)
+        assert qh_loaded.num_qubits == qh_vc.num_qubits
+        assert len(qh_loaded.pauli_strings) == len(qh_vc.pauli_strings)
+
+
+class TestVerstraeteCiracPauliWeightScaling:
+    """Verify that nearest-neighbor hop Pauli weight remains constant for grid lengths L in {2, 3, 4}."""
+
+    def test_pauli_weight_scaling(self) -> None:
+        """Check nearest-neighbor hopping terms in the mapped qubit Hamiltonian.
+
+        Max Pauli weight of nearest-neighbor hops should be constant for grids of dimensions:
+        - 2x2 (L=2)
+        - 2x3 (L=3)
+        - 2x4 (L=4)
+        """
+        mapper = create("qubit_mapper", "qdk")
+
+        max_weights = []
+        for grid_length in [2, 3, 4]:
+            lattice = LatticeGraph.square(2, grid_length)
+            # Create a simple hopping-only Hamiltonian (U=0) on the 2xL lattice
+            ham = create_hubbard_hamiltonian(lattice, epsilon=0.0, t=1.0, U=0.0)
+
+            vc_mapping = MajoranaMapping.verstraete_cirac(lattice)
+            qh_vc = mapper.run(ham, vc_mapping)
+
+            weights = []
+            for pauli_str in qh_vc.pauli_strings:
+                if pauli_str == "I" * len(pauli_str):
+                    continue
+                # Weight is the number of non-I characters
+                weight = sum(1 for c in pauli_str if c != "I")
+                weights.append(weight)
+
+            max_weights.append(max(weights))
+
+        # Check that the maximum Pauli weight does not grow with L
+        assert max_weights[0] == max_weights[1] == max_weights[2], (
+            f"Maximum Pauli weights grew or varied with grid length: {max_weights}"
+        )

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -134,26 +134,28 @@ class TestVerstraeteCiracMapping:
             lattice = LatticeGraph.square(nx, ny)
             ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
 
-            mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=1)
-            assert len(mapping.stabilizers) == nx * ny - nx - ny + 1
+            # Verify stabilizer properties for both spinless (nss=1) and spinful (nss=2) cases
+            for nss in [1, 2]:
+                mapping = MajoranaMapping.verstraete_cirac(lattice, nss)
+                assert len(mapping.stabilizers) == nss * nx * ny
 
-            qh_vc = mapper.run(ham, mapping)
+                qh_vc = mapper.run(ham, mapping)
 
-            # Convert stabilizers to Pauli labels
-            stabs = []
-            for _, word in mapping.stabilizers:
-                label = sparse_pauli_word_to_label(word, qh_vc.num_qubits)
-                stabs.append(label)
+                # Convert stabilizers to Pauli labels
+                stabs = []
+                for _, word in mapping.stabilizers:
+                    label = sparse_pauli_word_to_label(word, qh_vc.num_qubits)
+                    stabs.append(label)
 
-            # Check mutual commutation of stabilizers: [S_i, S_j] = 0
-            for i in range(len(stabs)):
-                for j in range(i + 1, len(stabs)):
-                    assert commute(stabs[i], stabs[j]), f"Stabilizers {i} and {j} do not commute!"
+                # Check mutual commutation of stabilizers: [S_i, S_j] = 0
+                for i in range(len(stabs)):
+                    for j in range(i + 1, len(stabs)):
+                        assert commute(stabs[i], stabs[j]), f"Stabilizers {i} and {j} do not commute!"
 
-            # Check commutation with Hamiltonian: [H, S_i] = 0
-            for i, stab in enumerate(stabs):
-                for p_term in qh_vc.pauli_strings:
-                    assert commute(stab, p_term), f"Stabilizer {i} does not commute with Hamiltonian term {p_term}!"
+                # Check commutation with Hamiltonian: [H, S_i] = 0
+                for i, stab in enumerate(stabs):
+                    for p_term in qh_vc.pauli_strings:
+                        assert commute(stab, p_term), f"Stabilizer {i} does not commute with Hamiltonian term {p_term}!"
 
     def test_pauli_weight_scaling(self) -> None:
         """Check nearest-neighbor hopping terms in the mapped qubit Hamiltonian.
@@ -196,85 +198,83 @@ class TestVerstraeteCiracMapping:
 class TestVerstraeteCiracSpectral:
     """Tests covering the spectral validation of the Verstraete-Cirac mapping."""
 
-    @pytest.mark.slow
     def test_spectral_validation_2x2_hubbard(self) -> None:
-        """Compare eigenvalues of 2x2 periodic Fermi-Hubbard model under VC and Jordan-Wigner mappings.
+        """Compare eigenvalues of 2x2 periodic Fermi-Hubbard model under VC and JW mappings.
 
         Model parameters: t = 1.0, U = 4.0, half-filling (epsilon = -U/2 = -2.0).
         """
         lattice = LatticeGraph.square(2, 2, periodic_x=True)
-
-        # 4 sites in lattice, each with 2 spin species -> 8 spin-orbitals / modes
-        n_modes = 8
-
-        hubbard_ham = create_hubbard_hamiltonian(lattice, epsilon=-2.0, t=1.0, U=4.0)
-
+        n_modes = 8  # 4 spatial sites * 2 spin species
+        hamiltonian = create_hubbard_hamiltonian(lattice, epsilon=-2.0, t=1.0, U=4.0)
         mapper = create("qubit_mapper", "qdk")
+
         jw_mapping = MajoranaMapping.jordan_wigner(num_modes=n_modes)
-        qh_jw = mapper.run(hubbard_ham, jw_mapping)
-
-        # Solve JW eigenvalues using sparse solver
-        h_jw = qh_jw.to_matrix(sparse=True)
-        eigs_jw, _ = eigsh(h_jw, k=10, which="SA")
-        eigs_jw = np.sort(eigs_jw)
-        unique_jw = np.unique(np.round(eigs_jw, 6))
-
-        vc_mapping = MajoranaMapping.verstraete_cirac(lattice)
-        qh_vc = mapper.run(hubbard_ham, vc_mapping)
-
-        assert qh_vc.num_qubits == 2 * n_modes
-        h_vc = qh_vc.to_matrix(sparse=True)
-
-        # Solve for 128 eigenvalues to cover the 64-fold degeneracy of the ground state and first excited state
-        eigs_vc, _ = eigsh(h_vc, k=128, which="SA")
-        eigs_vc = np.sort(eigs_vc)
-        unique_vc = np.unique(np.round(eigs_vc, 6))
-
-        # We check the 2 lowest unique eigenvalues.
-        np.testing.assert_allclose(unique_vc[:2], unique_jw[:2], atol=1e-10)
-
-    @pytest.mark.slow
-    def test_spectral_validation_3x3_huckel(self) -> None:
-        """Compare eigenvalues of 3x3 Hückel model under VC and Jordan-Wigner mappings."""
-        lattice = LatticeGraph.square(3, 3)
-
-        # 9 sites in lattice, each with 1 spin species -> 9 spin-orbitals / modes
-        n_modes = 9
-
-        huckel_ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
-
-        mapper = create("qubit_mapper", "qdk")
-        jw_mapping = MajoranaMapping.jordan_wigner(num_modes=n_modes)
-        qh_jw = mapper.run(huckel_ham, jw_mapping)
+        qh_jw = mapper.run(hamiltonian, jw_mapping)
         h_jw = qh_jw.to_matrix(sparse=True)
         eigs_jw, _ = eigsh(h_jw, k=10, which="SA")
         unique_jw = np.unique(np.round(np.sort(eigs_jw), 6))
 
-        mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=1)
-        qh_vc = mapper.run(huckel_ham, mapping)
+        vc_mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=2)
+        qh_vc = mapper.run(hamiltonian, vc_mapping)
+
+        # Verify system size and extract lowest unique eigenvalues
+        assert qh_vc.num_qubits == 2 * n_modes
         h_vc = qh_vc.to_matrix(sparse=True)
+        eigs_vc, _ = eigsh(h_vc, k=10, which="SA")
+        unique_vc = np.unique(np.round(np.sort(eigs_vc), 6))
 
-        # We solve for a few eigenvalues of H_vc and project into the code space (+1 eigenstate of all stabilizers)
-        eigs_vc, vecs_vc = eigsh(h_vc, k=40, which="SA")
+        # Ensure lowest physical energy levels match baseline
+        np.testing.assert_allclose(unique_vc[:2], unique_jw[:2], atol=1e-10)
 
+    def test_spectral_validation_3x3_huckel(self) -> None:
+        """Compare eigenvalues of 3x3 Hückel model under VC and JW mappings.
+
+        Validates that the lowest eigenstates of the penalized Hamiltonian are
+        in the +1 codespace sector of the generated loop-plaquette stabilizers.
+        """
+        lattice = LatticeGraph.square(3, 3)
+        n_modes = 9  # 9 spatial sites * 1 spin species (spinless)
+        hamiltonian = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
+        mapper = create("qubit_mapper", "qdk")
+
+        jw_mapping = MajoranaMapping.jordan_wigner(num_modes=n_modes)
+        qh_jw = mapper.run(hamiltonian, jw_mapping)
+        h_jw = qh_jw.to_matrix(sparse=True)
+        eigs_jw, _ = eigsh(h_jw, k=10, which="SA")
+        unique_jw = np.unique(np.round(np.sort(eigs_jw), 6))
+
+        vc_mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=1)
+        qh_vc = mapper.run(hamiltonian, vc_mapping)
+
+        # Extract lowest eigenstates and their respective eigenstates
+        assert qh_vc.num_qubits == 2 * n_modes
+        h_vc = qh_vc.to_matrix(sparse=True)
+        eigs_vc, vecs_vc = eigsh(h_vc, k=10, which="SA")
+
+        # Construct sparse matrices for each generated loop-plaquette stabilizer
         stabs = []
-        for coeff, word in mapping.stabilizers:
+        for coeff, word in vc_mapping.stabilizers:
             label = sparse_pauli_word_to_label(word, qh_vc.num_qubits)
             qh_stab = QubitHamiltonian([label], np.array([coeff]))
             stabs.append(qh_stab.to_matrix(sparse=True))
 
+        # Project and filter out any unphysical states (out-of-codespace)
         code_space_eigs = []
         for idx in range(len(eigs_vc)):
             vec = vecs_vc[:, idx]
             is_in_code_space = True
+
             for stab in stabs:
-                exp = np.real(vec.conj().T @ (stab @ vec))
-                if not np.isclose(exp, 1.0, atol=1e-4):
+                # Only a simultaneous +1 eigenstate belongs to the physical codespace
+                expectation_value = np.real(vec.conj().T @ (stab @ vec))
+                if not np.isclose(expectation_value, 1.0, atol=1e-4):
                     is_in_code_space = False
                     break
+
             if is_in_code_space:
                 code_space_eigs.append(eigs_vc[idx])
 
+        # Assert that physical states were found and unique energy levels match baseline
         assert len(code_space_eigs) >= 2
         unique_vc = np.unique(np.round(np.sort(code_space_eigs), 6))
         np.testing.assert_allclose(unique_vc[:2], unique_jw[:2], atol=1e-10)

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -64,7 +64,7 @@ class TestVerstraeteCiracMapping:
         lattice_honeycomb = LatticeGraph.honeycomb(2, 2, periodic_x=True, periodic_y=True)
         mapping_honeycomb = MajoranaMapping.verstraete_cirac(lattice_honeycomb)
         assert len(mapping_honeycomb.stabilizers) > 0
-        
+
         lattice_triangular = LatticeGraph.triangular(2, 2)
         mapping_triangular = MajoranaMapping.verstraete_cirac(lattice_triangular)
         assert len(mapping_triangular.stabilizers) > 0

--- a/python/tests/test_verstraete_cirac.py
+++ b/python/tests/test_verstraete_cirac.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 from scipy.sparse.linalg import eigsh
 
+from qdk_chemistry._core.data import sparse_pauli_word_to_label
 from qdk_chemistry.algorithms import create
 from qdk_chemistry.data import LatticeGraph, MajoranaMapping, QubitHamiltonian
 from qdk_chemistry.utils.model_hamiltonians import create_hubbard_hamiltonian, create_huckel_hamiltonian
@@ -22,36 +23,32 @@ class TestVerstraeteCiracMapping:
 
     def test_factory_and_dimensions(self) -> None:
         """Test that VC factory accepts correct grid dimensions and rejects invalid ones."""
-        # Valid even x_dimension grids
+        # Testing valid grids: square and rectangular
         lattice_2x2 = LatticeGraph.square(2, 2)
         mapping_2x2 = MajoranaMapping.verstraete_cirac(lattice_2x2)
-        assert mapping_2x2.grid_nx == 2
-        assert mapping_2x2.grid_ny == 2
+        assert len(mapping_2x2.stabilizers) > 0
         assert mapping_2x2.name == "verstraete-cirac"
         assert mapping_2x2.base_encoding == "verstraete-cirac"
         assert not mapping_2x2.is_majorana_atomic
 
         lattice_2x3 = LatticeGraph.square(2, 3)
         mapping_2x3 = MajoranaMapping.verstraete_cirac(lattice_2x3)
-        assert mapping_2x3.grid_nx == 2
-        assert mapping_2x3.grid_ny == 3
-
-        lattice_4x4 = LatticeGraph.square(4, 4)
-        mapping_4x4 = MajoranaMapping.verstraete_cirac(lattice_4x4)
-        assert mapping_4x4.grid_nx == 4
-        assert mapping_4x4.grid_ny == 4
+        assert len(mapping_2x3.stabilizers) > 0
 
         lattice_3x3 = LatticeGraph.square(3, 3)
         mapping_3x3 = MajoranaMapping.verstraete_cirac(lattice_3x3)
-        assert mapping_3x3.grid_nx == 3
-        assert mapping_3x3.grid_ny == 3
+        assert len(mapping_3x3.stabilizers) > 0
+
+        lattice_4x4 = LatticeGraph.square(4, 4)
+        mapping_4x4 = MajoranaMapping.verstraete_cirac(lattice_4x4)
+        assert len(mapping_4x4.stabilizers) > 0
 
         # Invalid spin species count should raise ValueError / invalid_argument
         with pytest.raises(ValueError, match="spin"):
             MajoranaMapping.verstraete_cirac(lattice_2x2, num_spin_species=0)
 
-    def test_general_lattices_single_spin(self) -> None:
-        """Verify that QubitMapper consumes VC mapping for general 2D lattices with single spin species."""
+    def test_general_lattices(self) -> None:
+        """Verify that QubitMapper consumes VC mapping for general 2D lattices."""
         mapper = create("qubit_mapper", "qdk")
         for nx, ny in [(2, 2), (2, 3), (3, 3), (4, 4)]:
             lattice = LatticeGraph.square(nx, ny)
@@ -72,8 +69,7 @@ class TestVerstraeteCiracMapping:
         lattice = LatticeGraph.square(2, 2)
         mapping = MajoranaMapping.verstraete_cirac(lattice)
         base = mapping.without_tapering()
-        assert base.grid_nx == 2
-        assert base.grid_ny == 2
+        assert len(base.stabilizers) == len(mapping.stabilizers)
         assert base.name == "verstraete-cirac"
 
     def test_serialization_round_trip(self) -> None:
@@ -81,15 +77,27 @@ class TestVerstraeteCiracMapping:
         lattice = LatticeGraph.square(2, 2)
         mapping = MajoranaMapping.verstraete_cirac(lattice)
 
+        # Construct a simple Hubbard Hamiltonian on the lattice
+        ham = create_hubbard_hamiltonian(lattice, epsilon=-2.0, t=1.0, U=4.0)
+        mapper = create("qubit_mapper", "qdk")
+        qh_orig = mapper.run(ham, mapping)
+
         # JSON Round-trip
         json_data = mapping.to_json()
         loaded_json = MajoranaMapping.from_json(json_data)
         assert loaded_json.name == mapping.name
-        assert loaded_json.grid_nx == mapping.grid_nx
-        assert loaded_json.grid_ny == mapping.grid_ny
         assert loaded_json.num_modes == mapping.num_modes
         assert loaded_json.num_qubits == mapping.num_qubits
         assert not loaded_json.is_majorana_atomic
+
+        qh_json = mapper.run(ham, loaded_json)
+        assert qh_json.num_qubits == qh_orig.num_qubits
+        assert len(qh_json.pauli_strings) == len(qh_orig.pauli_strings)
+        terms_orig = sorted(zip(qh_orig.pauli_strings, qh_orig.coefficients, strict=False))
+        terms_json = sorted(zip(qh_json.pauli_strings, qh_json.coefficients, strict=False))
+        for (p_orig, c_orig), (p_json, c_json) in zip(terms_orig, terms_json, strict=False):
+            assert p_orig == p_json
+            assert np.isclose(c_orig, c_json, atol=1e-10)
 
         # HDF5 Round-trip
         with tempfile.NamedTemporaryFile(suffix=".h5") as f:
@@ -98,30 +106,109 @@ class TestVerstraeteCiracMapping:
             with h5py.File(f.name, "r") as hf:
                 loaded_hdf5 = MajoranaMapping.from_hdf5(hf)
         assert loaded_hdf5.name == mapping.name
-        assert loaded_hdf5.grid_nx == mapping.grid_nx
-        assert loaded_hdf5.grid_ny == mapping.grid_ny
         assert loaded_hdf5.num_modes == mapping.num_modes
         assert loaded_hdf5.num_qubits == mapping.num_qubits
         assert not loaded_hdf5.is_majorana_atomic
 
+        qh_hdf5 = mapper.run(ham, loaded_hdf5)
+        assert qh_hdf5.num_qubits == qh_orig.num_qubits
+        assert len(qh_hdf5.pauli_strings) == len(qh_orig.pauli_strings)
+        terms_hdf5 = sorted(zip(qh_hdf5.pauli_strings, qh_hdf5.coefficients, strict=False))
+        for (p_orig, c_orig), (p_h5, c_h5) in zip(terms_orig, terms_hdf5, strict=False):
+            assert p_orig == p_h5
+            assert np.isclose(c_orig, c_h5, atol=1e-10)
 
-class TestVerstraeteCiracHubbardSpectral:
-    """Spectral validation of Verstraete-Cirac mapping for Fermi-Hubbard model."""
+    def test_stabilizers_and_commutation(self) -> None:
+        """Verify that stabilizers mutually commute and commute with mapped H."""
 
+        def commute(p1: str, p2: str) -> bool:
+            assert len(p1) == len(p2)
+            anti_commutes = 0
+            for c1, c2 in zip(p1, p2, strict=False):
+                if c1 != "I" and c2 not in {"I", c1}:
+                    anti_commutes += 1
+            return (anti_commutes % 2) == 0
+
+        mapper = create("qubit_mapper", "qdk")
+        for nx, ny in [(2, 2), (3, 3), (3, 4)]:
+            lattice = LatticeGraph.square(nx, ny)
+            ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
+
+            mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=1)
+            assert len(mapping.stabilizers) == nx * ny - nx - ny + 1
+
+            qh_vc = mapper.run(ham, mapping)
+
+            # Convert stabilizers to Pauli labels
+            stabs = []
+            for _, word in mapping.stabilizers:
+                label = sparse_pauli_word_to_label(word, qh_vc.num_qubits)
+                stabs.append(label)
+
+            # Check mutual commutation of stabilizers: [S_i, S_j] = 0
+            for i in range(len(stabs)):
+                for j in range(i + 1, len(stabs)):
+                    assert commute(stabs[i], stabs[j]), f"Stabilizers {i} and {j} do not commute!"
+
+            # Check commutation with Hamiltonian: [H, S_i] = 0
+            for i, stab in enumerate(stabs):
+                for p_term in qh_vc.pauli_strings:
+                    assert commute(stab, p_term), f"Stabilizer {i} does not commute with Hamiltonian term {p_term}!"
+
+    def test_pauli_weight_scaling(self) -> None:
+        """Check nearest-neighbor hopping terms in the mapped qubit Hamiltonian.
+
+        Max Pauli weight of nearest-neighbor hops should be constant for square grids of dimensions:
+        - 2x2 (L=2)
+        - 3x3 (L=3)
+        - 4x4 (L=4)
+        """
+        mapper = create("qubit_mapper", "qdk")
+
+        max_weights = []
+        for grid_length in [2, 3, 4]:
+            lattice = LatticeGraph.square(grid_length, grid_length)
+            # Create a simple hopping-only Hamiltonian (U=0) on the L x L lattice
+            ham = create_hubbard_hamiltonian(lattice, epsilon=0.0, t=1.0, U=0.0)
+
+            vc_mapping = MajoranaMapping.verstraete_cirac(lattice)
+            qh_vc = mapper.run(ham, vc_mapping)
+
+            weights = []
+            for pauli_str, coeff in zip(qh_vc.pauli_strings, qh_vc.coefficients, strict=False):
+                if pauli_str == "I" * len(pauli_str):
+                    continue
+                # Skip stabilizer penalty terms (which have coefficient >= 9.0,
+                # whereas nearest-neighbor hops have coefficient <= 1.0)
+                if np.abs(coeff) > 2.0:
+                    continue
+                # Weight is the number of non-I characters
+                weight = sum(1 for c in pauli_str if c != "I")
+                weights.append(weight)
+
+            max_weights.append(max(weights))
+
+        assert max_weights[0] == max_weights[1] == max_weights[2], (
+            f"Maximum Pauli weights grew or varied with grid length: {max_weights}"
+        )
+
+
+class TestVerstraeteCiracSpectral:
+    """Tests covering the spectral validation of the Verstraete-Cirac mapping."""
+
+    @pytest.mark.slow
     def test_spectral_validation_2x2_hubbard(self) -> None:
-        """Compare eigenvalues of 2x2 Hubbard model under VC and Jordan-Wigner mappings.
+        """Compare eigenvalues of 2x2 periodic Fermi-Hubbard model under VC and Jordan-Wigner mappings.
 
         Model parameters: t = 1.0, U = 4.0, half-filling (epsilon = -U/2 = -2.0).
         """
-        # 1. Construct 2x2 square lattice
-        lattice = LatticeGraph.square(2, 2)
+        lattice = LatticeGraph.square(2, 2, periodic_x=True)
+
         # 4 sites in lattice, each with 2 spin species -> 8 spin-orbitals / modes
         n_modes = 8
 
-        # 2. Construct Hubbard Hamiltonian
         hubbard_ham = create_hubbard_hamiltonian(lattice, epsilon=-2.0, t=1.0, U=4.0)
 
-        # 3. Map using Jordan-Wigner (JW)
         mapper = create("qubit_mapper", "qdk")
         jw_mapping = MajoranaMapping.jordan_wigner(num_modes=n_modes)
         qh_jw = mapper.run(hubbard_ham, jw_mapping)
@@ -132,64 +219,62 @@ class TestVerstraeteCiracHubbardSpectral:
         eigs_jw = np.sort(eigs_jw)
         unique_jw = np.unique(np.round(eigs_jw, 6))
 
-        # 4. Map using Verstraete-Cirac (VC)
         vc_mapping = MajoranaMapping.verstraete_cirac(lattice)
         qh_vc = mapper.run(hubbard_ham, vc_mapping)
 
-        # Verify VC number of qubits.
         assert qh_vc.num_qubits == 2 * n_modes
-
-        # Solve VC eigenvalues using sparse solver
         h_vc = qh_vc.to_matrix(sparse=True)
+
         # Solve for 128 eigenvalues to cover the 64-fold degeneracy of the ground state and first excited state
         eigs_vc, _ = eigsh(h_vc, k=128, which="SA")
         eigs_vc = np.sort(eigs_vc)
         unique_vc = np.unique(np.round(eigs_vc, 6))
 
-        # The unique lowest eigenvalues in the code space of VC must match the unique lowest eigenvalues of JW.
         # We check the 2 lowest unique eigenvalues.
         np.testing.assert_allclose(unique_vc[:2], unique_jw[:2], atol=1e-10)
 
-        # Test serialization of the resulting QubitHamiltonian
-        qh_json = qh_vc.to_json()
-        qh_loaded = QubitHamiltonian.from_json(qh_json)
-        assert qh_loaded.num_qubits == qh_vc.num_qubits
-        assert len(qh_loaded.pauli_strings) == len(qh_vc.pauli_strings)
+    @pytest.mark.slow
+    def test_spectral_validation_3x3_huckel(self) -> None:
+        """Compare eigenvalues of 3x3 Hückel model under VC and Jordan-Wigner mappings."""
+        lattice = LatticeGraph.square(3, 3)
 
+        # 9 sites in lattice, each with 1 spin species -> 9 spin-orbitals / modes
+        n_modes = 9
 
-class TestVerstraeteCiracPauliWeightScaling:
-    """Verify that nearest-neighbor hop Pauli weight remains constant for grid lengths L in {2, 3, 4}."""
+        huckel_ham = create_huckel_hamiltonian(lattice, epsilon=-2.0, t=1.0)
 
-    def test_pauli_weight_scaling(self) -> None:
-        """Check nearest-neighbor hopping terms in the mapped qubit Hamiltonian.
-
-        Max Pauli weight of nearest-neighbor hops should be constant for grids of dimensions:
-        - 2x2 (L=2)
-        - 2x3 (L=3)
-        - 2x4 (L=4)
-        """
         mapper = create("qubit_mapper", "qdk")
+        jw_mapping = MajoranaMapping.jordan_wigner(num_modes=n_modes)
+        qh_jw = mapper.run(huckel_ham, jw_mapping)
+        h_jw = qh_jw.to_matrix(sparse=True)
+        eigs_jw, _ = eigsh(h_jw, k=10, which="SA")
+        unique_jw = np.unique(np.round(np.sort(eigs_jw), 6))
 
-        max_weights = []
-        for grid_length in [2, 3, 4]:
-            lattice = LatticeGraph.square(2, grid_length)
-            # Create a simple hopping-only Hamiltonian (U=0) on the 2xL lattice
-            ham = create_hubbard_hamiltonian(lattice, epsilon=0.0, t=1.0, U=0.0)
+        mapping = MajoranaMapping.verstraete_cirac(lattice, num_spin_species=1)
+        qh_vc = mapper.run(huckel_ham, mapping)
+        h_vc = qh_vc.to_matrix(sparse=True)
 
-            vc_mapping = MajoranaMapping.verstraete_cirac(lattice)
-            qh_vc = mapper.run(ham, vc_mapping)
+        # We solve for a few eigenvalues of H_vc and project into the code space (+1 eigenstate of all stabilizers)
+        eigs_vc, vecs_vc = eigsh(h_vc, k=40, which="SA")
 
-            weights = []
-            for pauli_str in qh_vc.pauli_strings:
-                if pauli_str == "I" * len(pauli_str):
-                    continue
-                # Weight is the number of non-I characters
-                weight = sum(1 for c in pauli_str if c != "I")
-                weights.append(weight)
+        stabs = []
+        for coeff, word in mapping.stabilizers:
+            label = sparse_pauli_word_to_label(word, qh_vc.num_qubits)
+            qh_stab = QubitHamiltonian([label], np.array([coeff]))
+            stabs.append(qh_stab.to_matrix(sparse=True))
 
-            max_weights.append(max(weights))
+        code_space_eigs = []
+        for idx in range(len(eigs_vc)):
+            vec = vecs_vc[:, idx]
+            is_in_code_space = True
+            for stab in stabs:
+                exp = np.real(vec.conj().T @ (stab @ vec))
+                if not np.isclose(exp, 1.0, atol=1e-4):
+                    is_in_code_space = False
+                    break
+            if is_in_code_space:
+                code_space_eigs.append(eigs_vc[idx])
 
-        # Check that the maximum Pauli weight does not grow with L
-        assert max_weights[0] == max_weights[1] == max_weights[2], (
-            f"Maximum Pauli weights grew or varied with grid length: {max_weights}"
-        )
+        assert len(code_space_eigs) >= 2
+        unique_vc = np.unique(np.round(np.sort(code_space_eigs), 6))
+        np.testing.assert_allclose(unique_vc[:2], unique_jw[:2], atol=1e-10)


### PR DESCRIPTION
# Feature: Specialized fast paths in `QdkQubitMapper`

## Description

Closes [#474](https://github.com/microsoft/qdk-chemistry/issues/474).

This PR implements container-aware fast mapping paths in the QDK native qubit mapping engine (`QdkQubitMapper`) for **Cholesky (density-fitted)** and **sparse lattice** Hamiltonians. These specialized paths completely bypass the dense $O(N^4)$ two-body integral tensor materialization, reducing memory usage and compute overhead.

### Key Highlights:

* **Compile-Time Template Dispatch**: The native engine templates `majorana_map_impl` over a custom `TEriProvider` interface to eliminate virtual function overhead and compile specialized mapping paths for each container:
  1. **`DenseEriProvider`**: Handles standard full-integral tensors with optimal dense lookups.
  2. **`CholeskyEriProvider`**: Performs three-center row contractions on-the-fly with `Eigen::Map` vectorization (AVX/AVX2) and caches the last contracted row index to avoid up to 3x redundant contractions in unrestricted calculations.
  3. **`SparseEriProvider`**: Stores only unique canonical integrals in a coordinate-packed $O(M)$ hash map to avoid the 8x memory expansion of fully symmetry-permuted maps.
* **True $O(M)$ Sparse Complexity**: By using compile-time branching (`if constexpr`), the sparse path directly sweeps over only the $M$ non-zero integrals in `SparseEriProvider`, bypassing the quadruple loops over the $O(N^4)$ index space entirely.
* **Correct Energy Shift Exclusion**: Correctly handles the core energy offset by passing `0.0` to the mapping engine in the C++ polymorphic dispatch `majorana_map_hamiltonian` wrapper, ensuring numerical equivalence with the python-dense fallback path.


---

## Acceptance & Testing Criteria

- [x] Swept tests parameterized over molecular active-space sizes corresponding to H2 (norb=2), H2O (norb=7), and N2 (norb=14), covering both restricted (RHF) and unrestricted (UHF) Cholesky Hamiltonians.
- [x] Swept tests parameterized over lattice configurations including Hubbard 2x2 square grids, Hubbard 1x4 chains, and Pariser–Parr–Pople (PPP) chains.
- [x] Cross-validated all mapping results to verify term-by-term numerical equivalence to within a `1e-12` absolute tolerance against the dense `CanonicalFourCenterHamiltonianContainer` fallback path across Jordan-Wigner, Bravyi-Kitaev, and Parity encodings.
- [x] Included PySCF-based real molecular orbital tests if the package is available on the runner system.
---

## Test Results & Benchmark

```
tests/test_qdk_qubit_mapper_factorized.py::test_cholesky_fast_path PASSED                                  [ 33%]
tests/test_qdk_qubit_mapper_factorized.py::test_sparse_fast_path PASSED                                    [ 66%]
tests/test_qdk_qubit_mapper_factorized.py::test_cholesky_molecular_fast_path PASSED                        [100%]
```

Tested fast paths with a benchmark (running this [gist](https://gist.github.com/nirajvenkat/a2e9d2151cbc3badc0b3ea93add5cd43) in `python/`):

```
==================================================
1. BENCHMARKING SPARSE HAMILTONIAN PATH (Hubbard)
==================================================
Sparse Fast Path Time : 0.0030 seconds
Dense Fallback Time   : 0.0025 seconds
--> Sparse Speedup    : 0.83x

==================================================
2. BENCHMARKING CHOLESKY HAMILTONIAN PATH (Low-Rank)
==================================================
Cholesky Fast Path Time : 0.2333 seconds
Dense Fallback Time     : 0.1958 seconds
--> Cholesky Speedup    : 0.84x
==================================================
```

