### PR TITLE
Temporarily disable PR coverage comment to unblock hackathon PRs

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -468,13 +468,6 @@ jobs:
           echo "</details>" >> pr-comment.md
         fi
 
-    - name: Comment PR with coverage
-      if: github.event_name == 'pull_request'
-      uses: marocchino/sticky-pull-request-comment@v3
-      with:
-        path: pr-comment.md
-        header: coverage-report
-
     - name: Add coverage to job summary
       run: |
         # Create comprehensive summary with table and detailed reports


### PR DESCRIPTION
This PR temporarily removes the "Comment PR with coverage" job from our CI/CD pipelines to unblock the current set of PRs from the UnitaryHack hackathon. Multiple PRs are failing during in this stage despite passing all other tests, as they are being opened from forks of qdk-chemistry, which we have not yet tested. The GITHUB_TOKEN from branches in external forks will not have write permission on our repository, which is required by [sticky-pull-request-comment](https://github.com/marocchino/sticky-pull-request-comment) to actually put the comment on PRs in our repository.

We can certainly solve this problem in the future, but for the time being it's more important to allow the UnitaryHack PRs to go through. 