### PR TITLE
Specialize QDK mapper for sparse and Cholesky Hamiltonians

### DIFF
--- a/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
+++ b/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
@@ -18,6 +18,8 @@
 
 namespace qdk::chemistry::data {
 
+class Hamiltonian;
+
 /**
  * @brief Data class describing a fermion-to-qubit encoding.
  *
@@ -332,5 +334,24 @@ MajoranaMapResult majorana_map_hamiltonian(
     const double* h1_beta, const double* eri_aaaa, const double* eri_aabb,
     const double* eri_bbbb, std::size_t n_spatial, bool spin_symmetric,
     double threshold, double integral_threshold);
+
+/**
+ * @brief Map a Hamiltonian to qubit Pauli terms via the native container path.
+ *
+ * The overload preserves QubitMapper semantics: the scalar core-energy shift is
+ * not folded into the returned Pauli operator. Container-specific two-body
+ * storage is consumed directly when a sparse or Cholesky representation is
+ * available; other containers use the dense pointer overload.
+ *
+ * @param mapping The Majorana-to-Pauli encoding.
+ * @param hamiltonian The Hamiltonian to map.
+ * @param threshold Pauli terms with |coeff| < threshold are dropped.
+ * @param integral_threshold Integrals with |value| < this are skipped.
+ * @return MajoranaMapResult with Pauli words and coefficients.
+ */
+MajoranaMapResult majorana_map_hamiltonian(const MajoranaMapping& mapping,
+                                           const Hamiltonian& hamiltonian,
+                                           double threshold,
+                                           double integral_threshold);
 
 }  // namespace qdk::chemistry::data

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -334,23 +334,39 @@ struct SparseEriProvider {
     std::size_t r;
     std::size_t s;
 
+    bool operator==(const Key& other) const = default;
+
     friend bool operator<(const Key& left, const Key& right) {
       return std::tie(left.p, left.q, left.r, left.s) <
              std::tie(right.p, right.q, right.r, right.s);
     }
   };
 
+  struct KeyHash {
+    std::size_t operator()(const Key& key) const noexcept {
+      utils::HashContext ctx;
+      hash_value(ctx, "sparse_eri_key");
+      hash_value(ctx, static_cast<uint64_t>(key.p));
+      hash_value(ctx, static_cast<uint64_t>(key.q));
+      hash_value(ctx, static_cast<uint64_t>(key.r));
+      hash_value(ctx, static_cast<uint64_t>(key.s));
+      return ctx.hash_code();
+    }
+  };
+
   std::size_t n_spatial;
   std::size_t n2;
-  std::map<Key, double> entries;
+  std::vector<std::pair<Key, double>> entries;
+  std::unordered_map<Key, double, KeyHash> lookup;
 
   SparseEriProvider(std::size_t n,
                     const SparseHamiltonianContainer::TwoBodyMap& values)
       : n_spatial(n), n2(n * n) {
+    std::map<Key, double> canonical_entries;
     for (const auto& [indices, value] : values) {
       auto [p, q, r, s] = indices;
       Key key = canonicalize_checked(p, q, r, s);
-      auto [it, inserted] = entries.emplace(key, value);
+      auto [it, inserted] = canonical_entries.emplace(key, value);
       if (!inserted) {
         double scale = std::max({1.0, std::abs(it->second), std::abs(value)});
         if (std::abs(it->second - value) > 1e-12 * scale) {
@@ -359,6 +375,12 @@ struct SparseEriProvider {
               "symmetry-equivalent indices.");
         }
       }
+    }
+    entries.reserve(canonical_entries.size());
+    lookup.reserve(canonical_entries.size());
+    for (const auto& [key, value] : canonical_entries) {
+      entries.emplace_back(key, value);
+      lookup.emplace(key, value);
     }
   }
 
@@ -388,8 +410,8 @@ struct SparseEriProvider {
 
   double aaaa(std::size_t p, std::size_t q, std::size_t r,
               std::size_t s) const {
-    auto it = entries.find(canonicalize(p, q, r, s));
-    return it == entries.end() ? 0.0 : it->second;
+    auto it = lookup.find(canonicalize(p, q, r, s));
+    return it == lookup.end() ? 0.0 : it->second;
   }
 
   std::vector<double> row_aaaa(std::size_t p, std::size_t q) const {
@@ -790,6 +812,12 @@ MajoranaMapResult majorana_map_hamiltonian(const MajoranaMapping& mapping,
 
   const std::size_t n_spatial = static_cast<std::size_t>(h1_alpha.rows());
   const bool spin_symmetric = hamiltonian.is_restricted();
+  if (!spin_symmetric && (h1_beta.rows() != h1_alpha.rows() ||
+                          h1_beta.cols() != h1_alpha.cols())) {
+    throw std::invalid_argument(
+        "majorana_map_hamiltonian: beta one-body integrals must match the "
+        "alpha one-body integral shape for unrestricted Hamiltonians.");
+  }
 
   std::vector<double> h1_alpha_flat(n_spatial * n_spatial);
   std::vector<double> h1_beta_flat(n_spatial * n_spatial);
@@ -804,19 +832,16 @@ MajoranaMapResult majorana_map_hamiltonian(const MajoranaMapping& mapping,
   constexpr double excluded_core_energy = 0.0;
 
   if (hamiltonian.has_container_type<SparseHamiltonianContainer>()) {
-    if (!spin_symmetric) {
-      throw std::invalid_argument(
-          "majorana_map_hamiltonian: sparse container mapping currently "
-          "requires restricted orbitals.");
+    if (spin_symmetric) {
+      const auto& sparse =
+          hamiltonian.get_container<SparseHamiltonianContainer>();
+      detail::SparseEriProvider provider(n_spatial,
+                                         sparse.sparse_two_body_integrals());
+      return detail::dispatch_majorana_map(
+          mapping, excluded_core_energy, h1_alpha_flat.data(),
+          h1_beta_flat.data(), provider, n_spatial, spin_symmetric, threshold,
+          integral_threshold);
     }
-    const auto& sparse =
-        hamiltonian.get_container<SparseHamiltonianContainer>();
-    detail::SparseEriProvider provider(n_spatial,
-                                       sparse.sparse_two_body_integrals());
-    return detail::dispatch_majorana_map(
-        mapping, excluded_core_energy, h1_alpha_flat.data(),
-        h1_beta_flat.data(), provider, n_spatial, spin_symmetric, threshold,
-        integral_threshold);
   }
 
   if (hamiltonian.has_container_type<CholeskyHamiltonianContainer>()) {
@@ -827,6 +852,13 @@ MajoranaMapResult majorana_map_hamiltonian(const MajoranaMapping& mapping,
       throw std::invalid_argument(
           "majorana_map_hamiltonian: Cholesky three-center rows must equal "
           "n_spatial^2.");
+    }
+    if (!spin_symmetric &&
+        (l_beta.rows() != l_alpha.rows() || l_beta.cols() != l_alpha.cols())) {
+      throw std::invalid_argument(
+          "majorana_map_hamiltonian: beta Cholesky three-center integrals "
+          "must match alpha rows and auxiliary columns for unrestricted "
+          "Hamiltonians.");
     }
     detail::CholeskyEriProvider provider{
         l_alpha, l_beta, n_spatial, n_spatial * n_spatial,

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -2,17 +2,24 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
 
+#include <algorithm>
 #include <array>
 #include <bit>
 #include <cmath>
 #include <complex>
 #include <cstddef>
 #include <cstdint>
+#include <map>
+#include <qdk/chemistry/data/hamiltonian.hpp>
+#include <qdk/chemistry/data/hamiltonian_containers/cholesky.hpp>
+#include <qdk/chemistry/data/hamiltonian_containers/sparse.hpp>
 #include <qdk/chemistry/data/majorana_mapping.hpp>
 #include <qdk/chemistry/data/pauli_operator.hpp>
 #include <qdk/chemistry/utils/hash_context.hpp>
+#include <span>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -191,12 +198,239 @@ class PackedAccumulator {
 //     cross-spin channels are related by Coulomb symmetry (pq|rs) =
 //     (rs|pq) and are handled in a single merged loop.
 
-template <std::size_t NW>
-MajoranaMapResult majorana_map_impl(
-    const MajoranaMapping& mapping, double core_energy, const double* h1_alpha,
-    const double* h1_beta, const double* eri_aaaa, const double* eri_aabb,
-    const double* eri_bbbb, std::size_t n_spatial, bool spin_symmetric,
-    double threshold, double integral_threshold) {
+inline std::size_t idx4(std::size_t n_spatial, std::size_t p, std::size_t q,
+                        std::size_t r, std::size_t s) {
+  return ((p * n_spatial + q) * n_spatial + r) * n_spatial + s;
+}
+
+inline std::size_t canonical_pair_index(std::size_t n_spatial, std::size_t p,
+                                        std::size_t q) {
+  if (p > q) std::swap(p, q);
+  return p * n_spatial - (p * (p - 1)) / 2 + (q - p);
+}
+
+struct DenseEriProvider {
+  const double* eri_aaaa;
+  const double* eri_aabb;
+  const double* eri_bbbb;
+  std::size_t n_spatial;
+  std::size_t n2;
+
+  double aaaa(std::size_t p, std::size_t q, std::size_t r,
+              std::size_t s) const {
+    return eri_aaaa[idx4(n_spatial, p, q, r, s)];
+  }
+
+  std::span<const double> row_aaaa(std::size_t p, std::size_t q) const {
+    return {eri_aaaa + (p * n_spatial + q) * n2, n2};
+  }
+
+  std::span<const double> row_aabb(std::size_t p, std::size_t q) const {
+    return {eri_aabb + (p * n_spatial + q) * n2, n2};
+  }
+
+  std::span<const double> row_bbbb(std::size_t p, std::size_t q) const {
+    return {eri_bbbb + (p * n_spatial + q) * n2, n2};
+  }
+
+  template <typename Callback>
+  void for_each_restricted_eri(const std::vector<std::size_t>& sym_map,
+                               double integral_threshold,
+                               Callback&& callback) const {
+    for (std::size_t p = 0; p < n_spatial; ++p) {
+      for (std::size_t q = p; q < n_spatial; ++q) {
+        std::size_t pq_idx = sym_map[p * n_spatial + q];
+        auto row = row_aaaa(p, q);
+        for (std::size_t r = 0; r < n_spatial; ++r) {
+          for (std::size_t s = r; s < n_spatial; ++s) {
+            std::size_t rs_idx = sym_map[r * n_spatial + s];
+            if (pq_idx > rs_idx) continue;
+
+            double eri = row[r * n_spatial + s];
+            if (std::abs(eri) < integral_threshold) continue;
+            callback(p, q, r, s, pq_idx, rs_idx, eri);
+          }
+        }
+      }
+    }
+  }
+};
+
+struct CholeskyEriProvider {
+  const Eigen::MatrixXd& l_alpha;
+  const Eigen::MatrixXd& l_beta;
+  std::size_t n_spatial;
+  std::size_t n2;
+  std::size_t naux;
+
+  double dot_rows(const Eigen::MatrixXd& left, std::size_t left_row,
+                  const Eigen::MatrixXd& right, std::size_t right_row) const {
+    double value = 0.0;
+    for (std::size_t aux = 0; aux < naux; ++aux) {
+      value += left(left_row, aux) * right(right_row, aux);
+    }
+    return value;
+  }
+
+  std::vector<double> build_row(const Eigen::MatrixXd& left,
+                                const Eigen::MatrixXd& right, std::size_t p,
+                                std::size_t q) const {
+    std::vector<double> row(n2, 0.0);
+    const std::size_t pq = p * n_spatial + q;
+    for (std::size_t aux = 0; aux < naux; ++aux) {
+      const double scale = left(pq, aux);
+      if (scale == 0.0) continue;
+      for (std::size_t rs = 0; rs < n2; ++rs) {
+        row[rs] += scale * right(rs, aux);
+      }
+    }
+    return row;
+  }
+
+  double aaaa(std::size_t p, std::size_t q, std::size_t r,
+              std::size_t s) const {
+    return dot_rows(l_alpha, p * n_spatial + q, l_alpha, r * n_spatial + s);
+  }
+
+  std::vector<double> row_aaaa(std::size_t p, std::size_t q) const {
+    return build_row(l_alpha, l_alpha, p, q);
+  }
+
+  std::vector<double> row_aabb(std::size_t p, std::size_t q) const {
+    return build_row(l_alpha, l_beta, p, q);
+  }
+
+  std::vector<double> row_bbbb(std::size_t p, std::size_t q) const {
+    return build_row(l_beta, l_beta, p, q);
+  }
+
+  template <typename Callback>
+  void for_each_restricted_eri(const std::vector<std::size_t>& sym_map,
+                               double integral_threshold,
+                               Callback&& callback) const {
+    for (std::size_t p = 0; p < n_spatial; ++p) {
+      for (std::size_t q = p; q < n_spatial; ++q) {
+        std::size_t pq_idx = sym_map[p * n_spatial + q];
+        auto row = row_aaaa(p, q);
+        for (std::size_t r = 0; r < n_spatial; ++r) {
+          for (std::size_t s = r; s < n_spatial; ++s) {
+            std::size_t rs_idx = sym_map[r * n_spatial + s];
+            if (pq_idx > rs_idx) continue;
+
+            double eri = row[r * n_spatial + s];
+            if (std::abs(eri) < integral_threshold) continue;
+            callback(p, q, r, s, pq_idx, rs_idx, eri);
+          }
+        }
+      }
+    }
+  }
+};
+
+struct SparseEriProvider {
+  struct Key {
+    std::size_t p;
+    std::size_t q;
+    std::size_t r;
+    std::size_t s;
+
+    friend bool operator<(const Key& left, const Key& right) {
+      return std::tie(left.p, left.q, left.r, left.s) <
+             std::tie(right.p, right.q, right.r, right.s);
+    }
+  };
+
+  std::size_t n_spatial;
+  std::size_t n2;
+  std::map<Key, double> entries;
+
+  SparseEriProvider(std::size_t n,
+                    const SparseHamiltonianContainer::TwoBodyMap& values)
+      : n_spatial(n), n2(n * n) {
+    for (const auto& [indices, value] : values) {
+      auto [p, q, r, s] = indices;
+      Key key = canonicalize_checked(p, q, r, s);
+      auto [it, inserted] = entries.emplace(key, value);
+      if (!inserted) {
+        double scale = std::max({1.0, std::abs(it->second), std::abs(value)});
+        if (std::abs(it->second - value) > 1e-12 * scale) {
+          throw std::invalid_argument(
+              "Sparse two-body integrals contain inconsistent values for "
+              "symmetry-equivalent indices.");
+        }
+      }
+    }
+  }
+
+  Key canonicalize_checked(int p, int q, int r, int s) const {
+    auto checked = [&](int index) -> std::size_t {
+      if (index < 0 || static_cast<std::size_t>(index) >= n_spatial) {
+        throw std::invalid_argument(
+            "Sparse two-body integral index is outside the active-space "
+            "orbital range.");
+      }
+      return static_cast<std::size_t>(index);
+    };
+    return canonicalize(checked(p), checked(q), checked(r), checked(s));
+  }
+
+  Key canonicalize(std::size_t p, std::size_t q, std::size_t r,
+                   std::size_t s) const {
+    if (p > q) std::swap(p, q);
+    if (r > s) std::swap(r, s);
+    if (canonical_pair_index(n_spatial, p, q) >
+        canonical_pair_index(n_spatial, r, s)) {
+      std::swap(p, r);
+      std::swap(q, s);
+    }
+    return {p, q, r, s};
+  }
+
+  double aaaa(std::size_t p, std::size_t q, std::size_t r,
+              std::size_t s) const {
+    auto it = entries.find(canonicalize(p, q, r, s));
+    return it == entries.end() ? 0.0 : it->second;
+  }
+
+  std::vector<double> row_aaaa(std::size_t p, std::size_t q) const {
+    std::vector<double> row(n2, 0.0);
+    for (std::size_t r = 0; r < n_spatial; ++r) {
+      for (std::size_t s = 0; s < n_spatial; ++s) {
+        row[r * n_spatial + s] = aaaa(p, q, r, s);
+      }
+    }
+    return row;
+  }
+
+  std::vector<double> row_aabb(std::size_t p, std::size_t q) const {
+    return row_aaaa(p, q);
+  }
+
+  std::vector<double> row_bbbb(std::size_t p, std::size_t q) const {
+    return row_aaaa(p, q);
+  }
+
+  template <typename Callback>
+  void for_each_restricted_eri(const std::vector<std::size_t>& sym_map,
+                               double integral_threshold,
+                               Callback&& callback) const {
+    for (const auto& [key, eri] : entries) {
+      if (std::abs(eri) < integral_threshold) continue;
+      std::size_t pq_idx = sym_map[key.p * n_spatial + key.q];
+      std::size_t rs_idx = sym_map[key.r * n_spatial + key.s];
+      callback(key.p, key.q, key.r, key.s, pq_idx, rs_idx, eri);
+    }
+  }
+};
+
+template <std::size_t NW, typename EriProvider>
+MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
+                                    double core_energy, const double* h1_alpha,
+                                    const double* h1_beta,
+                                    const EriProvider& eri_provider,
+                                    std::size_t n_spatial, bool spin_symmetric,
+                                    double threshold,
+                                    double integral_threshold) {
   const std::size_t n_modes = 2 * n_spatial;
 
   PackedAccumulator<NW> acc;
@@ -270,11 +504,6 @@ MajoranaMapResult majorana_map_impl(
     acc.accumulate(identity, std::complex<double>(core_energy, 0.0));
   }
 
-  auto idx4 = [n_spatial](std::size_t p, std::size_t q, std::size_t r,
-                          std::size_t s) -> std::size_t {
-    return ((p * n_spatial + q) * n_spatial + r) * n_spatial + s;
-  };
-
   // ─── One-body terms ──────────────────────────────────────────────
   std::vector<double> h1_eff_alpha(n_spatial * n_spatial);
   std::vector<double> h1_eff_beta(n_spatial * n_spatial);
@@ -285,7 +514,7 @@ MajoranaMapResult majorana_map_impl(
       if (spin_symmetric) {
         double delta_corr = 0.0;
         for (std::size_t q = 0; q < n_spatial; ++q) {
-          delta_corr += eri_aaaa[idx4(p, q, q, s)];
+          delta_corr += eri_provider.aaaa(p, q, q, s);
         }
         h_a -= 0.5 * delta_corr;
         h_b = h_a;
@@ -367,40 +596,30 @@ MajoranaMapResult majorana_map_impl(
       }
     }
 
-    for (std::size_t p = 0; p < n_spatial; ++p) {
-      for (std::size_t q = p; q < n_spatial; ++q) {
-        std::size_t pq_idx = sym_map[p * n_spatial + q];
-        const auto& s_pq = sym_e[pq_idx];
-        for (std::size_t r = 0; r < n_spatial; ++r) {
-          for (std::size_t s = r; s < n_spatial; ++s) {
-            std::size_t rs_idx = sym_map[r * n_spatial + s];
-            if (pq_idx > rs_idx) continue;
+    eri_provider.for_each_restricted_eri(
+        sym_map, integral_threshold,
+        [&](std::size_t, std::size_t, std::size_t, std::size_t,
+            std::size_t pq_idx, std::size_t rs_idx, double eri) {
+          const auto& s_pq = sym_e[pq_idx];
+          const auto& s_rs = sym_e[rs_idx];
 
-            double eri = eri_aaaa[idx4(p, q, r, s)];
-            if (std::abs(eri) < integral_threshold) continue;
-
-            const auto& s_rs = sym_e[rs_idx];
-
-            if (pq_idx == rs_idx) {
-              double half_eri = 0.5 * eri;
-              for (const auto& [c1, w1] : s_pq.terms) {
-                for (const auto& [c2, w2] : s_rs.terms) {
-                  acc.accumulate_product(w1, w2, half_eri * c1 * c2);
-                }
+          if (pq_idx == rs_idx) {
+            double half_eri = 0.5 * eri;
+            for (const auto& [c1, w1] : s_pq.terms) {
+              for (const auto& [c2, w2] : s_rs.terms) {
+                acc.accumulate_product(w1, w2, half_eri * c1 * c2);
               }
-            } else {
-              double half_eri = 0.5 * eri;
-              for (const auto& [c1, w1] : s_pq.terms) {
-                for (const auto& [c2, w2] : s_rs.terms) {
-                  acc.accumulate_product(w1, w2, half_eri * c1 * c2);
-                  acc.accumulate_product(w2, w1, half_eri * c2 * c1);
-                }
+            }
+          } else {
+            double half_eri = 0.5 * eri;
+            for (const auto& [c1, w1] : s_pq.terms) {
+              for (const auto& [c2, w2] : s_rs.terms) {
+                acc.accumulate_product(w1, w2, half_eri * c1 * c2);
+                acc.accumulate_product(w2, w1, half_eri * c2 * c1);
               }
             }
           }
-        }
-      }
-    }
+        });
 
   } else {
     auto accumulate_two_body_product =
@@ -437,9 +656,10 @@ MajoranaMapResult majorana_map_impl(
     // αα channel
     for (std::size_t p = 0; p < n_spatial; ++p) {
       for (std::size_t q = 0; q < n_spatial; ++q) {
+        auto row = eri_provider.row_aaaa(p, q);
         for (std::size_t r = 0; r < n_spatial; ++r) {
           for (std::size_t s = 0; s < n_spatial; ++s) {
-            double eri = eri_aaaa[idx4(p, q, r, s)];
+            double eri = row[r * n_spatial + s];
             if (std::abs(eri) < integral_threshold) continue;
             accumulate_two_body_product(mode_alpha(p), mode_alpha(q),
                                         mode_alpha(r), mode_alpha(s), eri);
@@ -454,9 +674,10 @@ MajoranaMapResult majorana_map_impl(
     // ββ channel
     for (std::size_t p = 0; p < n_spatial; ++p) {
       for (std::size_t q = 0; q < n_spatial; ++q) {
+        auto row = eri_provider.row_bbbb(p, q);
         for (std::size_t r = 0; r < n_spatial; ++r) {
           for (std::size_t s = 0; s < n_spatial; ++s) {
-            double eri = eri_bbbb[idx4(p, q, r, s)];
+            double eri = row[r * n_spatial + s];
             if (std::abs(eri) < integral_threshold) continue;
             accumulate_two_body_product(mode_beta(p), mode_beta(q),
                                         mode_beta(r), mode_beta(s), eri);
@@ -471,9 +692,10 @@ MajoranaMapResult majorana_map_impl(
     // αβ + βα cross-spin channels, related by Coulomb symmetry (pq|rs)=(rs|pq)
     for (std::size_t p = 0; p < n_spatial; ++p) {
       for (std::size_t q = 0; q < n_spatial; ++q) {
+        auto row = eri_provider.row_aabb(p, q);
         for (std::size_t r = 0; r < n_spatial; ++r) {
           for (std::size_t s = 0; s < n_spatial; ++s) {
-            double eri = eri_aabb[idx4(p, q, r, s)];
+            double eri = row[r * n_spatial + s];
             if (std::abs(eri) < integral_threshold) continue;
             accumulate_two_body_product(mode_alpha(p), mode_alpha(q),
                                         mode_beta(r), mode_beta(s), eri);
@@ -501,27 +723,26 @@ MajoranaMapResult majorana_map_impl(
 }
 
 // Dispatch table: function pointer per NW, covering 1..16 (up to 1024 qubits).
+template <typename EriProvider>
 using DispatchFn = MajoranaMapResult (*)(const MajoranaMapping&, double,
                                          const double*, const double*,
-                                         const double*, const double*,
-                                         const double*, std::size_t, bool,
+                                         const EriProvider&, std::size_t, bool,
                                          double, double);
 
-template <std::size_t... Is>
-constexpr std::array<DispatchFn, sizeof...(Is)> make_dispatch_table(
-    std::index_sequence<Is...>) {
-  return {{&majorana_map_impl<Is + 1>...}};
+template <typename EriProvider, std::size_t... Is>
+constexpr std::array<DispatchFn<EriProvider>, sizeof...(Is)>
+make_dispatch_table(std::index_sequence<Is...>) {
+  return {{&majorana_map_impl<Is + 1, EriProvider>...}};
 }
 
 constexpr std::size_t max_nw = 16;
 
-}  // namespace detail
-
-MajoranaMapResult majorana_map_hamiltonian(
+template <typename EriProvider>
+MajoranaMapResult dispatch_majorana_map(
     const MajoranaMapping& mapping, double core_energy, const double* h1_alpha,
-    const double* h1_beta, const double* eri_aaaa, const double* eri_aabb,
-    const double* eri_bbbb, std::size_t n_spatial, bool spin_symmetric,
-    double threshold, double integral_threshold) {
+    const double* h1_beta, const EriProvider& eri_provider,
+    std::size_t n_spatial, bool spin_symmetric, double threshold,
+    double integral_threshold) {
   const std::size_t num_qubits = mapping.num_qubits();
   if (num_qubits == 0) {
     throw std::invalid_argument(
@@ -530,18 +751,97 @@ MajoranaMapResult majorana_map_hamiltonian(
   }
   const std::size_t num_words = (num_qubits + 63) / 64;
 
-  if (num_words > detail::max_nw) {
+  if (num_words > max_nw) {
     throw std::invalid_argument(
         "majorana_map_hamiltonian: num_qubits=" + std::to_string(num_qubits) +
-        " exceeds the maximum of " + std::to_string(detail::max_nw * 64) +
-        " qubits.");
+        " exceeds the maximum of " + std::to_string(max_nw * 64) + " qubits.");
   }
 
   static const auto table =
-      detail::make_dispatch_table(std::make_index_sequence<detail::max_nw>{});
-  return table[num_words - 1](mapping, core_energy, h1_alpha, h1_beta, eri_aaaa,
-                              eri_aabb, eri_bbbb, n_spatial, spin_symmetric,
+      make_dispatch_table<EriProvider>(std::make_index_sequence<max_nw>{});
+  return table[num_words - 1](mapping, core_energy, h1_alpha, h1_beta,
+                              eri_provider, n_spatial, spin_symmetric,
                               threshold, integral_threshold);
+}
+
+}  // namespace detail
+
+MajoranaMapResult majorana_map_hamiltonian(
+    const MajoranaMapping& mapping, double core_energy, const double* h1_alpha,
+    const double* h1_beta, const double* eri_aaaa, const double* eri_aabb,
+    const double* eri_bbbb, std::size_t n_spatial, bool spin_symmetric,
+    double threshold, double integral_threshold) {
+  detail::DenseEriProvider provider{eri_aaaa, eri_aabb, eri_bbbb, n_spatial,
+                                    n_spatial * n_spatial};
+  return detail::dispatch_majorana_map(mapping, core_energy, h1_alpha, h1_beta,
+                                       provider, n_spatial, spin_symmetric,
+                                       threshold, integral_threshold);
+}
+
+MajoranaMapResult majorana_map_hamiltonian(const MajoranaMapping& mapping,
+                                           const Hamiltonian& hamiltonian,
+                                           double threshold,
+                                           double integral_threshold) {
+  auto [h1_alpha, h1_beta] = hamiltonian.get_one_body_integrals();
+  if (h1_alpha.rows() != h1_alpha.cols()) {
+    throw std::invalid_argument(
+        "majorana_map_hamiltonian: alpha one-body integrals must be square.");
+  }
+
+  const std::size_t n_spatial = static_cast<std::size_t>(h1_alpha.rows());
+  const bool spin_symmetric = hamiltonian.is_restricted();
+
+  std::vector<double> h1_alpha_flat(n_spatial * n_spatial);
+  std::vector<double> h1_beta_flat(n_spatial * n_spatial);
+  for (std::size_t p = 0; p < n_spatial; ++p) {
+    for (std::size_t q = 0; q < n_spatial; ++q) {
+      h1_alpha_flat[p * n_spatial + q] = h1_alpha(p, q);
+      h1_beta_flat[p * n_spatial + q] =
+          spin_symmetric ? h1_alpha(p, q) : h1_beta(p, q);
+    }
+  }
+
+  constexpr double excluded_core_energy = 0.0;
+
+  if (hamiltonian.has_container_type<SparseHamiltonianContainer>()) {
+    if (!spin_symmetric) {
+      throw std::invalid_argument(
+          "majorana_map_hamiltonian: sparse container mapping currently "
+          "requires restricted orbitals.");
+    }
+    const auto& sparse =
+        hamiltonian.get_container<SparseHamiltonianContainer>();
+    detail::SparseEriProvider provider(n_spatial,
+                                       sparse.sparse_two_body_integrals());
+    return detail::dispatch_majorana_map(
+        mapping, excluded_core_energy, h1_alpha_flat.data(),
+        h1_beta_flat.data(), provider, n_spatial, spin_symmetric, threshold,
+        integral_threshold);
+  }
+
+  if (hamiltonian.has_container_type<CholeskyHamiltonianContainer>()) {
+    const auto& cholesky =
+        hamiltonian.get_container<CholeskyHamiltonianContainer>();
+    auto [l_alpha, l_beta] = cholesky.get_three_center_integrals();
+    if (static_cast<std::size_t>(l_alpha.rows()) != n_spatial * n_spatial) {
+      throw std::invalid_argument(
+          "majorana_map_hamiltonian: Cholesky three-center rows must equal "
+          "n_spatial^2.");
+    }
+    detail::CholeskyEriProvider provider{
+        l_alpha, l_beta, n_spatial, n_spatial * n_spatial,
+        static_cast<std::size_t>(l_alpha.cols())};
+    return detail::dispatch_majorana_map(
+        mapping, excluded_core_energy, h1_alpha_flat.data(),
+        h1_beta_flat.data(), provider, n_spatial, spin_symmetric, threshold,
+        integral_threshold);
+  }
+
+  auto [eri_aaaa, eri_aabb, eri_bbbb] = hamiltonian.get_two_body_integrals();
+  return majorana_map_hamiltonian(
+      mapping, excluded_core_energy, h1_alpha_flat.data(), h1_beta_flat.data(),
+      eri_aaaa.data(), eri_aabb.data(), eri_bbbb.data(), n_spatial,
+      spin_symmetric, threshold, integral_threshold);
 }
 
 }  // namespace qdk::chemistry::data

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -9,7 +9,6 @@
 #include <complex>
 #include <cstddef>
 #include <cstdint>
-#include <map>
 #include <qdk/chemistry/data/hamiltonian.hpp>
 #include <qdk/chemistry/data/hamiltonian_containers/cholesky.hpp>
 #include <qdk/chemistry/data/hamiltonian_containers/sparse.hpp>
@@ -221,15 +220,18 @@ struct DenseEriProvider {
     return eri_aaaa[idx4(n_spatial, p, q, r, s)];
   }
 
-  std::span<const double> row_aaaa(std::size_t p, std::size_t q) const {
+  std::span<const double> row_aaaa(std::size_t p, std::size_t q,
+                                   std::vector<double>&) const {
     return {eri_aaaa + (p * n_spatial + q) * n2, n2};
   }
 
-  std::span<const double> row_aabb(std::size_t p, std::size_t q) const {
+  std::span<const double> row_aabb(std::size_t p, std::size_t q,
+                                   std::vector<double>&) const {
     return {eri_aabb + (p * n_spatial + q) * n2, n2};
   }
 
-  std::span<const double> row_bbbb(std::size_t p, std::size_t q) const {
+  std::span<const double> row_bbbb(std::size_t p, std::size_t q,
+                                   std::vector<double>&) const {
     return {eri_bbbb + (p * n_spatial + q) * n2, n2};
   }
 
@@ -237,10 +239,11 @@ struct DenseEriProvider {
   void for_each_restricted_eri(const std::vector<std::size_t>& sym_map,
                                double integral_threshold,
                                Callback&& callback) const {
+    std::vector<double> scratch;
     for (std::size_t p = 0; p < n_spatial; ++p) {
       for (std::size_t q = p; q < n_spatial; ++q) {
         std::size_t pq_idx = sym_map[p * n_spatial + q];
-        auto row = row_aaaa(p, q);
+        auto row = row_aaaa(p, q, scratch);
         for (std::size_t r = 0; r < n_spatial; ++r) {
           for (std::size_t s = r; s < n_spatial; ++s) {
             std::size_t rs_idx = sym_map[r * n_spatial + s];
@@ -272,19 +275,20 @@ struct CholeskyEriProvider {
     return value;
   }
 
-  std::vector<double> build_row(const Eigen::MatrixXd& left,
-                                const Eigen::MatrixXd& right, std::size_t p,
-                                std::size_t q) const {
-    std::vector<double> row(n2, 0.0);
+  std::span<const double> build_row(const Eigen::MatrixXd& left,
+                                    const Eigen::MatrixXd& right, std::size_t p,
+                                    std::size_t q,
+                                    std::vector<double>& scratch) const {
+    scratch.assign(n2, 0.0);
     const std::size_t pq = p * n_spatial + q;
     for (std::size_t aux = 0; aux < naux; ++aux) {
       const double scale = left(pq, aux);
       if (scale == 0.0) continue;
       for (std::size_t rs = 0; rs < n2; ++rs) {
-        row[rs] += scale * right(rs, aux);
+        scratch[rs] += scale * right(rs, aux);
       }
     }
-    return row;
+    return {scratch.data(), scratch.size()};
   }
 
   double aaaa(std::size_t p, std::size_t q, std::size_t r,
@@ -292,26 +296,30 @@ struct CholeskyEriProvider {
     return dot_rows(l_alpha, p * n_spatial + q, l_alpha, r * n_spatial + s);
   }
 
-  std::vector<double> row_aaaa(std::size_t p, std::size_t q) const {
-    return build_row(l_alpha, l_alpha, p, q);
+  std::span<const double> row_aaaa(std::size_t p, std::size_t q,
+                                   std::vector<double>& scratch) const {
+    return build_row(l_alpha, l_alpha, p, q, scratch);
   }
 
-  std::vector<double> row_aabb(std::size_t p, std::size_t q) const {
-    return build_row(l_alpha, l_beta, p, q);
+  std::span<const double> row_aabb(std::size_t p, std::size_t q,
+                                   std::vector<double>& scratch) const {
+    return build_row(l_alpha, l_beta, p, q, scratch);
   }
 
-  std::vector<double> row_bbbb(std::size_t p, std::size_t q) const {
-    return build_row(l_beta, l_beta, p, q);
+  std::span<const double> row_bbbb(std::size_t p, std::size_t q,
+                                   std::vector<double>& scratch) const {
+    return build_row(l_beta, l_beta, p, q, scratch);
   }
 
   template <typename Callback>
   void for_each_restricted_eri(const std::vector<std::size_t>& sym_map,
                                double integral_threshold,
                                Callback&& callback) const {
+    std::vector<double> scratch;
     for (std::size_t p = 0; p < n_spatial; ++p) {
       for (std::size_t q = p; q < n_spatial; ++q) {
         std::size_t pq_idx = sym_map[p * n_spatial + q];
-        auto row = row_aaaa(p, q);
+        auto row = row_aaaa(p, q, scratch);
         for (std::size_t r = 0; r < n_spatial; ++r) {
           for (std::size_t s = r; s < n_spatial; ++s) {
             std::size_t rs_idx = sym_map[r * n_spatial + s];
@@ -360,28 +368,40 @@ struct SparseEriProvider {
   std::unordered_map<Key, double, KeyHash> lookup;
 
   SparseEriProvider(std::size_t n,
-                    const SparseHamiltonianContainer::TwoBodyMap& values)
+                    const SparseHamiltonianContainer::TwoBodyMap& values,
+                    double integral_threshold)
       : n_spatial(n), n2(n * n) {
-    std::map<Key, double> canonical_entries;
+    lookup.reserve(values.size());
     for (const auto& [indices, value] : values) {
       auto [p, q, r, s] = indices;
       Key key = canonicalize_checked(p, q, r, s);
-      auto [it, inserted] = canonical_entries.emplace(key, value);
+      auto [it, inserted] = lookup.emplace(key, value);
       if (!inserted) {
-        double scale = std::max({1.0, std::abs(it->second), std::abs(value)});
-        if (std::abs(it->second - value) > 1e-12 * scale) {
+        if (inconsistent_duplicate(it->second, value, integral_threshold)) {
           throw std::invalid_argument(
               "Sparse two-body integrals contain inconsistent values for "
               "symmetry-equivalent indices.");
         }
       }
     }
-    entries.reserve(canonical_entries.size());
-    lookup.reserve(canonical_entries.size());
-    for (const auto& [key, value] : canonical_entries) {
+    entries.reserve(lookup.size());
+    for (const auto& [key, value] : lookup) {
       entries.emplace_back(key, value);
-      lookup.emplace(key, value);
     }
+    std::sort(entries.begin(), entries.end(),
+              [](const auto& left, const auto& right) {
+                return left.first < right.first;
+              });
+  }
+
+  static bool inconsistent_duplicate(double left, double right,
+                                     double integral_threshold) {
+    if (std::abs(left) < integral_threshold &&
+        std::abs(right) < integral_threshold) {
+      return false;
+    }
+    double scale = std::max({1.0, std::abs(left), std::abs(right)});
+    return std::abs(left - right) > 1e-12 * scale;
   }
 
   Key canonicalize_checked(int p, int q, int r, int s) const {
@@ -414,22 +434,25 @@ struct SparseEriProvider {
     return it == lookup.end() ? 0.0 : it->second;
   }
 
-  std::vector<double> row_aaaa(std::size_t p, std::size_t q) const {
-    std::vector<double> row(n2, 0.0);
+  std::span<const double> row_aaaa(std::size_t p, std::size_t q,
+                                   std::vector<double>& scratch) const {
+    scratch.assign(n2, 0.0);
     for (std::size_t r = 0; r < n_spatial; ++r) {
       for (std::size_t s = 0; s < n_spatial; ++s) {
-        row[r * n_spatial + s] = aaaa(p, q, r, s);
+        scratch[r * n_spatial + s] = aaaa(p, q, r, s);
       }
     }
-    return row;
+    return {scratch.data(), scratch.size()};
   }
 
-  std::vector<double> row_aabb(std::size_t p, std::size_t q) const {
-    return row_aaaa(p, q);
+  std::span<const double> row_aabb(std::size_t p, std::size_t q,
+                                   std::vector<double>& scratch) const {
+    return row_aaaa(p, q, scratch);
   }
 
-  std::vector<double> row_bbbb(std::size_t p, std::size_t q) const {
-    return row_aaaa(p, q);
+  std::span<const double> row_bbbb(std::size_t p, std::size_t q,
+                                   std::vector<double>& scratch) const {
+    return row_aaaa(p, q, scratch);
   }
 
   template <typename Callback>
@@ -644,6 +667,7 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
         });
 
   } else {
+    std::vector<double> row_scratch;
     auto accumulate_two_body_product =
         [&](std::size_t mode_p, std::size_t mode_q, std::size_t mode_r,
             std::size_t mode_s, double eri) {
@@ -678,7 +702,7 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
     // αα channel
     for (std::size_t p = 0; p < n_spatial; ++p) {
       for (std::size_t q = 0; q < n_spatial; ++q) {
-        auto row = eri_provider.row_aaaa(p, q);
+        auto row = eri_provider.row_aaaa(p, q, row_scratch);
         for (std::size_t r = 0; r < n_spatial; ++r) {
           for (std::size_t s = 0; s < n_spatial; ++s) {
             double eri = row[r * n_spatial + s];
@@ -696,7 +720,7 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
     // ββ channel
     for (std::size_t p = 0; p < n_spatial; ++p) {
       for (std::size_t q = 0; q < n_spatial; ++q) {
-        auto row = eri_provider.row_bbbb(p, q);
+        auto row = eri_provider.row_bbbb(p, q, row_scratch);
         for (std::size_t r = 0; r < n_spatial; ++r) {
           for (std::size_t s = 0; s < n_spatial; ++s) {
             double eri = row[r * n_spatial + s];
@@ -714,7 +738,7 @@ MajoranaMapResult majorana_map_impl(const MajoranaMapping& mapping,
     // αβ + βα cross-spin channels, related by Coulomb symmetry (pq|rs)=(rs|pq)
     for (std::size_t p = 0; p < n_spatial; ++p) {
       for (std::size_t q = 0; q < n_spatial; ++q) {
-        auto row = eri_provider.row_aabb(p, q);
+        auto row = eri_provider.row_aabb(p, q, row_scratch);
         for (std::size_t r = 0; r < n_spatial; ++r) {
           for (std::size_t s = 0; s < n_spatial; ++s) {
             double eri = row[r * n_spatial + s];
@@ -835,8 +859,8 @@ MajoranaMapResult majorana_map_hamiltonian(const MajoranaMapping& mapping,
     if (spin_symmetric) {
       const auto& sparse =
           hamiltonian.get_container<SparseHamiltonianContainer>();
-      detail::SparseEriProvider provider(n_spatial,
-                                         sparse.sparse_two_body_integrals());
+      detail::SparseEriProvider provider(
+          n_spatial, sparse.sparse_two_body_integrals(), integral_threshold);
       return detail::dispatch_majorana_map(
           mapping, excluded_core_energy, h1_alpha_flat.data(),
           h1_beta_flat.data(), provider, n_spatial, spin_symmetric, threshold,

--- a/cpp/tests/test_majorana_mapping.cpp
+++ b/cpp/tests/test_majorana_mapping.cpp
@@ -4,10 +4,17 @@
 
 #include <gtest/gtest.h>
 
+#include <Eigen/Dense>
 #include <complex>
+#include <memory>
+#include <qdk/chemistry/data/hamiltonian.hpp>
+#include <qdk/chemistry/data/hamiltonian_containers/cholesky.hpp>
 #include <qdk/chemistry/data/majorana_mapping.hpp>
+#include <qdk/chemistry/data/orbitals.hpp>
+#include <qdk/chemistry/data/symmetry/symmetry.hpp>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -58,6 +65,22 @@ void expect_real_term(
   EXPECT_NEAR(it->second.real(), expected, 1e-12);
   EXPECT_NEAR(it->second.imag(), 0.0, 1e-12);
 }
+
+std::shared_ptr<const SymmetryProduct> model_spin_symmetry(bool restricted) {
+  return std::make_shared<const SymmetryProduct>(
+      SymmetryProduct({axes::spin(1, restricted)}));
+}
+
+class ThrowingDenseCholeskyContainer : public CholeskyHamiltonianContainer {
+ public:
+  using CholeskyHamiltonianContainer::CholeskyHamiltonianContainer;
+
+  std::tuple<const Eigen::VectorXd&, const Eigen::VectorXd&,
+             const Eigen::VectorXd&>
+  get_two_body_integrals() const override {
+    throw std::runtime_error("dense Cholesky materialization is forbidden");
+  }
+};
 
 }  // namespace
 
@@ -213,6 +236,26 @@ TEST(MajoranaMapEngineTest, RejectsZeroQubitMappings) {
                                /*threshold=*/1e-12,
                                /*integral_threshold=*/1e-12),
       std::invalid_argument);
+}
+
+TEST(MajoranaMapEngineTest,
+     CholeskyHamiltonianOverloadDoesNotCallDenseTwoBodyGetter) {
+  Eigen::MatrixXd h1(2, 2);
+  h1 << 0.2, -0.1, -0.1, 0.3;
+  Eigen::MatrixXd three_center(4, 2);
+  three_center << 0.4, 0.1, -0.2, 0.3, -0.2, 0.3, 0.5, -0.4;
+  auto orbitals = std::make_shared<ModelOrbitals>(2, model_spin_symmetry(true));
+  Eigen::MatrixXd inactive_fock = Eigen::MatrixXd::Zero(0, 0);
+
+  Hamiltonian hamiltonian(std::make_unique<ThrowingDenseCholeskyContainer>(
+      h1, three_center, orbitals, /*core_energy=*/0.0, inactive_fock));
+  auto mapping = MajoranaMapping::jordan_wigner(4);
+
+  MajoranaMapResult result;
+  EXPECT_NO_THROW(result = majorana_map_hamiltonian(
+                      mapping, hamiltonian, /*threshold=*/1e-12,
+                      /*integral_threshold=*/1e-12));
+  EXPECT_FALSE(result.words.empty());
 }
 
 TEST(MajoranaMappingHashTest, EqualMappingsHaveStableHash) {

--- a/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
+++ b/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
@@ -195,6 +195,14 @@ Use ``QubitHamiltonian.to_interleaved()`` for alternative qubit orderings if nee
 
 Both restricted (RHF) and unrestricted (UHF) Hamiltonians are supported.
 
+For :class:`~qdk_chemistry.data.SparseHamiltonianContainer` inputs, the native
+mapper iterates the stored two-body terms directly instead of first
+materializing a dense four-index tensor. For
+:class:`~qdk_chemistry.data.CholeskyHamiltonianContainer` inputs, it contracts
+one ``(pq|*)`` row at a time from the three-center factors, preserving the same
+returned :class:`~qdk_chemistry.data.QubitHamiltonian` semantics, including the
+existing convention that core energy is not folded into the mapped operator.
+
 Custom encodings can be defined by constructing a :class:`~qdk_chemistry.data.MajoranaMapping` from a Pauli-string table.
 
 .. rubric:: Settings

--- a/python/src/pybind11/data/majorana_mapping.cpp
+++ b/python/src/pybind11/data/majorana_mapping.cpp
@@ -8,6 +8,7 @@
 #include <pybind11/stl.h>
 
 #include <nlohmann/json.hpp>
+#include <qdk/chemistry/data/hamiltonian.hpp>
 #include <qdk/chemistry/data/majorana_mapping.hpp>
 #include <qdk/chemistry/data/pauli_operator.hpp>
 #include <qdk/chemistry/data/tapering.hpp>
@@ -323,6 +324,28 @@ Map a fermionic Hamiltonian to qubit Pauli terms using Majorana loops.
 When ``spin_symmetric`` is true, uses a spin-summed fast path that assumes
 identical integrals across spin channels (restricted orbitals). When false,
 handles each spin channel independently (unrestricted orbitals).
+
+Returns ``(words, coefficients)`` where ``words`` is a list of sparse
+Pauli words.
+)");
+
+  data.def(
+      "majorana_map_hamiltonian",
+      [](const MajoranaMapping& mapping, const Hamiltonian& hamiltonian,
+         double threshold, double integral_threshold) -> py::tuple {
+        auto result = majorana_map_hamiltonian(mapping, hamiltonian, threshold,
+                                               integral_threshold);
+        return py::make_tuple(py::cast(result.words),
+                              py::cast(result.coefficients));
+      },
+      py::arg("mapping"), py::arg("hamiltonian"), py::arg("threshold"),
+      py::arg("integral_threshold"),
+      R"(
+Map a Hamiltonian to qubit Pauli terms using the native container path.
+
+Sparse and Cholesky containers are consumed without materializing a dense
+four-index tensor. Other containers use the dense mapping path. The scalar
+core-energy shift is excluded to match QubitMapper output semantics.
 
 Returns ``(words, coefficients)`` where ``words`` is a list of sparse
 Pauli words.

--- a/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
+++ b/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
@@ -137,11 +137,9 @@ class QdkQubitMapper(QubitMapper):
         threshold = float(self.settings().get("threshold"))
         integral_threshold = float(self.settings().get("integral_threshold"))
 
-        h1_alpha, h1_beta = hamiltonian.get_one_body_integrals()
-        h2_aaaa, h2_aabb, h2_bbbb = hamiltonian.get_two_body_integrals()
+        h1_alpha, _ = hamiltonian.get_one_body_integrals()
         n_spatial = h1_alpha.shape[0]
         n_spin_orbitals = 2 * n_spatial
-        spin_symmetric = hamiltonian.get_orbitals().is_restricted()
 
         if base_mapping.num_modes != n_spin_orbitals:
             raise ValueError(
@@ -150,22 +148,9 @@ class QdkQubitMapper(QubitMapper):
                 f"Use MajoranaMapping.jordan_wigner(num_modes={n_spin_orbitals}) or equivalent."
             )
 
-        h1_a_flat = np.ascontiguousarray(h1_alpha).ravel()
-        h1_b_flat = h1_a_flat if spin_symmetric else np.ascontiguousarray(h1_beta).ravel()
-        h2_aaaa_flat = np.ascontiguousarray(h2_aaaa).ravel()
-        h2_aabb_flat = h2_aaaa_flat if spin_symmetric else np.ascontiguousarray(h2_aabb).ravel()
-        h2_bbbb_flat = h2_aaaa_flat if spin_symmetric else np.ascontiguousarray(h2_bbbb).ravel()
-
         words, coefficients = majorana_map_hamiltonian(
             base_mapping,
-            0.0,
-            h1_a_flat,
-            h1_b_flat,
-            h2_aaaa_flat,
-            h2_aabb_flat,
-            h2_bbbb_flat,
-            n_spatial,
-            spin_symmetric,
+            hamiltonian,
             threshold,
             integral_threshold,
         )

--- a/python/tests/test_qdk_qubit_mapper_container_paths.py
+++ b/python/tests/test_qdk_qubit_mapper_container_paths.py
@@ -27,6 +27,16 @@ from qdk_chemistry.utils.model_hamiltonians import create_hubbard_hamiltonian, c
 
 from .test_helpers import create_test_basis_set, create_test_orbitals
 
+try:
+    from pyscf import ao2mo, gto, scf
+
+    PYSCF_AVAILABLE = True
+except ImportError:
+    ao2mo = None
+    gto = None
+    scf = None
+    PYSCF_AVAILABLE = False
+
 
 def _dense_hamiltonian(one_body: np.ndarray, two_body: np.ndarray) -> Hamiltonian:
     orbitals = create_test_orbitals(one_body.shape[0])
@@ -107,6 +117,39 @@ def _three_center(n_orbitals: int, n_auxiliary: int, start: int) -> np.ndarray:
     return centered.reshape(n_orbitals**2, n_auxiliary) / (10.0 * n_orbitals * n_auxiliary)
 
 
+def _molecular_cholesky_pair(atom: str, basis: str) -> tuple[Hamiltonian, Hamiltonian, int]:
+    assert ao2mo is not None
+    assert gto is not None
+    assert scf is not None
+
+    mol = gto.M(atom=atom, basis=basis, unit="Angstrom", verbose=0)
+    mf = scf.RHF(mol)
+    mf.conv_tol = 1e-10
+    mf.kernel()
+    assert mf.converged
+
+    coefficients = mf.mo_coeff
+    n_orbitals = coefficients.shape[1]
+    one_body = coefficients.T @ mf.get_hcore() @ coefficients
+    eri_mo = ao2mo.restore(1, ao2mo.kernel(mol, coefficients), n_orbitals)
+
+    pair_matrix = np.asarray(eri_mo).reshape(n_orbitals**2, n_orbitals**2)
+    pair_matrix = (pair_matrix + pair_matrix.T) / 2
+    eigvals, eigvecs = np.linalg.eigh(pair_matrix)
+    keep = eigvals > 1e-12
+    three_center = np.ascontiguousarray(eigvecs[:, keep] * np.sqrt(eigvals[keep]))
+    dense_two_body = np.ascontiguousarray((three_center @ three_center.T).reshape(n_orbitals**4))
+
+    orbitals = create_test_orbitals(n_orbitals)
+    core_energy = float(mf.energy_nuc())
+    dense = Hamiltonian(
+        CanonicalFourCenterHamiltonianContainer(one_body, dense_two_body, orbitals, core_energy, np.eye(0))
+    )
+    cholesky = Hamiltonian(CholeskyHamiltonianContainer(one_body, three_center, orbitals, core_energy, np.eye(0)))
+
+    return cholesky, dense, n_orbitals
+
+
 MAPPING_FACTORIES = [
     MajoranaMapping.jordan_wigner,
     MajoranaMapping.bravyi_kitaev,
@@ -128,6 +171,12 @@ RESTRICTED_CHOLESKY_CASES = [
 UNRESTRICTED_CHOLESKY_CASES = [
     pytest.param(2, 2, id="two-orbital"),
     pytest.param(3, 2, id="three-orbital"),
+]
+
+MOLECULAR_CHOLESKY_CASES = [
+    pytest.param("H 0 0 0; H 0 0 0.74", "sto-3g", id="h2-sto3g"),
+    pytest.param("O 0 0 0; H 0 0.757 0.587; H 0 -0.757 0.587", "sto-3g", id="h2o-sto3g"),
+    pytest.param("N 0 0 0; N 0 0 1.10", "sto-3g", id="n2-sto3g"),
 ]
 
 
@@ -186,6 +235,53 @@ def test_sparse_container_canonicalizes_symmetry_related_two_body_keys(mapping_f
     )
 
 
+def test_sparse_container_ignores_below_threshold_duplicate_mismatch() -> None:
+    """Below-threshold symmetry duplicates should not fail consistency checks."""
+    n_orbitals = 2
+    one_body = np.diag([0.3, -0.1])
+    dense_two_body = np.zeros(n_orbitals**4)
+    _set_coulomb_symmetric(dense_two_body, n_orbitals, (0, 1, 0, 1), 1e-7)
+    mapping = MajoranaMapping.jordan_wigner(num_modes=2 * n_orbitals)
+    mapper = qdk_mapper_module.QdkQubitMapper(integral_threshold=1e-6)
+
+    sparse_hamiltonian = Hamiltonian(
+        SparseHamiltonianContainer(
+            sparse.csc_matrix(one_body),
+            {
+                (0, 1, 0, 1): 1e-7,
+                (1, 0, 0, 1): 2e-7,
+            },
+        )
+    )
+    dense_hamiltonian = _dense_hamiltonian(one_body, dense_two_body)
+
+    _assert_equivalent(
+        mapper.run(sparse_hamiltonian, mapping),
+        mapper.run(dense_hamiltonian, mapping),
+    )
+
+
+def test_sparse_container_rejects_above_threshold_duplicate_mismatch() -> None:
+    """Meaningful symmetry duplicate disagreements should stay explicit."""
+    n_orbitals = 2
+    one_body = np.zeros((n_orbitals, n_orbitals))
+    mapping = MajoranaMapping.jordan_wigner(num_modes=2 * n_orbitals)
+    mapper = qdk_mapper_module.QdkQubitMapper(integral_threshold=1e-12)
+
+    sparse_hamiltonian = Hamiltonian(
+        SparseHamiltonianContainer(
+            sparse.csc_matrix(one_body),
+            {
+                (0, 1, 0, 1): 0.7,
+                (1, 0, 0, 1): 0.5,
+            },
+        )
+    )
+
+    with pytest.raises(ValueError, match="inconsistent values"):
+        mapper.run(sparse_hamiltonian, mapping)
+
+
 @pytest.mark.parametrize("model_factory", SPARSE_MODEL_FACTORIES)
 @pytest.mark.parametrize("mapping_factory", MAPPING_FACTORIES)
 def test_sparse_model_hamiltonian_maps_like_dense_materialization(mapping_factory, model_factory) -> None:
@@ -221,6 +317,23 @@ def test_cholesky_container_maps_like_dense_reconstruction(mapping_factory, n_or
     _assert_equivalent(
         mapper.run(cholesky, mapping),
         mapper.run(dense, mapping),
+    )
+
+
+@pytest.mark.skipif(not PYSCF_AVAILABLE, reason="PySCF not available")
+@pytest.mark.parametrize(("atom", "basis"), MOLECULAR_CHOLESKY_CASES)
+@pytest.mark.parametrize("mapping_factory", MAPPING_FACTORIES)
+def test_molecular_cholesky_container_maps_like_dense_reconstruction(mapping_factory, atom, basis) -> None:
+    """Molecular Cholesky-backed systems should match dense references."""
+    cholesky, dense, n_orbitals = _molecular_cholesky_pair(atom, basis)
+
+    mapping = mapping_factory(num_modes=2 * n_orbitals)
+    mapper = create("qubit_mapper", "qdk")
+
+    _assert_equivalent(
+        mapper.run(cholesky, mapping),
+        mapper.run(dense, mapping),
+        atol=5e-11,
     )
 
 

--- a/python/tests/test_qdk_qubit_mapper_container_paths.py
+++ b/python/tests/test_qdk_qubit_mapper_container_paths.py
@@ -6,6 +6,7 @@
 # --------------------------------------------------------------------------------------------
 
 from collections import defaultdict
+from collections.abc import Callable
 
 import numpy as np
 import pytest
@@ -22,7 +23,7 @@ from qdk_chemistry.data import (
     Orbitals,
     SparseHamiltonianContainer,
 )
-from qdk_chemistry.utils.model_hamiltonians import create_hubbard_hamiltonian
+from qdk_chemistry.utils.model_hamiltonians import create_hubbard_hamiltonian, create_ppp_hamiltonian, ohno_potential
 
 from .test_helpers import create_test_basis_set, create_test_orbitals
 
@@ -73,10 +74,60 @@ def _assert_equivalent(left, right, atol: float = 1e-12) -> None:
         assert coefficient == pytest.approx(right_terms[pauli_string], abs=atol)
 
 
+def _hubbard_chain() -> Hamiltonian:
+    return create_hubbard_hamiltonian(LatticeGraph.chain(4), epsilon=-0.25, t=0.8, U=0.4)
+
+
+def _hubbard_square() -> Hamiltonian:
+    return create_hubbard_hamiltonian(LatticeGraph.square(2, 2), epsilon=-0.2, t=0.6, U=0.5)
+
+
+def _ppp_chain() -> Hamiltonian:
+    n_sites = 4
+    lattice = LatticeGraph.chain(n_sites)
+    onsite = 0.4
+    return create_ppp_hamiltonian(
+        lattice,
+        epsilon=np.zeros(n_sites),
+        t=np.ones((n_sites, n_sites)),
+        U=np.full(n_sites, onsite),
+        V=ohno_potential(lattice, U=onsite, R=1.2, epsilon_r=0.9),
+        z=np.ones(n_sites),
+    )
+
+
+def _symmetric_one_body(n_orbitals: int, start: int) -> np.ndarray:
+    values = np.arange(start, start + n_orbitals**2, dtype=float).reshape(n_orbitals, n_orbitals)
+    return (values + values.T) / (20.0 * n_orbitals**2)
+
+
+def _three_center(n_orbitals: int, n_auxiliary: int, start: int) -> np.ndarray:
+    values = np.arange(start, start + n_orbitals**2 * n_auxiliary, dtype=float)
+    centered = values - values.mean()
+    return centered.reshape(n_orbitals**2, n_auxiliary) / (10.0 * n_orbitals * n_auxiliary)
+
+
 MAPPING_FACTORIES = [
     MajoranaMapping.jordan_wigner,
     MajoranaMapping.bravyi_kitaev,
     MajoranaMapping.parity,
+]
+
+SPARSE_MODEL_FACTORIES: list[Callable[[], Hamiltonian]] = [
+    _hubbard_chain,
+    _hubbard_square,
+    _ppp_chain,
+]
+
+RESTRICTED_CHOLESKY_CASES = [
+    pytest.param(2, 2, id="two-orbital"),
+    pytest.param(3, 2, id="three-orbital"),
+    pytest.param(4, 3, id="four-orbital"),
+]
+
+UNRESTRICTED_CHOLESKY_CASES = [
+    pytest.param(2, 2, id="two-orbital"),
+    pytest.param(3, 2, id="three-orbital"),
 ]
 
 
@@ -135,18 +186,15 @@ def test_sparse_container_canonicalizes_symmetry_related_two_body_keys(mapping_f
     )
 
 
+@pytest.mark.parametrize("model_factory", SPARSE_MODEL_FACTORIES)
 @pytest.mark.parametrize("mapping_factory", MAPPING_FACTORIES)
-def test_sparse_model_hamiltonian_maps_like_dense_materialization(mapping_factory) -> None:
+def test_sparse_model_hamiltonian_maps_like_dense_materialization(mapping_factory, model_factory) -> None:
     """A real sparse model Hamiltonian should match its dense materialized path."""
-    sparse_hamiltonian = create_hubbard_hamiltonian(
-        LatticeGraph.chain(4),
-        epsilon=-0.25,
-        t=0.8,
-        U=0.4,
-    )
+    sparse_hamiltonian = model_factory()
     dense_hamiltonian = _dense_copy(sparse_hamiltonian)
+    h1_alpha, _ = sparse_hamiltonian.get_one_body_integrals()
 
-    mapping = mapping_factory(num_modes=8)
+    mapping = mapping_factory(num_modes=2 * h1_alpha.shape[0])
     mapper = create("qubit_mapper", "qdk")
 
     _assert_equivalent(
@@ -155,19 +203,12 @@ def test_sparse_model_hamiltonian_maps_like_dense_materialization(mapping_factor
     )
 
 
+@pytest.mark.parametrize(("n_orbitals", "n_auxiliary"), RESTRICTED_CHOLESKY_CASES)
 @pytest.mark.parametrize("mapping_factory", MAPPING_FACTORIES)
-def test_cholesky_container_maps_like_dense_reconstruction(mapping_factory) -> None:
+def test_cholesky_container_maps_like_dense_reconstruction(mapping_factory, n_orbitals, n_auxiliary) -> None:
     """The Cholesky path should stream rows while preserving dense-path semantics."""
-    n_orbitals = 2
-    one_body = np.array([[0.4, -0.1], [-0.1, 0.2]])
-    three_center = np.array(
-        [
-            [0.7, 0.0],
-            [0.2, -0.3],
-            [0.2, -0.3],
-            [0.5, 0.4],
-        ]
-    )
+    one_body = _symmetric_one_body(n_orbitals, start=1)
+    three_center = _three_center(n_orbitals, n_auxiliary, start=10)
     orbitals = create_test_orbitals(n_orbitals)
     cholesky = Hamiltonian(CholeskyHamiltonianContainer(one_body, three_center, orbitals, 0.0, np.eye(0)))
 
@@ -183,28 +224,16 @@ def test_cholesky_container_maps_like_dense_reconstruction(mapping_factory) -> N
     )
 
 
+@pytest.mark.parametrize(("n_orbitals", "n_auxiliary"), UNRESTRICTED_CHOLESKY_CASES)
 @pytest.mark.parametrize("mapping_factory", MAPPING_FACTORIES)
-def test_unrestricted_cholesky_container_maps_like_dense_reconstruction(mapping_factory) -> None:
+def test_unrestricted_cholesky_container_maps_like_dense_reconstruction(
+    mapping_factory, n_orbitals, n_auxiliary
+) -> None:
     """The Cholesky row path should preserve separate alpha/beta spin channels."""
-    n_orbitals = 2
-    one_body_alpha = np.array([[0.4, -0.1], [-0.1, 0.2]])
-    one_body_beta = np.array([[0.5, 0.03], [0.03, 0.1]])
-    three_center_alpha = np.array(
-        [
-            [0.7, 0.0],
-            [0.2, -0.3],
-            [0.1, 0.4],
-            [0.5, 0.2],
-        ]
-    )
-    three_center_beta = np.array(
-        [
-            [0.6, 0.1],
-            [-0.2, 0.2],
-            [0.3, -0.1],
-            [0.4, 0.5],
-        ]
-    )
+    one_body_alpha = _symmetric_one_body(n_orbitals, start=1)
+    one_body_beta = _symmetric_one_body(n_orbitals, start=5)
+    three_center_alpha = _three_center(n_orbitals, n_auxiliary, start=10)
+    three_center_beta = _three_center(n_orbitals, n_auxiliary, start=20)
     orbitals = _unrestricted_orbitals(n_orbitals)
     cholesky = Hamiltonian(
         CholeskyHamiltonianContainer(

--- a/python/tests/test_qdk_qubit_mapper_container_paths.py
+++ b/python/tests/test_qdk_qubit_mapper_container_paths.py
@@ -1,0 +1,242 @@
+"""Container-aware QDK qubit mapper tests."""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from collections import defaultdict
+
+import numpy as np
+import pytest
+from scipy import sparse
+
+import qdk_chemistry.algorithms.qubit_mapper.qdk_qubit_mapper as qdk_mapper_module
+from qdk_chemistry.algorithms import create
+from qdk_chemistry.data import (
+    CanonicalFourCenterHamiltonianContainer,
+    CholeskyHamiltonianContainer,
+    Hamiltonian,
+    LatticeGraph,
+    MajoranaMapping,
+    Orbitals,
+    SparseHamiltonianContainer,
+)
+from qdk_chemistry.utils.model_hamiltonians import create_hubbard_hamiltonian
+
+from .test_helpers import create_test_basis_set, create_test_orbitals
+
+
+def _dense_hamiltonian(one_body: np.ndarray, two_body: np.ndarray) -> Hamiltonian:
+    orbitals = create_test_orbitals(one_body.shape[0])
+    return Hamiltonian(CanonicalFourCenterHamiltonianContainer(one_body, two_body, orbitals, 0.0, np.eye(0)))
+
+
+def _dense_copy(hamiltonian: Hamiltonian) -> Hamiltonian:
+    h1_alpha, _ = hamiltonian.get_one_body_integrals()
+    eri_aaaa, _, _ = hamiltonian.get_two_body_integrals()
+    return _dense_hamiltonian(h1_alpha, np.array(eri_aaaa))
+
+
+def _unrestricted_orbitals(n_orbitals: int) -> Orbitals:
+    coeffs_alpha = np.eye(n_orbitals)
+    coeffs_beta = np.eye(n_orbitals)
+    coeffs_beta[0, 0] = 0.9
+    return Orbitals(coeffs_alpha, coeffs_beta, None, None, None, create_test_basis_set(n_orbitals))
+
+
+def _set_coulomb_symmetric(two_body: np.ndarray, n_orbitals: int, indices, value: float) -> None:
+    p, q, r, s = indices
+    keys = set()
+    for left in {(p, q), (q, p)}:
+        for right in {(r, s), (s, r)}:
+            keys.add((*left, *right))
+            keys.add((*right, *left))
+
+    for a, b, c, d in keys:
+        two_body[((a * n_orbitals + b) * n_orbitals + c) * n_orbitals + d] = value
+
+
+def _terms_by_pauli(qh) -> dict[str, complex]:
+    assert len(qh.pauli_strings) == len(qh.coefficients)
+    terms: defaultdict[str, complex] = defaultdict(complex)
+    for pauli_string, coefficient in zip(qh.pauli_strings, qh.coefficients, strict=True):
+        terms[pauli_string] += coefficient
+    return dict(sorted(terms.items()))
+
+
+def _assert_equivalent(left, right, atol: float = 1e-12) -> None:
+    left_terms = _terms_by_pauli(left)
+    right_terms = _terms_by_pauli(right)
+    assert left_terms.keys() == right_terms.keys()
+    for pauli_string, coefficient in left_terms.items():
+        assert coefficient == pytest.approx(right_terms[pauli_string], abs=atol)
+
+
+MAPPING_FACTORIES = [
+    MajoranaMapping.jordan_wigner,
+    MajoranaMapping.bravyi_kitaev,
+    MajoranaMapping.parity,
+]
+
+
+def test_qdk_mapper_passes_hamiltonian_to_native_overload(monkeypatch) -> None:
+    """The Python mapper should let the native layer choose the container path."""
+    hamiltonian = _dense_hamiltonian(np.array([[1.0]]), np.zeros(1))
+    mapping = MajoranaMapping.jordan_wigner(num_modes=2)
+    seen = {}
+
+    def fake_majorana_map_hamiltonian(mapping_arg, hamiltonian_arg, threshold, integral_threshold):
+        seen["mapping"] = mapping_arg
+        seen["hamiltonian"] = hamiltonian_arg
+        seen["threshold"] = threshold
+        seen["integral_threshold"] = integral_threshold
+        return [[]], [1.0]
+
+    monkeypatch.setattr(qdk_mapper_module, "majorana_map_hamiltonian", fake_majorana_map_hamiltonian)
+
+    result = qdk_mapper_module.QdkQubitMapper(threshold=1e-9, integral_threshold=1e-8).run(hamiltonian, mapping)
+
+    assert result.pauli_strings == ["II"]
+    assert seen == {
+        "mapping": mapping,
+        "hamiltonian": hamiltonian,
+        "threshold": 1e-9,
+        "integral_threshold": 1e-8,
+    }
+
+
+@pytest.mark.parametrize(
+    "mapping_factory",
+    MAPPING_FACTORIES,
+)
+def test_sparse_container_canonicalizes_symmetry_related_two_body_keys(mapping_factory) -> None:
+    """Sparse ERIs may be stored at a symmetry-related key, not the canonical dense key."""
+    n_orbitals = 2
+    one_body = np.zeros((n_orbitals, n_orbitals))
+    value = 0.7
+
+    dense_two_body = np.zeros(n_orbitals**4)
+    _set_coulomb_symmetric(dense_two_body, n_orbitals, (0, 1, 0, 1), value)
+    dense = _dense_hamiltonian(one_body, dense_two_body)
+
+    sparse_container = SparseHamiltonianContainer(
+        sparse.csc_matrix(one_body),
+        {(1, 0, 0, 1): value},
+    )
+    sparse_hamiltonian = Hamiltonian(sparse_container)
+
+    mapping = mapping_factory(num_modes=2 * n_orbitals)
+    mapper = create("qubit_mapper", "qdk")
+
+    _assert_equivalent(
+        mapper.run(sparse_hamiltonian, mapping),
+        mapper.run(dense, mapping),
+    )
+
+
+@pytest.mark.parametrize("mapping_factory", MAPPING_FACTORIES)
+def test_sparse_model_hamiltonian_maps_like_dense_materialization(mapping_factory) -> None:
+    """A real sparse model Hamiltonian should match its dense materialized path."""
+    sparse_hamiltonian = create_hubbard_hamiltonian(
+        LatticeGraph.chain(4),
+        epsilon=-0.25,
+        t=0.8,
+        U=0.4,
+    )
+    dense_hamiltonian = _dense_copy(sparse_hamiltonian)
+
+    mapping = mapping_factory(num_modes=8)
+    mapper = create("qubit_mapper", "qdk")
+
+    _assert_equivalent(
+        mapper.run(sparse_hamiltonian, mapping),
+        mapper.run(dense_hamiltonian, mapping),
+    )
+
+
+@pytest.mark.parametrize("mapping_factory", MAPPING_FACTORIES)
+def test_cholesky_container_maps_like_dense_reconstruction(mapping_factory) -> None:
+    """The Cholesky path should stream rows while preserving dense-path semantics."""
+    n_orbitals = 2
+    one_body = np.array([[0.4, -0.1], [-0.1, 0.2]])
+    three_center = np.array(
+        [
+            [0.7, 0.0],
+            [0.2, -0.3],
+            [0.2, -0.3],
+            [0.5, 0.4],
+        ]
+    )
+    orbitals = create_test_orbitals(n_orbitals)
+    cholesky = Hamiltonian(CholeskyHamiltonianContainer(one_body, three_center, orbitals, 0.0, np.eye(0)))
+
+    dense_two_body = (three_center @ three_center.T).reshape(n_orbitals**4)
+    dense = _dense_hamiltonian(one_body, dense_two_body)
+
+    mapping = mapping_factory(num_modes=2 * n_orbitals)
+    mapper = create("qubit_mapper", "qdk")
+
+    _assert_equivalent(
+        mapper.run(cholesky, mapping),
+        mapper.run(dense, mapping),
+    )
+
+
+@pytest.mark.parametrize("mapping_factory", MAPPING_FACTORIES)
+def test_unrestricted_cholesky_container_maps_like_dense_reconstruction(mapping_factory) -> None:
+    """The Cholesky row path should preserve separate alpha/beta spin channels."""
+    n_orbitals = 2
+    one_body_alpha = np.array([[0.4, -0.1], [-0.1, 0.2]])
+    one_body_beta = np.array([[0.5, 0.03], [0.03, 0.1]])
+    three_center_alpha = np.array(
+        [
+            [0.7, 0.0],
+            [0.2, -0.3],
+            [0.1, 0.4],
+            [0.5, 0.2],
+        ]
+    )
+    three_center_beta = np.array(
+        [
+            [0.6, 0.1],
+            [-0.2, 0.2],
+            [0.3, -0.1],
+            [0.4, 0.5],
+        ]
+    )
+    orbitals = _unrestricted_orbitals(n_orbitals)
+    cholesky = Hamiltonian(
+        CholeskyHamiltonianContainer(
+            one_body_alpha,
+            one_body_beta,
+            three_center_alpha,
+            three_center_beta,
+            orbitals,
+            0.0,
+            np.eye(0),
+            np.eye(0),
+        )
+    )
+
+    dense = Hamiltonian(
+        CanonicalFourCenterHamiltonianContainer(
+            one_body_alpha,
+            one_body_beta,
+            (three_center_alpha @ three_center_alpha.T).reshape(n_orbitals**4),
+            (three_center_alpha @ three_center_beta.T).reshape(n_orbitals**4),
+            (three_center_beta @ three_center_beta.T).reshape(n_orbitals**4),
+            orbitals,
+            0.0,
+            np.eye(0),
+            np.eye(0),
+        )
+    )
+
+    mapping = mapping_factory(num_modes=2 * n_orbitals)
+    mapper = create("qubit_mapper", "qdk")
+
+    _assert_equivalent(
+        mapper.run(cholesky, mapping),
+        mapper.run(dense, mapping),
+    )


### PR DESCRIPTION
Fixes #474.

## Summary

This PR adds native container paths to the QDK qubit mapper while keeping the public `QubitMapper.run()` behavior unchanged.

- Adds a `majorana_map_hamiltonian(mapping, hamiltonian, threshold, integral_threshold)` C++ overload and pybind binding.
- Updates the Python QDK mapper to pass the `Hamiltonian` directly, so C++ owns dense/sparse/Cholesky dispatch.
- Keeps the existing dense pointer path as the fallback for canonical four-center containers.
- Adds a sparse ERI provider that canonicalizes sparse two-body keys, validates bounds, rejects meaningful inconsistent symmetry-duplicate values, and iterates stored canonical nonzeros in deterministic order.
- Adds a Cholesky ERI provider that contracts one `(pq|*)` row at a time from three-center factors, avoiding dense `N^4` tensor materialization while reusing the existing mapping loop semantics.
- Documents the sparse and Cholesky paths under the native `"qdk"` mapper section, including the existing convention that core energy is not folded into the mapped operator.

## Notes on related PRs

I saw #513, #530, and #534 are also open for this issue. This is an alternate implementation of the same requested feature, with emphasis on keeping Python dispatch minimal, making C++ the single dispatch point, using row-wise Cholesky contraction, and covering the requested sparse/model and Cholesky cases with deterministic mapper comparisons. I am happy to adapt this toward whichever implementation direction maintainers prefer.

## Acceptance coverage

Local checks run on macOS/Python 3.13:

```bash
QDK_CHEMISTRY_RESOURCES_PATH="$PWD/python/.venv/lib/python3.13/site-packages/qdk_chemistry/share/qdk/chemistry/scf/resources" \
  python/.venv/bin/python -m pytest \
  python/tests/test_qdk_qubit_mapper_container_paths.py \
  python/tests/test_qdk_qubit_mapper.py -q -rs
# 77 passed, 9 skipped
# skipped: PySCF-gated H2/H2O/N2 molecular Cholesky cases when PySCF is not installed locally

cmake --build /tmp/qdk-chemistry-cpp-tests-make --target test_majorana_mapping -j 4
/tmp/qdk-chemistry-cpp-tests-make/tests/test_majorana_mapping --gtest_color=no
# 12 passed

python/.venv/bin/python -m ruff format --check python/tests/test_qdk_qubit_mapper_container_paths.py
python/.venv/bin/python -m ruff check python/tests/test_qdk_qubit_mapper_container_paths.py
/Library/Developer/CommandLineTools/usr/bin/clang-format --dry-run -Werror \
  cpp/src/qdk/chemistry/data/majorana_map_engine.cpp \
  cpp/tests/test_majorana_mapping.cpp
git diff --check
# passed
```

The Python tests cover:

- sparse model Hamiltonians from Hubbard chain, Hubbard square, and PPP factories across Jordan-Wigner, Bravyi-Kitaev, and parity mappings;
- synthetic restricted and unrestricted Cholesky containers across the same mappings;
- PySCF-gated molecular Cholesky H2, H2O, and N2 STO-3G cases across the same mappings;
- sparse symmetry canonicalization and threshold-aware duplicate handling.

The C++ regression test checks that the Cholesky Hamiltonian overload uses the factorized container path without calling dense two-body materialization.

## AI usage disclosure

Travis Crew (CrewRiz) used AI-assisted coding support while preparing this PR. I reviewed the implementation, tests, documentation, and local verification output, and I take responsibility for the final contribution.
