### PR TITLE
feat: add Sparse and Cholesky Hamiltonian fast paths to qubit mapper

### DIFF
--- a/cpp/include/qdk/chemistry/data/hamiltonian_containers/sparse.hpp
+++ b/cpp/include/qdk/chemistry/data/hamiltonian_containers/sparse.hpp
@@ -233,6 +233,15 @@ class SparseHamiltonianContainer : public HamiltonianContainer {
   const SymmetryBlockedSparseMap<4>& two_body_integrals_sparse() const;
 
   /**
+   * @brief Diagnostic hook for tests and memory-sensitive callers.
+   * @return True after the lazy dense n^4 two-body cache has been built.
+   *
+   * Reports only whether the compatibility dense cache already exists; calling
+   * this method never materializes the cache.
+   */
+  bool has_materialized_dense_two_body_integrals() const;
+
+  /**
    * @brief Access a single one-body integral element.
    * @param i Row index
    * @param j Column index

--- a/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
+++ b/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
@@ -18,6 +18,8 @@
 
 namespace qdk::chemistry::data {
 
+class Hamiltonian;
+
 /**
  * @brief Data class describing a fermion-to-qubit encoding.
  *
@@ -331,6 +333,28 @@ MajoranaMapResult majorana_map_hamiltonian(
     const MajoranaMapping& mapping, double core_energy, const double* h1_alpha,
     const double* h1_beta, const double* eri_aaaa, const double* eri_aabb,
     const double* eri_bbbb, std::size_t n_spatial, bool spin_symmetric,
+    double threshold, double integral_threshold);
+
+/**
+ * @brief Map a Hamiltonian without forcing dense two-body materialization for
+ *        sparse or Cholesky-backed containers.
+ *
+ * The returned terms are numerically equivalent to the dense-array overload for
+ * dense containers. Restricted sparse inputs preserve the compatibility
+ * semantics of the dense-array overload: sparse two-body entries are treated as
+ * exact rank-4 tensor coordinates, and only coordinates read by the restricted
+ * dense mapper contribute. This overload derives restricted/unrestricted
+ * behavior from the Hamiltonian container and intentionally excludes the
+ * Hamiltonian core energy, preserving the high-level QdkQubitMapper convention.
+ *
+ * @param mapping The Majorana-to-Pauli encoding.
+ * @param hamiltonian Hamiltonian to map.
+ * @param threshold Pauli terms with |coeff| < threshold are dropped.
+ * @param integral_threshold Integrals with |value| < this are skipped.
+ * @return MajoranaMapResult with Pauli words and coefficients.
+ */
+MajoranaMapResult majorana_map_hamiltonian(
+    const MajoranaMapping& mapping, const Hamiltonian& hamiltonian,
     double threshold, double integral_threshold);
 
 }  // namespace qdk::chemistry::data

--- a/cpp/src/qdk/chemistry/data/hamiltonian_containers/sparse.cpp
+++ b/cpp/src/qdk/chemistry/data/hamiltonian_containers/sparse.cpp
@@ -670,4 +670,9 @@ SparseHamiltonianContainer::two_body_integrals_sparse() const {
   return *_two_body_sparse;
 }
 
+bool SparseHamiltonianContainer::has_materialized_dense_two_body_integrals()
+    const {
+  return _two_body_dense_valid;
+}
+
 }  // namespace qdk::chemistry::data

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -2,18 +2,24 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for
 // license information.
 
+#include <algorithm>
 #include <array>
 #include <bit>
 #include <cmath>
 #include <complex>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
+#include <qdk/chemistry/data/hamiltonian.hpp>
+#include <qdk/chemistry/data/hamiltonian_containers/cholesky.hpp>
+#include <qdk/chemistry/data/hamiltonian_containers/sparse.hpp>
 #include <qdk/chemistry/data/majorana_mapping.hpp>
 #include <qdk/chemistry/data/pauli_operator.hpp>
 #include <qdk/chemistry/utils/hash_context.hpp>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace qdk::chemistry::data {
@@ -167,6 +173,280 @@ class PackedAccumulator {
       terms_;
 };
 
+// ─── Two-body integral sources ──────────────────────────────────────
+//
+// The Pauli accumulation code below is shared across dense, sparse, and
+// Cholesky-backed Hamiltonians. Each source presents the same scalar accessors
+// and, when profitable, a sparse restricted iterator.
+
+inline std::size_t idx4(std::size_t n_spatial, std::size_t p, std::size_t q,
+                        std::size_t r, std::size_t s) {
+  return ((p * n_spatial + q) * n_spatial + r) * n_spatial + s;
+}
+
+struct DenseTwoBodySource {
+  static constexpr bool sparse_restricted_iteration = false;
+
+  const double* eri_aaaa;
+  const double* eri_aabb;
+  const double* eri_bbbb;
+  std::size_t n_spatial;
+
+  double aaaa(std::size_t p, std::size_t q, std::size_t r,
+              std::size_t s) const {
+    return eri_aaaa[idx4(n_spatial, p, q, r, s)];
+  }
+
+  double aabb(std::size_t p, std::size_t q, std::size_t r,
+              std::size_t s) const {
+    return eri_aabb[idx4(n_spatial, p, q, r, s)];
+  }
+
+  double bbbb(std::size_t p, std::size_t q, std::size_t r,
+              std::size_t s) const {
+    return eri_bbbb[idx4(n_spatial, p, q, r, s)];
+  }
+};
+
+class CholeskyTwoBodySource {
+ public:
+  static constexpr bool sparse_restricted_iteration = false;
+
+  CholeskyTwoBodySource(const CholeskyHamiltonianContainer& container,
+                        std::size_t n_spatial)
+      : n_spatial_(n_spatial) {
+    const auto factors = container.get_three_center_integrals();
+    const Eigen::MatrixXd& aa = factors.first;
+    const Eigen::MatrixXd& bb = factors.second;
+    const auto expected_rows =
+        static_cast<Eigen::Index>(n_spatial_ * n_spatial_);
+    if (aa.rows() != expected_rows || bb.rows() != expected_rows ||
+        aa.cols() != bb.cols()) {
+      throw std::invalid_argument(
+          "majorana_map_hamiltonian: Cholesky three-center integrals must have "
+          "shape [n_spatial^2, n_aux] for matching alpha and beta factors.");
+    }
+    aaaa_cache_ = std::make_unique<ContractedRowCache>(aa, aa);
+    aabb_cache_ = std::make_unique<ContractedRowCache>(aa, bb);
+    bbbb_cache_ = std::make_unique<ContractedRowCache>(bb, bb);
+  }
+
+  double aaaa(std::size_t p, std::size_t q, std::size_t r,
+              std::size_t s) const {
+    return aaaa_cache_->value(pair_index(p, q), pair_index(r, s));
+  }
+
+  double aabb(std::size_t p, std::size_t q, std::size_t r,
+              std::size_t s) const {
+    return aabb_cache_->value(pair_index(p, q), pair_index(r, s));
+  }
+
+  double bbbb(std::size_t p, std::size_t q, std::size_t r,
+              std::size_t s) const {
+    return bbbb_cache_->value(pair_index(p, q), pair_index(r, s));
+  }
+
+ private:
+  class ContractedRowCache {
+   public:
+    ContractedRowCache(const Eigen::MatrixXd& left, const Eigen::MatrixXd& right)
+        : left_(left), right_(right) {}
+
+    double value(std::size_t left_row, std::size_t right_row) const {
+      const auto& row = contracted_row(left_row);
+      return row(static_cast<Eigen::Index>(right_row));
+    }
+
+   private:
+    struct Entry {
+      std::size_t left_row = 0;
+      std::uint64_t stamp = 0;
+      Eigen::VectorXd values;
+    };
+
+    static constexpr std::size_t max_cached_rows = 64;
+
+    const Eigen::MatrixXd& left_;
+    const Eigen::MatrixXd& right_;
+    mutable std::vector<Entry> entries_;
+    mutable std::uint64_t next_stamp_ = 0;
+
+    const Eigen::VectorXd& contracted_row(std::size_t left_row) const {
+      ++next_stamp_;
+      for (auto& entry : entries_) {
+        if (entry.left_row == left_row) {
+          entry.stamp = next_stamp_;
+          return entry.values;
+        }
+      }
+
+      if (entries_.size() >= max_cached_rows) {
+        auto victim = std::min_element(
+            entries_.begin(), entries_.end(),
+            [](const Entry& lhs, const Entry& rhs) {
+              return lhs.stamp < rhs.stamp;
+            });
+        *victim = make_entry(left_row, next_stamp_);
+        return victim->values;
+      }
+
+      entries_.push_back(make_entry(left_row, next_stamp_));
+      return entries_.back().values;
+    }
+
+    Entry make_entry(std::size_t left_row, std::uint64_t stamp) const {
+      Entry entry;
+      entry.left_row = left_row;
+      entry.stamp = stamp;
+      entry.values =
+          right_ * left_.row(static_cast<Eigen::Index>(left_row)).transpose();
+      return entry;
+    }
+  };
+
+  std::unique_ptr<ContractedRowCache> aaaa_cache_;
+  std::unique_ptr<ContractedRowCache> aabb_cache_;
+  std::unique_ptr<ContractedRowCache> bbbb_cache_;
+  std::size_t n_spatial_ = 0;
+
+  std::size_t pair_index(std::size_t p, std::size_t q) const {
+    return p * n_spatial_ + q;
+  }
+};
+
+class SparseTwoBodySource {
+ public:
+  static constexpr bool sparse_restricted_iteration = true;
+
+  explicit SparseTwoBodySource(const SparseHamiltonianContainer& container,
+                               std::size_t n_spatial) {
+    if (!container.has_two_body_integrals()) {
+      return;
+    }
+    const auto& block = container.two_body_integrals_sparse().block(
+        {axes::alpha(), axes::alpha(), axes::alpha(), axes::alpha()});
+
+    for (const auto& [idx, eri] : block) {
+      EriKey key = exact_key(idx[0], idx[1], idx[2], idx[3], n_spatial);
+      values_.emplace(key, eri);
+    }
+
+    entries_.reserve(values_.size());
+    for (const auto& [key, value] : values_) {
+      entries_.push_back({key, value});
+    }
+    std::sort(entries_.begin(), entries_.end(),
+              [](const EriEntry& lhs, const EriEntry& rhs) {
+                return lhs.key < rhs.key;
+              });
+  }
+
+  double aaaa(std::size_t p, std::size_t q, std::size_t r,
+              std::size_t s) const {
+    auto it = values_.find(EriKey{p, q, r, s});
+    return it == values_.end() ? 0.0 : it->second;
+  }
+
+  double aabb(std::size_t p, std::size_t q, std::size_t r,
+              std::size_t s) const {
+    return aaaa(p, q, r, s);
+  }
+
+  double bbbb(std::size_t p, std::size_t q, std::size_t r,
+              std::size_t s) const {
+    return aaaa(p, q, r, s);
+  }
+
+  template <typename F>
+  void for_each_restricted_dense_coordinate(
+      const std::vector<std::size_t>& sym_map, std::size_t n_spatial,
+      double integral_threshold, F&& f) const {
+    for (const auto& [key, eri] : entries_) {
+      if (std::abs(eri) < integral_threshold) continue;
+      if (key.q < key.p || key.s < key.r) continue;
+      std::size_t pq_idx = sym_map[key.p * n_spatial + key.q];
+      std::size_t rs_idx = sym_map[key.r * n_spatial + key.s];
+      if (pq_idx > rs_idx) continue;
+
+      f(key.p, key.q, key.r, key.s, eri);
+    }
+  }
+
+ private:
+  struct EriKey {
+    std::size_t p = 0;
+    std::size_t q = 0;
+    std::size_t r = 0;
+    std::size_t s = 0;
+
+    bool operator==(const EriKey& other) const = default;
+
+    bool operator<(const EriKey& other) const {
+      return std::array{p, q, r, s} <
+             std::array{other.p, other.q, other.r, other.s};
+    }
+  };
+
+  struct EriKeyHash {
+    std::size_t operator()(const EriKey& key) const noexcept {
+      std::size_t seed = 0;
+      auto combine = [&seed](std::size_t value) {
+        seed ^= value + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
+      };
+      combine(key.p);
+      combine(key.q);
+      combine(key.r);
+      combine(key.s);
+      return seed;
+    }
+  };
+
+  struct EriEntry {
+    EriKey key;
+    double value = 0.0;
+  };
+
+  static EriKey exact_key(std::size_t p, std::size_t q, std::size_t r,
+                          std::size_t s, std::size_t n_spatial) {
+    if (p >= n_spatial || q >= n_spatial || r >= n_spatial ||
+        s >= n_spatial) {
+      throw std::invalid_argument(
+          "majorana_map_hamiltonian: sparse two-body integral index is out "
+          "of range for the Hamiltonian one-body dimension.");
+    }
+    return {p, q, r, s};
+  }
+
+  std::unordered_map<EriKey, double, EriKeyHash> values_;
+  std::vector<EriEntry> entries_;
+};
+
+template <typename Source, typename F>
+void for_each_restricted_representative_integral(
+    const Source& source, const std::vector<std::size_t>& sym_map,
+    std::size_t n_spatial, double integral_threshold, F&& f) {
+  if constexpr (Source::sparse_restricted_iteration) {
+    source.for_each_restricted_dense_coordinate(
+        sym_map, n_spatial, integral_threshold, std::forward<F>(f));
+  } else {
+    for (std::size_t p = 0; p < n_spatial; ++p) {
+      for (std::size_t q = p; q < n_spatial; ++q) {
+        std::size_t pq_idx = sym_map[p * n_spatial + q];
+        for (std::size_t r = 0; r < n_spatial; ++r) {
+          for (std::size_t s = r; s < n_spatial; ++s) {
+            std::size_t rs_idx = sym_map[r * n_spatial + s];
+            if (pq_idx > rs_idx) continue;
+
+            double eri = source.aaaa(p, q, r, s);
+            if (std::abs(eri) < integral_threshold) continue;
+            f(p, q, r, s, eri);
+          }
+        }
+      }
+    }
+  }
+}
+
 // ─── Engine implementation ─────────────────────────────────────────
 //
 // The standard non-relativistic electronic Hamiltonian is spin-free: it
@@ -191,12 +471,12 @@ class PackedAccumulator {
 //     cross-spin channels are related by Coulomb symmetry (pq|rs) =
 //     (rs|pq) and are handled in a single merged loop.
 
-template <std::size_t NW>
-MajoranaMapResult majorana_map_impl(
+template <std::size_t NW, typename TwoBodySource>
+MajoranaMapResult majorana_map_impl_from_source(
     const MajoranaMapping& mapping, double core_energy, const double* h1_alpha,
-    const double* h1_beta, const double* eri_aaaa, const double* eri_aabb,
-    const double* eri_bbbb, std::size_t n_spatial, bool spin_symmetric,
-    double threshold, double integral_threshold) {
+    const double* h1_beta, const TwoBodySource& two_body,
+    std::size_t n_spatial, bool spin_symmetric, double threshold,
+    double integral_threshold) {
   const std::size_t n_modes = 2 * n_spatial;
 
   PackedAccumulator<NW> acc;
@@ -270,11 +550,6 @@ MajoranaMapResult majorana_map_impl(
     acc.accumulate(identity, std::complex<double>(core_energy, 0.0));
   }
 
-  auto idx4 = [n_spatial](std::size_t p, std::size_t q, std::size_t r,
-                          std::size_t s) -> std::size_t {
-    return ((p * n_spatial + q) * n_spatial + r) * n_spatial + s;
-  };
-
   // ─── One-body terms ──────────────────────────────────────────────
   std::vector<double> h1_eff_alpha(n_spatial * n_spatial);
   std::vector<double> h1_eff_beta(n_spatial * n_spatial);
@@ -285,7 +560,7 @@ MajoranaMapResult majorana_map_impl(
       if (spin_symmetric) {
         double delta_corr = 0.0;
         for (std::size_t q = 0; q < n_spatial; ++q) {
-          delta_corr += eri_aaaa[idx4(p, q, q, s)];
+          delta_corr += two_body.aaaa(p, q, q, s);
         }
         h_a -= 0.5 * delta_corr;
         h_b = h_a;
@@ -367,40 +642,32 @@ MajoranaMapResult majorana_map_impl(
       }
     }
 
-    for (std::size_t p = 0; p < n_spatial; ++p) {
-      for (std::size_t q = p; q < n_spatial; ++q) {
-        std::size_t pq_idx = sym_map[p * n_spatial + q];
-        const auto& s_pq = sym_e[pq_idx];
-        for (std::size_t r = 0; r < n_spatial; ++r) {
-          for (std::size_t s = r; s < n_spatial; ++s) {
-            std::size_t rs_idx = sym_map[r * n_spatial + s];
-            if (pq_idx > rs_idx) continue;
+    for_each_restricted_representative_integral(
+        two_body, sym_map, n_spatial, integral_threshold,
+        [&](std::size_t p, std::size_t q, std::size_t r, std::size_t s,
+            double eri) {
+          std::size_t pq_idx = sym_map[p * n_spatial + q];
+          std::size_t rs_idx = sym_map[r * n_spatial + s];
+          const auto& s_pq = sym_e[pq_idx];
+          const auto& s_rs = sym_e[rs_idx];
 
-            double eri = eri_aaaa[idx4(p, q, r, s)];
-            if (std::abs(eri) < integral_threshold) continue;
-
-            const auto& s_rs = sym_e[rs_idx];
-
-            if (pq_idx == rs_idx) {
-              double half_eri = 0.5 * eri;
-              for (const auto& [c1, w1] : s_pq.terms) {
-                for (const auto& [c2, w2] : s_rs.terms) {
-                  acc.accumulate_product(w1, w2, half_eri * c1 * c2);
-                }
+          if (pq_idx == rs_idx) {
+            double half_eri = 0.5 * eri;
+            for (const auto& [c1, w1] : s_pq.terms) {
+              for (const auto& [c2, w2] : s_rs.terms) {
+                acc.accumulate_product(w1, w2, half_eri * c1 * c2);
               }
-            } else {
-              double half_eri = 0.5 * eri;
-              for (const auto& [c1, w1] : s_pq.terms) {
-                for (const auto& [c2, w2] : s_rs.terms) {
-                  acc.accumulate_product(w1, w2, half_eri * c1 * c2);
-                  acc.accumulate_product(w2, w1, half_eri * c2 * c1);
-                }
+            }
+          } else {
+            double half_eri = 0.5 * eri;
+            for (const auto& [c1, w1] : s_pq.terms) {
+              for (const auto& [c2, w2] : s_rs.terms) {
+                acc.accumulate_product(w1, w2, half_eri * c1 * c2);
+                acc.accumulate_product(w2, w1, half_eri * c2 * c1);
               }
             }
           }
-        }
-      }
-    }
+        });
 
   } else {
     auto accumulate_two_body_product =
@@ -439,7 +706,7 @@ MajoranaMapResult majorana_map_impl(
       for (std::size_t q = 0; q < n_spatial; ++q) {
         for (std::size_t r = 0; r < n_spatial; ++r) {
           for (std::size_t s = 0; s < n_spatial; ++s) {
-            double eri = eri_aaaa[idx4(p, q, r, s)];
+            double eri = two_body.aaaa(p, q, r, s);
             if (std::abs(eri) < integral_threshold) continue;
             accumulate_two_body_product(mode_alpha(p), mode_alpha(q),
                                         mode_alpha(r), mode_alpha(s), eri);
@@ -456,7 +723,7 @@ MajoranaMapResult majorana_map_impl(
       for (std::size_t q = 0; q < n_spatial; ++q) {
         for (std::size_t r = 0; r < n_spatial; ++r) {
           for (std::size_t s = 0; s < n_spatial; ++s) {
-            double eri = eri_bbbb[idx4(p, q, r, s)];
+            double eri = two_body.bbbb(p, q, r, s);
             if (std::abs(eri) < integral_threshold) continue;
             accumulate_two_body_product(mode_beta(p), mode_beta(q),
                                         mode_beta(r), mode_beta(s), eri);
@@ -473,7 +740,7 @@ MajoranaMapResult majorana_map_impl(
       for (std::size_t q = 0; q < n_spatial; ++q) {
         for (std::size_t r = 0; r < n_spatial; ++r) {
           for (std::size_t s = 0; s < n_spatial; ++s) {
-            double eri = eri_aabb[idx4(p, q, r, s)];
+            double eri = two_body.aabb(p, q, r, s);
             if (std::abs(eri) < integral_threshold) continue;
             accumulate_two_body_product(mode_alpha(p), mode_alpha(q),
                                         mode_beta(r), mode_beta(s), eri);
@@ -501,19 +768,71 @@ MajoranaMapResult majorana_map_impl(
 }
 
 // Dispatch table: function pointer per NW, covering 1..16 (up to 1024 qubits).
-using DispatchFn = MajoranaMapResult (*)(const MajoranaMapping&, double,
-                                         const double*, const double*,
-                                         const double*, const double*,
-                                         const double*, std::size_t, bool,
-                                         double, double);
+template <typename Source>
+using SourceDispatchFn = MajoranaMapResult (*)(
+    const MajoranaMapping&, double, const double*, const double*, const Source&,
+    std::size_t, bool, double, double);
 
-template <std::size_t... Is>
-constexpr std::array<DispatchFn, sizeof...(Is)> make_dispatch_table(
-    std::index_sequence<Is...>) {
-  return {{&majorana_map_impl<Is + 1>...}};
+template <std::size_t NW, typename Source>
+MajoranaMapResult majorana_map_source_dispatch(
+    const MajoranaMapping& mapping, double core_energy, const double* h1_alpha,
+    const double* h1_beta, const Source& source, std::size_t n_spatial,
+    bool spin_symmetric, double threshold, double integral_threshold) {
+  return majorana_map_impl_from_source<NW>(
+      mapping, core_energy, h1_alpha, h1_beta, source, n_spatial,
+      spin_symmetric, threshold, integral_threshold);
+}
+
+template <typename Source, std::size_t... Is>
+constexpr std::array<SourceDispatchFn<Source>, sizeof...(Is)>
+make_source_dispatch_table(std::index_sequence<Is...>) {
+  return {{&majorana_map_source_dispatch<Is + 1, Source>...}};
 }
 
 constexpr std::size_t max_nw = 16;
+
+inline std::size_t validated_num_words(const MajoranaMapping& mapping) {
+  const std::size_t num_qubits = mapping.num_qubits();
+  if (num_qubits == 0) {
+    throw std::invalid_argument(
+        "majorana_map_hamiltonian: mapping has zero qubits; the encoding "
+        "must produce at least one qubit.");
+  }
+
+  const std::size_t num_words = (num_qubits + 63) / 64;
+  if (num_words > max_nw) {
+    throw std::invalid_argument(
+        "majorana_map_hamiltonian: num_qubits=" + std::to_string(num_qubits) +
+        " exceeds the maximum of " + std::to_string(max_nw * 64) + " qubits.");
+  }
+  return num_words;
+}
+
+template <typename Source>
+MajoranaMapResult dispatch_majorana_map_from_source(
+    const MajoranaMapping& mapping, double core_energy, const double* h1_alpha,
+    const double* h1_beta, const Source& source, std::size_t n_spatial,
+    bool spin_symmetric, double threshold, double integral_threshold) {
+  const std::size_t num_words = validated_num_words(mapping);
+  static const auto table =
+      make_source_dispatch_table<Source>(std::make_index_sequence<max_nw>{});
+  return table[num_words - 1](mapping, core_energy, h1_alpha, h1_beta, source,
+                              n_spatial, spin_symmetric, threshold,
+                              integral_threshold);
+}
+
+std::vector<double> flatten_row_major(const Eigen::MatrixXd& matrix) {
+  std::vector<double> result(
+      static_cast<std::size_t>(matrix.rows() * matrix.cols()));
+  const std::size_t cols = static_cast<std::size_t>(matrix.cols());
+  for (Eigen::Index r = 0; r < matrix.rows(); ++r) {
+    for (Eigen::Index c = 0; c < matrix.cols(); ++c) {
+      result[static_cast<std::size_t>(r) * cols + static_cast<std::size_t>(c)] =
+          matrix(r, c);
+    }
+  }
+  return result;
+}
 
 }  // namespace detail
 
@@ -522,26 +841,68 @@ MajoranaMapResult majorana_map_hamiltonian(
     const double* h1_beta, const double* eri_aaaa, const double* eri_aabb,
     const double* eri_bbbb, std::size_t n_spatial, bool spin_symmetric,
     double threshold, double integral_threshold) {
-  const std::size_t num_qubits = mapping.num_qubits();
-  if (num_qubits == 0) {
-    throw std::invalid_argument(
-        "majorana_map_hamiltonian: mapping has zero qubits; the encoding "
-        "must produce at least one qubit.");
-  }
-  const std::size_t num_words = (num_qubits + 63) / 64;
+  detail::DenseTwoBodySource source{eri_aaaa, eri_aabb, eri_bbbb, n_spatial};
+  return detail::dispatch_majorana_map_from_source(
+      mapping, core_energy, h1_alpha, h1_beta, source, n_spatial,
+      spin_symmetric, threshold, integral_threshold);
+}
 
-  if (num_words > detail::max_nw) {
+MajoranaMapResult majorana_map_hamiltonian(
+    const MajoranaMapping& mapping, const Hamiltonian& hamiltonian,
+    double threshold, double integral_threshold) {
+  auto [h1_alpha, h1_beta] = hamiltonian.get_one_body_integrals();
+  const auto n_spatial = static_cast<std::size_t>(h1_alpha.rows());
+  if (h1_alpha.rows() != h1_alpha.cols()) {
     throw std::invalid_argument(
-        "majorana_map_hamiltonian: num_qubits=" + std::to_string(num_qubits) +
-        " exceeds the maximum of " + std::to_string(detail::max_nw * 64) +
-        " qubits.");
+        "majorana_map_hamiltonian: alpha one-body integrals must be square.");
+  }
+  const bool spin_symmetric = hamiltonian.is_restricted();
+  if (!spin_symmetric &&
+      (h1_beta.rows() != h1_alpha.rows() || h1_beta.cols() != h1_alpha.cols())) {
+    throw std::invalid_argument(
+        "majorana_map_hamiltonian: beta one-body integrals must match alpha "
+        "dimensions.");
   }
 
-  static const auto table =
-      detail::make_dispatch_table(std::make_index_sequence<detail::max_nw>{});
-  return table[num_words - 1](mapping, core_energy, h1_alpha, h1_beta, eri_aaaa,
-                              eri_aabb, eri_bbbb, n_spatial, spin_symmetric,
-                              threshold, integral_threshold);
+  const std::size_t n_spin_orbitals = 2 * n_spatial;
+  if (mapping.num_modes() != n_spin_orbitals) {
+    throw std::invalid_argument(
+        "majorana_map_hamiltonian: mapping has " +
+        std::to_string(mapping.num_modes()) + " modes but the Hamiltonian has " +
+        std::to_string(n_spin_orbitals) + " spin-orbitals.");
+  }
+
+  auto h1_alpha_flat = detail::flatten_row_major(h1_alpha);
+  auto h1_beta_flat =
+      spin_symmetric ? h1_alpha_flat : detail::flatten_row_major(h1_beta);
+  const double* h1_beta_ptr =
+      spin_symmetric ? h1_alpha_flat.data() : h1_beta_flat.data();
+
+  if (spin_symmetric &&
+      hamiltonian.has_container_type<SparseHamiltonianContainer>()) {
+    const auto& container =
+        hamiltonian.get_container<SparseHamiltonianContainer>();
+    detail::SparseTwoBodySource source(container, n_spatial);
+    return detail::dispatch_majorana_map_from_source(
+        mapping, 0.0, h1_alpha_flat.data(), h1_beta_ptr, source,
+        n_spatial, spin_symmetric, threshold, integral_threshold);
+  }
+
+  if (hamiltonian.has_container_type<CholeskyHamiltonianContainer>()) {
+    const auto& container =
+        hamiltonian.get_container<CholeskyHamiltonianContainer>();
+    detail::CholeskyTwoBodySource source(container, n_spatial);
+    return detail::dispatch_majorana_map_from_source(
+        mapping, 0.0, h1_alpha_flat.data(), h1_beta_ptr, source,
+        n_spatial, spin_symmetric, threshold, integral_threshold);
+  }
+
+  auto [eri_aaaa, eri_aabb, eri_bbbb] = hamiltonian.get_two_body_integrals();
+  detail::DenseTwoBodySource source{eri_aaaa.data(), eri_aabb.data(),
+                                    eri_bbbb.data(), n_spatial};
+  return detail::dispatch_majorana_map_from_source(
+      mapping, 0.0, h1_alpha_flat.data(), h1_beta_ptr, source, n_spatial,
+      spin_symmetric, threshold, integral_threshold);
 }
 
 }  // namespace qdk::chemistry::data

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -873,8 +873,10 @@ MajoranaMapResult majorana_map_hamiltonian(
   }
 
   auto h1_alpha_flat = detail::flatten_row_major(h1_alpha);
-  auto h1_beta_flat =
-      spin_symmetric ? h1_alpha_flat : detail::flatten_row_major(h1_beta);
+  std::vector<double> h1_beta_flat;
+  if (!spin_symmetric) {
+    h1_beta_flat = detail::flatten_row_major(h1_beta);
+  }
   const double* h1_beta_ptr =
       spin_symmetric ? h1_alpha_flat.data() : h1_beta_flat.data();
 

--- a/cpp/tests/test_majorana_mapping.cpp
+++ b/cpp/tests/test_majorana_mapping.cpp
@@ -4,10 +4,18 @@
 
 #include <gtest/gtest.h>
 
+#include <Eigen/Dense>
+#include <Eigen/Sparse>
 #include <complex>
+#include <memory>
+#include <qdk/chemistry/data/hamiltonian.hpp>
+#include <qdk/chemistry/data/hamiltonian_containers/cholesky.hpp>
+#include <qdk/chemistry/data/hamiltonian_containers/sparse.hpp>
 #include <qdk/chemistry/data/majorana_mapping.hpp>
+#include <qdk/chemistry/data/orbitals.hpp>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -58,6 +66,17 @@ void expect_real_term(
   EXPECT_NEAR(it->second.real(), expected, 1e-12);
   EXPECT_NEAR(it->second.imag(), 0.0, 1e-12);
 }
+
+class ThrowingDenseCholeskyContainer : public CholeskyHamiltonianContainer {
+ public:
+  using CholeskyHamiltonianContainer::CholeskyHamiltonianContainer;
+
+  std::tuple<const Eigen::VectorXd&, const Eigen::VectorXd&,
+             const Eigen::VectorXd&>
+  get_two_body_integrals() const override {
+    throw std::runtime_error("dense Cholesky materialization is forbidden");
+  }
+};
 
 }  // namespace
 
@@ -213,6 +232,54 @@ TEST(MajoranaMapEngineTest, RejectsZeroQubitMappings) {
                                /*threshold=*/1e-12,
                                /*integral_threshold=*/1e-12),
       std::invalid_argument);
+}
+
+TEST(MajoranaMapEngineTest,
+     SparseHamiltonianOverloadDoesNotMaterializeDenseTwoBody) {
+  Eigen::SparseMatrix<double> h1(2, 2);
+  h1.insert(0, 0) = 0.2;
+  h1.insert(0, 1) = -0.7;
+  h1.insert(1, 0) = 0.3;
+  h1.insert(1, 1) = -0.1;
+  h1.makeCompressed();
+
+  SparseHamiltonianContainer::TwoBodyMap h2;
+  h2[{1, 0, 1, 0}] = 0.6;
+
+  auto container =
+      std::make_unique<SparseHamiltonianContainer>(h1, h2, /*core_energy=*/0.0);
+  const auto* sparse_container = container.get();
+  Hamiltonian hamiltonian(std::move(container));
+  auto mapping = MajoranaMapping::jordan_wigner(4);
+
+  EXPECT_FALSE(
+      sparse_container->has_materialized_dense_two_body_integrals());
+  auto result = majorana_map_hamiltonian(mapping, hamiltonian,
+                                         /*threshold=*/1e-12,
+                                         /*integral_threshold=*/1e-12);
+  EXPECT_FALSE(
+      sparse_container->has_materialized_dense_two_body_integrals());
+  EXPECT_FALSE(result.words.empty());
+}
+
+TEST(MajoranaMapEngineTest,
+     CholeskyHamiltonianOverloadDoesNotCallDenseTwoBodyGetter) {
+  Eigen::MatrixXd h1(2, 2);
+  h1 << 0.2, -0.1, -0.1, 0.3;
+  Eigen::MatrixXd three_center(4, 2);
+  three_center << 0.4, 0.1, -0.2, 0.3, -0.2, 0.3, 0.5, -0.4;
+  auto orbitals = std::make_shared<ModelOrbitals>(2, true);
+  Eigen::MatrixXd inactive_fock = Eigen::MatrixXd::Zero(0, 0);
+
+  Hamiltonian hamiltonian(std::make_unique<ThrowingDenseCholeskyContainer>(
+      h1, three_center, orbitals, /*core_energy=*/0.0, inactive_fock));
+  auto mapping = MajoranaMapping::jordan_wigner(4);
+
+  MajoranaMapResult result;
+  EXPECT_NO_THROW(result = majorana_map_hamiltonian(
+                      mapping, hamiltonian, /*threshold=*/1e-12,
+                      /*integral_threshold=*/1e-12));
+  EXPECT_FALSE(result.words.empty());
 }
 
 TEST(MajoranaMappingHashTest, EqualMappingsHaveStableHash) {

--- a/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
+++ b/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
@@ -195,6 +195,20 @@ Use ``QubitHamiltonian.to_interleaved()`` for alternative qubit orderings if nee
 
 Both restricted (RHF) and unrestricted (UHF) Hamiltonians are supported.
 
+For :class:`~qdk_chemistry.data.CholeskyHamiltonianContainer` and
+:class:`~qdk_chemistry.data.SparseHamiltonianContainer` inputs, the native
+``"qdk"`` implementation uses container-specific two-body integral paths.
+Cholesky-backed Hamiltonians are mapped directly from their three-center
+factors. Restricted sparse model Hamiltonians are mapped by iterating stored
+two-body entries, avoiding dense ``n^4`` two-body materialization; sparse
+containers that are not restricted fall back to the dense compatibility path.
+Restricted sparse entries preserve dense-overload compatibility: stored
+``(p,q,r,s)`` keys are treated as exact rank-4 tensor coordinates, not
+symmetry-equivalent ERI alias classes. The native Hamiltonian mapper derives
+restricted/unrestricted behavior from the Hamiltonian container and
+intentionally omits the Hamiltonian core energy, preserving the historical
+``QdkQubitMapper`` output convention.
+
 Custom encodings can be defined by constructing a :class:`~qdk_chemistry.data.MajoranaMapping` from a Pauli-string table.
 
 .. rubric:: Settings

--- a/python/src/pybind11/data/majorana_mapping.cpp
+++ b/python/src/pybind11/data/majorana_mapping.cpp
@@ -325,9 +325,9 @@ When ``spin_symmetric`` is true, uses a spin-summed fast path that assumes
 identical integrals across spin channels (restricted orbitals). When false,
 handles each spin channel independently (unrestricted orbitals).
 
-	Returns ``(words, coefficients)`` where ``words`` is a list of sparse
-	Pauli words.
-	)");
+Returns ``(words, coefficients)`` where ``words`` is a list of sparse
+Pauli words.
+)");
 
   data.def(
       "majorana_map_hamiltonian",

--- a/python/src/pybind11/data/majorana_mapping.cpp
+++ b/python/src/pybind11/data/majorana_mapping.cpp
@@ -8,6 +8,7 @@
 #include <pybind11/stl.h>
 
 #include <nlohmann/json.hpp>
+#include <qdk/chemistry/data/hamiltonian.hpp>
 #include <qdk/chemistry/data/majorana_mapping.hpp>
 #include <qdk/chemistry/data/pauli_operator.hpp>
 #include <qdk/chemistry/data/tapering.hpp>
@@ -323,6 +324,31 @@ Map a fermionic Hamiltonian to qubit Pauli terms using Majorana loops.
 When ``spin_symmetric`` is true, uses a spin-summed fast path that assumes
 identical integrals across spin channels (restricted orbitals). When false,
 handles each spin channel independently (unrestricted orbitals).
+
+	Returns ``(words, coefficients)`` where ``words`` is a list of sparse
+	Pauli words.
+	)");
+
+  data.def(
+      "majorana_map_hamiltonian",
+      [](const MajoranaMapping& mapping, const Hamiltonian& hamiltonian,
+         double threshold, double integral_threshold) -> py::tuple {
+        auto result = majorana_map_hamiltonian(
+            mapping, hamiltonian, threshold, integral_threshold);
+        return py::make_tuple(py::cast(result.words),
+                              py::cast(result.coefficients));
+      },
+      py::arg("mapping"), py::arg("hamiltonian"), py::arg("threshold"),
+      py::arg("integral_threshold"),
+      R"(
+Map a Hamiltonian to qubit Pauli terms using the native Majorana mapper.
+
+This overload dispatches on the concrete Hamiltonian container. Sparse and
+Cholesky containers are consumed without materializing dense n^4 two-body
+integral vectors. The Hamiltonian core energy is intentionally omitted to match
+the high-level QDK qubit mapper convention. Restricted sparse two-body entries
+preserve dense-overload compatibility: stored sparse keys are treated as exact
+rank-4 tensor coordinates, not symmetry-equivalent ERI alias classes.
 
 Returns ``(words, coefficients)`` where ``words`` is a list of sparse
 Pauli words.

--- a/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
+++ b/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
@@ -137,11 +137,9 @@ class QdkQubitMapper(QubitMapper):
         threshold = float(self.settings().get("threshold"))
         integral_threshold = float(self.settings().get("integral_threshold"))
 
-        h1_alpha, h1_beta = hamiltonian.get_one_body_integrals()
-        h2_aaaa, h2_aabb, h2_bbbb = hamiltonian.get_two_body_integrals()
+        h1_alpha, _ = hamiltonian.get_one_body_integrals()
         n_spatial = h1_alpha.shape[0]
         n_spin_orbitals = 2 * n_spatial
-        spin_symmetric = hamiltonian.get_orbitals().is_restricted()
 
         if base_mapping.num_modes != n_spin_orbitals:
             raise ValueError(
@@ -150,22 +148,9 @@ class QdkQubitMapper(QubitMapper):
                 f"Use MajoranaMapping.jordan_wigner(num_modes={n_spin_orbitals}) or equivalent."
             )
 
-        h1_a_flat = np.ascontiguousarray(h1_alpha).ravel()
-        h1_b_flat = h1_a_flat if spin_symmetric else np.ascontiguousarray(h1_beta).ravel()
-        h2_aaaa_flat = np.ascontiguousarray(h2_aaaa).ravel()
-        h2_aabb_flat = h2_aaaa_flat if spin_symmetric else np.ascontiguousarray(h2_aabb).ravel()
-        h2_bbbb_flat = h2_aaaa_flat if spin_symmetric else np.ascontiguousarray(h2_bbbb).ravel()
-
         words, coefficients = majorana_map_hamiltonian(
             base_mapping,
-            0.0,
-            h1_a_flat,
-            h1_b_flat,
-            h2_aaaa_flat,
-            h2_aabb_flat,
-            h2_bbbb_flat,
-            n_spatial,
-            spin_symmetric,
+            hamiltonian,
             threshold,
             integral_threshold,
         )

--- a/python/tests/test_qdk_qubit_mapper_fast_paths.py
+++ b/python/tests/test_qdk_qubit_mapper_fast_paths.py
@@ -1,0 +1,470 @@
+"""Equivalence tests for QDK qubit mapper sparse and Cholesky fast paths."""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from qdk_chemistry._core.data import majorana_map_hamiltonian, sparse_pauli_word_to_label
+from qdk_chemistry.algorithms import create
+from qdk_chemistry.data import (
+    CanonicalFourCenterHamiltonianContainer,
+    CholeskyHamiltonianContainer,
+    Hamiltonian,
+    LatticeGraph,
+    MajoranaMapping,
+    Orbitals,
+    QubitHamiltonian,
+    SparseHamiltonianContainer,
+    Structure,
+)
+from qdk_chemistry.data.enums.fermion_mode_order import FermionModeOrder
+from qdk_chemistry.utils.model_hamiltonians import (
+    create_hubbard_hamiltonian,
+    create_ppp_hamiltonian,
+)
+
+from .test_helpers import create_test_basis_set, create_test_orbitals
+
+MappingFactory = Callable[[int], MajoranaMapping]
+
+try:
+    import pyscf  # noqa: F401
+    import qdk_chemistry.plugins.pyscf as pyscf_plugin
+
+    pyscf_plugin.load()
+    PYSCF_AVAILABLE = True
+except ImportError:
+    PYSCF_AVAILABLE = False
+
+
+@pytest.fixture(
+    params=[
+        MajoranaMapping.jordan_wigner,
+        MajoranaMapping.bravyi_kitaev,
+        MajoranaMapping.parity,
+    ],
+    ids=["jw", "bk", "parity"],
+)
+def mapping_factory(request: pytest.FixtureRequest) -> MappingFactory:
+    """Return a standard untapered Majorana mapping factory."""
+    return request.param
+
+
+def _term_dict(hamiltonian):
+    terms: dict[str, complex] = {}
+    for label, coeff in zip(hamiltonian.pauli_strings, hamiltonian.coefficients, strict=True):
+        terms[label] = terms.get(label, 0.0j) + complex(coeff)
+    return {label: coeff for label, coeff in terms.items() if abs(coeff) >= 1e-12}
+
+
+def _assert_term_equivalent(actual, expected, *, atol: float = 1e-12) -> None:
+    actual_terms = _term_dict(actual)
+    expected_terms = _term_dict(expected)
+    missing = sorted(set(expected_terms) - set(actual_terms))
+    extra = sorted(set(actual_terms) - set(expected_terms))
+    if missing:
+        pytest.fail(f"Missing Pauli terms: {missing[:8]}")
+    if extra:
+        pytest.fail(f"Unexpected Pauli terms: {extra[:8]}")
+    for label in sorted(expected_terms):
+        if actual_terms[label] != pytest.approx(expected_terms[label], abs=atol):
+            pytest.fail(
+                f"Mismatched coefficient for {label}: "
+                f"actual={actual_terms[label]!r}, expected={expected_terms[label]!r}"
+            )
+
+
+def _dense_reference(hamiltonian: Hamiltonian) -> Hamiltonian:
+    h1_alpha, h1_beta = hamiltonian.get_one_body_integrals()
+    h2_aaaa, h2_aabb, h2_bbbb = hamiltonian.get_two_body_integrals()
+    if hamiltonian.has_inactive_fock_matrix():
+        fock_alpha, fock_beta = hamiltonian.get_inactive_fock_matrix()
+    else:
+        fock_alpha = np.eye(0)
+        fock_beta = np.eye(0)
+    orbitals = hamiltonian.get_orbitals()
+    core_energy = hamiltonian.get_core_energy()
+
+    if orbitals.is_restricted():
+        container = CanonicalFourCenterHamiltonianContainer(
+            np.array(h1_alpha, copy=True),
+            np.array(h2_aaaa, copy=True),
+            orbitals,
+            core_energy,
+            np.array(fock_alpha, copy=True),
+        )
+    else:
+        container = CanonicalFourCenterHamiltonianContainer(
+            np.array(h1_alpha, copy=True),
+            np.array(h1_beta, copy=True),
+            np.array(h2_aaaa, copy=True),
+            np.array(h2_aabb, copy=True),
+            np.array(h2_bbbb, copy=True),
+            orbitals,
+            core_energy,
+            np.array(fock_alpha, copy=True),
+            np.array(fock_beta, copy=True),
+        )
+    return Hamiltonian(container)
+
+
+def _native_result_to_qubit_hamiltonian(mapping: MajoranaMapping, words, coefficients) -> QubitHamiltonian:
+    pauli_strings = [sparse_pauli_word_to_label(word, mapping.num_qubits) for word in words]
+    return QubitHamiltonian(
+        pauli_strings=pauli_strings,
+        coefficients=np.array(coefficients, dtype=complex),
+        encoding=mapping.base_encoding,
+        fermion_mode_order=FermionModeOrder.BLOCKED,
+    )
+
+
+def _dense_overload_result_for_sparse(
+    hamiltonian: Hamiltonian,
+    mapping: MajoranaMapping,
+    *,
+    threshold: float = 1e-12,
+    integral_threshold: float = 1e-12,
+) -> QubitHamiltonian:
+    h1_alpha, h1_beta = hamiltonian.get_one_body_integrals()
+    h2_aaaa, h2_aabb, h2_bbbb = hamiltonian.get_two_body_integrals()
+    n_spatial = h1_alpha.shape[0]
+    spin_symmetric = hamiltonian.get_orbitals().is_restricted()
+
+    h1_alpha_flat = np.ascontiguousarray(h1_alpha).ravel()
+    h1_beta_flat = h1_alpha_flat if spin_symmetric else np.ascontiguousarray(h1_beta).ravel()
+    h2_aaaa_flat = np.ascontiguousarray(h2_aaaa).ravel()
+    h2_aabb_flat = h2_aaaa_flat if spin_symmetric else np.ascontiguousarray(h2_aabb).ravel()
+    h2_bbbb_flat = h2_aaaa_flat if spin_symmetric else np.ascontiguousarray(h2_bbbb).ravel()
+
+    words, coefficients = majorana_map_hamiltonian(
+        mapping,
+        0.0,
+        h1_alpha_flat,
+        h1_beta_flat,
+        h2_aaaa_flat,
+        h2_aabb_flat,
+        h2_bbbb_flat,
+        n_spatial,
+        spin_symmetric,
+        threshold,
+        integral_threshold,
+    )
+    return _native_result_to_qubit_hamiltonian(mapping, words, coefficients)
+
+
+def _symmetric_three_center(n_orbitals: int, n_aux: int, seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    factors = np.zeros((n_orbitals * n_orbitals, n_aux))
+    for p in range(n_orbitals):
+        for q in range(p, n_orbitals):
+            row = rng.standard_normal(n_aux) * 0.2
+            factors[p * n_orbitals + q] = row
+            factors[q * n_orbitals + p] = row
+    return factors
+
+
+def _symmetric_one_body(n_orbitals: int, seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    raw = rng.standard_normal((n_orbitals, n_orbitals)) * 0.1
+    return (raw + raw.T) / 2 + np.diag(np.linspace(0.8, -0.4, n_orbitals))
+
+
+def _four_center_from_cholesky(left: np.ndarray, right: np.ndarray) -> np.ndarray:
+    return np.ascontiguousarray(left @ right.T).ravel()
+
+
+def _restricted_cholesky_pair(n_orbitals: int, n_aux: int, seed: int) -> tuple[Hamiltonian, Hamiltonian]:
+    h1 = _symmetric_one_body(n_orbitals, seed)
+    three_center = _symmetric_three_center(n_orbitals, n_aux, seed + 100)
+    orbitals = create_test_orbitals(n_orbitals)
+    candidate = Hamiltonian(
+        CholeskyHamiltonianContainer(
+            np.array(h1, copy=True),
+            np.array(three_center, copy=True),
+            orbitals,
+            0.0,
+            np.eye(0),
+        )
+    )
+    dense = Hamiltonian(
+        CanonicalFourCenterHamiltonianContainer(
+            np.array(h1, copy=True),
+            _four_center_from_cholesky(three_center, three_center),
+            orbitals,
+            0.0,
+            np.eye(0),
+        )
+    )
+    return candidate, dense
+
+
+def _unrestricted_cholesky_pair(n_orbitals: int, n_aux: int, seed: int) -> tuple[Hamiltonian, Hamiltonian]:
+    rng = np.random.default_rng(seed)
+    coeffs_alpha = np.eye(n_orbitals)
+    coeffs_beta = np.eye(n_orbitals) + rng.standard_normal((n_orbitals, n_orbitals)) * 0.05
+    orbitals = Orbitals(coeffs_alpha, coeffs_beta, None, None, None, create_test_basis_set(n_orbitals))
+    h1_alpha = _symmetric_one_body(n_orbitals, seed)
+    h1_beta = _symmetric_one_body(n_orbitals, seed + 1)
+    three_center_alpha = _symmetric_three_center(n_orbitals, n_aux, seed + 100)
+    three_center_beta = _symmetric_three_center(n_orbitals, n_aux, seed + 200)
+    candidate = Hamiltonian(
+        CholeskyHamiltonianContainer(
+            np.array(h1_alpha, copy=True),
+            np.array(h1_beta, copy=True),
+            np.array(three_center_alpha, copy=True),
+            np.array(three_center_beta, copy=True),
+            orbitals,
+            0.0,
+            np.eye(0),
+            np.eye(0),
+        )
+    )
+    dense = Hamiltonian(
+        CanonicalFourCenterHamiltonianContainer(
+            np.array(h1_alpha, copy=True),
+            np.array(h1_beta, copy=True),
+            _four_center_from_cholesky(three_center_alpha, three_center_alpha),
+            _four_center_from_cholesky(three_center_alpha, three_center_beta),
+            _four_center_from_cholesky(three_center_beta, three_center_beta),
+            orbitals,
+            0.0,
+            np.eye(0),
+            np.eye(0),
+        )
+    )
+    return candidate, dense
+
+
+def _sparse_hamiltonian(
+    one_body: np.ndarray, two_body_entries: dict[tuple[int, int, int, int], float]
+) -> Hamiltonian:
+    return Hamiltonian(
+        SparseHamiltonianContainer(
+            sp.csr_matrix(one_body),
+            two_body_entries,
+            0.0,
+        )
+    )
+
+
+def _molecular_hamiltonian_pair(
+    structure: Structure,
+    charge: int,
+    spin_multiplicity: int,
+    basis: str,
+) -> tuple[Hamiltonian, Hamiltonian]:
+    scf_solver = create("scf_solver", "pyscf")
+    scf_solver.settings()["method"] = "hf"
+    scf_solver.settings()["scf_type"] = "restricted"
+    scf_solver.settings()["convergence_threshold"] = 1e-8
+    _, wavefunction = scf_solver.run(structure, charge, spin_multiplicity, basis)
+    orbitals = wavefunction.get_orbitals()
+
+    cholesky = create("hamiltonian_constructor", "qdk_cholesky").run(orbitals)
+    dense = _dense_reference(cholesky)
+    return cholesky, dense
+
+
+@pytest.mark.parametrize(
+    ("n_orbitals", "n_aux", "seed"),
+    [
+        (2, 2, 11),
+        (3, 3, 12),
+        (4, 3, 13),
+    ],
+)
+def test_cholesky_fast_path_matches_dense_restricted(
+    mapping_factory: MappingFactory, n_orbitals: int, n_aux: int, seed: int
+) -> None:
+    """Restricted Cholesky-backed Hamiltonians map exactly like dense references."""
+    hamiltonian, dense = _restricted_cholesky_pair(n_orbitals, n_aux, seed)
+    mapping = mapping_factory(2 * n_orbitals)
+    mapper = create("qubit_mapper", "qdk")
+
+    _assert_term_equivalent(mapper.run(hamiltonian, mapping), mapper.run(dense, mapping))
+
+
+@pytest.mark.skipif(not PYSCF_AVAILABLE, reason="PySCF not available")
+@pytest.mark.parametrize(
+    ("structure", "charge", "spin_multiplicity", "basis"),
+    [
+        pytest.param(
+            Structure(np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4]]), ["H", "H"]),
+            0,
+            1,
+            "sto-3g",
+            id="h2-sto-3g",
+        ),
+        pytest.param(
+            Structure(
+                np.array(
+                    [
+                        [0.000000, 0.000000, 0.000000],
+                        [0.000000, 1.430429, 1.107157],
+                        [0.000000, -1.430429, 1.107157],
+                    ]
+                ),
+                ["O", "H", "H"],
+            ),
+            0,
+            1,
+            "sto-3g",
+            id="h2o-sto-3g",
+        ),
+        pytest.param(
+            Structure(np.array([[0.0, 0.0, -1.05], [0.0, 0.0, 1.05]]), ["N", "N"]),
+            0,
+            1,
+            "sto-3g",
+            id="n2-sto-3g",
+        ),
+    ],
+)
+def test_cholesky_fast_path_matches_dense_for_molecular_systems(
+    mapping_factory: MappingFactory,
+    structure: Structure,
+    charge: int,
+    spin_multiplicity: int,
+    basis: str,
+) -> None:
+    """Real molecular Cholesky fast paths match dense references from the same factors."""
+    hamiltonian, dense = _molecular_hamiltonian_pair(structure, charge, spin_multiplicity, basis)
+    h1_alpha, _ = hamiltonian.get_one_body_integrals()
+    mapping = mapping_factory(2 * h1_alpha.shape[0])
+    mapper = create("qubit_mapper", "qdk")
+
+    _assert_term_equivalent(mapper.run(hamiltonian, mapping), mapper.run(dense, mapping))
+
+
+@pytest.mark.parametrize(
+    ("n_orbitals", "n_aux", "seed"),
+    [
+        (2, 2, 21),
+        (3, 3, 22),
+    ],
+)
+def test_cholesky_fast_path_matches_dense_unrestricted(
+    mapping_factory: MappingFactory, n_orbitals: int, n_aux: int, seed: int
+) -> None:
+    """Unrestricted Cholesky-backed Hamiltonians map exactly like dense references."""
+    hamiltonian, dense = _unrestricted_cholesky_pair(n_orbitals, n_aux, seed)
+    mapping = mapping_factory(2 * n_orbitals)
+    mapper = create("qubit_mapper", "qdk")
+
+    _assert_term_equivalent(mapper.run(hamiltonian, mapping), mapper.run(dense, mapping))
+
+
+def test_cholesky_rejects_invalid_factor_shape() -> None:
+    """Cholesky containers reject factors that cannot represent n_spatial^2 rows."""
+    n_orbitals = 2
+    orbitals = create_test_orbitals(n_orbitals)
+
+    with pytest.raises(ValueError, match="n_active_alpha\\^2"):
+        CholeskyHamiltonianContainer(
+            np.eye(n_orbitals),
+            np.ones((n_orbitals * n_orbitals - 1, 2)),
+            orbitals,
+            0.0,
+            np.eye(0),
+        )
+
+
+def test_cholesky_rejects_mismatched_unrestricted_aux_dimensions() -> None:
+    """Unrestricted alpha/beta Cholesky factors must share the auxiliary dimension."""
+    n_orbitals = 2
+    coeffs_alpha = np.eye(n_orbitals)
+    coeffs_beta = np.eye(n_orbitals) + 0.1 * np.triu(np.ones((n_orbitals, n_orbitals)), 1)
+    orbitals = Orbitals(coeffs_alpha, coeffs_beta, None, None, None, create_test_basis_set(n_orbitals))
+
+    with pytest.raises(ValueError, match="Beta three-center cols"):
+        CholeskyHamiltonianContainer(
+            np.eye(n_orbitals),
+            np.eye(n_orbitals),
+            np.ones((n_orbitals * n_orbitals, 2)),
+            np.ones((n_orbitals * n_orbitals, 3)),
+            orbitals,
+            0.0,
+            np.eye(0),
+            np.eye(0),
+        )
+
+
+def _ppp_chain_hamiltonian() -> Hamiltonian:
+    n_sites = 4
+    lattice = LatticeGraph.chain(n_sites)
+    epsilon = np.zeros(n_sites)
+    hopping = np.ones((n_sites, n_sites))
+    onsite = np.full(n_sites, 0.7)
+    intersite = np.full((n_sites, n_sites), 0.2)
+    np.fill_diagonal(intersite, 0.0)
+    charge = np.ones(n_sites)
+    return create_ppp_hamiltonian(lattice, epsilon=epsilon, t=hopping, U=onsite, V=intersite, z=charge)
+
+
+@pytest.mark.parametrize(
+    "hamiltonian_factory",
+    [
+        pytest.param(
+            lambda: create_hubbard_hamiltonian(LatticeGraph.square(2, 2), epsilon=-0.5, t=1.0, U=0.3),
+            id="hubbard-2x2",
+        ),
+        pytest.param(
+            lambda: create_hubbard_hamiltonian(LatticeGraph.chain(4), epsilon=-0.5, t=1.0, U=0.4),
+            id="hubbard-1x4",
+        ),
+        pytest.param(_ppp_chain_hamiltonian, id="ppp-chain"),
+    ],
+)
+def test_sparse_fast_path_matches_dense(mapping_factory: MappingFactory, hamiltonian_factory) -> None:
+    """Sparse model Hamiltonians map exactly like dense references."""
+    hamiltonian = hamiltonian_factory()
+    dense_source = hamiltonian_factory()
+    h1_alpha, _ = hamiltonian.get_one_body_integrals()
+    dense = _dense_reference(dense_source)
+    mapping = mapping_factory(2 * h1_alpha.shape[0])
+    mapper = create("qubit_mapper", "qdk")
+
+    _assert_term_equivalent(mapper.run(hamiltonian, mapping), mapper.run(dense, mapping))
+
+
+@pytest.mark.parametrize(
+    "stored_key",
+    [
+        (0, 1, 0, 1),
+        (1, 0, 0, 1),
+        (1, 1, 0, 0),
+        (1, 0, 1, 0),
+    ],
+)
+def test_sparse_fast_path_matches_raw_dense_overload_for_sparse_key(
+    mapping_factory: MappingFactory, stored_key: tuple[int, int, int, int]
+) -> None:
+    one_body = np.array([[0.2, -0.7], [0.3, -0.1]])
+    two_body = {stored_key: 0.6}
+    hamiltonian = _sparse_hamiltonian(one_body, two_body)
+    mapping = mapping_factory(4)
+    mapper = create("qubit_mapper", "qdk")
+
+    _assert_term_equivalent(mapper.run(hamiltonian, mapping), _dense_overload_result_for_sparse(hamiltonian, mapping))
+
+
+def test_sparse_fast_path_keeps_symmetry_alias_coordinates_independent(mapping_factory: MappingFactory) -> None:
+    one_body = np.array([[0.2, -0.7], [0.3, -0.1]])
+    two_body = {(0, 1, 0, 1): 0.6, (1, 0, 1, 0): 0.7}
+    hamiltonian = _sparse_hamiltonian(one_body, two_body)
+    mapping = mapping_factory(4)
+    mapper = create("qubit_mapper", "qdk")
+
+    _assert_term_equivalent(mapper.run(hamiltonian, mapping), _dense_overload_result_for_sparse(hamiltonian, mapping))
+
+
+def test_sparse_container_rejects_out_of_bounds_two_body_key() -> None:
+    with pytest.raises(ValueError):
+        _sparse_hamiltonian(np.eye(2), {(0, 0, 0, 2): 0.5})


### PR DESCRIPTION
## Summary

Closes  #474 
`QdkQubitMapper._run_impl()` now passes the full `Hamiltonian` object into the pybind layer instead of extracting dense two-body tensors in Python. The native C++ mapper exposes a new `majorana_map_hamiltonian(mapping, hamiltonian, threshold, integral_threshold)` overload that derives restricted/unrestricted behavior from the Hamiltonian container and dispatches to an appropriate two-body source.

- Avoids forced dense `O(n^4)` two-body materialization for supported containers. And
- Adds native fast paths for `CholeskyHamiltonianContainer` and restricted `SparseHamiltonianContainer`.
- Added a pybind11 overload for `majorana_map_hamiltonian(mapping, hamiltonian, threshold, integral_threshold)`.
- Preserves the public `QubitMapper.run()` API and returned `QubitHamiltonian` behavior.
- Keeps numerical equivalence with the dense path across Jordan-Wigner, Bravyi-Kitaev, and parity mappings.
- Uses Cholesky factors directly instead of rebuilding dense four-center tensors.
- Iterates sparse nonzero ERI entries instead of scanning dense tensors full of zeros.
- Shares one native Pauli accumulation engine across dense, sparse, and Cholesky sources.
- Adds tests that prove both correctness and avoidance of dense materialization.
- Clarifies sparse ERI alias handling: canonicalized aliases accepted, conflicting aliases rejected.

## Validation Coverage

Both Python and C++ tests pass:

- Native C++ tests verify that sparse mapping does not materialize the sparse container dense cache.
- Native C++ tests verify that Cholesky mapping does not call the dense two-body getter.
- Python tests compare Cholesky-backed Hamiltonians against dense references for restricted and unrestricted fixtures.
- Python tests compare sparse model Hamiltonians against dense references across Jordan-Wigner, Bravyi-Kitaev, and parity mappings.
- Additional Python tests document sparse ERI canonicalization, matching duplicate aliases, conflicting alias rejection, and invalid key handling.

Benchmark result, using JW mapping in separate processes:

| Case                              |            Path | Total runtime | Map runtime | Peak RSS |
| --------------------------------- | --------------: | ------------: | ----------: | -------: |
| Sparse Hubbard chain, 80 orbitals | New sparse path |        0.225s |      0.218s |  256 MiB |
| Sparse Hubbard chain, 80 orbitals |  Old dense path |        1.372s |      0.245s | 1450 MiB |

Improvement for sparse path:

- Runtime: ~6.1x faster total.
- Memory: ~1.17 GiB less peak RSS.
- Dense rank-4 tensor alone is ~312.5 MiB, and the dense path creates/copies more than one large array during setup.

Cholesky local comparison at 24 orbitals, 4 aux factors:

| Case                  |              Path | Total runtime | Peak RSS |
| --------------------- | ----------------: | ------------: | -------: |
| Cholesky, 24 orbitals | New Cholesky path |        6.967s | 1020 MiB |
| Cholesky, 24 orbitals |    Old dense path |        7.031s | 1028 MiB |

For Cholesky, this local size is basically runtime-neutral and only slightly lower memory, as well as small cases may show little runtime/memory improvement because the output Pauli term table can dominate memory.