### PR TITLE
feat: add Zassenhaus Hamiltonian unitary builder(#483)

### DIFF
--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -611,3 +611,24 @@
     year={1992},
     doi={10.1016/0375-9601(92)90335-J}
 }
+@article{Wilcox1967,
+    title={Exponential Operators and Parameter Differentiation in Quantum Physics},
+    author={R. M. Wilcox},
+    journal={Journal of Mathematical Physics},
+    volume={8},
+    number={4},
+    pages={962--982},
+    year={1967},
+    doi={10.1063/1.1705306}
+}
+@article{Casas2012,
+    title={Efficient Computation of the Zassenhaus Formula},
+    author={Fernando Casas and Ander Murua and Mladen Nadinic},
+    journal={Computer Physics Communications},
+    volume={183},
+    number={11},
+    pages={2386--2391},
+    year={2012},
+    doi={10.1016/j.cpc.2012.06.006},
+    url={https://arxiv.org/abs/1204.0389}
+}

--- a/docs/source/user/comprehensive/algorithms/hamiltonian_unitary_builder.rst
+++ b/docs/source/user/comprehensive/algorithms/hamiltonian_unitary_builder.rst
@@ -142,9 +142,8 @@ When both ``num_divisions`` and ``target_accuracy`` are specified, the builder u
      - float
      - Coefficient threshold below which Pauli terms are discarded. Default is 1e-12.
 
-
 Consuming term partitions
--------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When the input :class:`~qdk_chemistry.data.QubitHamiltonian` carries a populated :attr:`~qdk_chemistry.data.QubitHamiltonian.term_partition`, the Trotter builder consumes it directly:
 
@@ -207,6 +206,55 @@ Example::
     #   exp(-i * +0.2500 * IIXI)
     #   exp(-i * +0.2500 * IXII)
     #   exp(-i * +0.2500 * XIII)
+
+
+.. _zassenhaus-builder:
+
+Zassenhaus product formulas
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Factory name: ``"zassenhaus"``
+
+The Zassenhaus builder approximates the time-evolution operator by making low-order commutator corrections explicit.
+For one time slice :math:`\Delta t = t/N`, write the Hamiltonian as :math:`H = \sum_j H_j` and define :math:`X_j = -i\Delta t H_j`.
+The builder constructs
+
+.. math::
+
+   e^{\sum_j X_j} \approx
+   \left(\prod_j e^{X_j}\right)e^{C_2}e^{C_3}\cdots e^{C_p},
+
+where each :math:`C_k` is the homogeneous order-:math:`k` Zassenhaus correction generated from nested commutators :cite:`Wilcox1967,Casas2012,Childs2021`.
+The correction exponents are evaluated as Pauli sums and flattened back into the same ``PauliProductFormulaContainer`` shape used by ``"trotter"``, so consumers such as :doc:`PhaseEstimation <phase_estimation>` do not need interface changes.
+
+Order 1 delegates to the first-order Trotter builder.
+For higher orders, the local approximation error scales as :math:`O(\Delta t^{p+1})`.
+The builder uses the user-provided ``order`` and varies only the number of divisions when ``target_accuracy`` is set.
+Automatic division estimates use the same ``error_bound`` strategies as the Trotter builder.
+
+.. rubric:: Settings
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Setting
+     - Type
+     - Description
+   * - ``order``
+     - int
+     - Zassenhaus expansion order. Default is 2.
+   * - ``target_accuracy``
+     - float
+     - Target approximation error :math:`\epsilon`. When set to 0.0 (default), automatic division-count estimation is disabled.
+   * - ``num_divisions``
+     - int
+     - Explicit number of time divisions :math:`N`. Default is 1.
+   * - ``error_bound``
+     - str
+     - Error bound strategy for automatic division-count estimation: ``"commutator"`` (default) or ``"naive"``.
+   * - ``weight_threshold``
+     - float
+     - Coefficient threshold below which Pauli terms and generated corrections are discarded. Default is 1e-12.
 
 
 Related classes

--- a/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
+++ b/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
@@ -48,6 +48,7 @@ __all__: list[str] = ["Zassenhaus", "ZassenhausSettings"]
 
 Word = tuple[int, ...]
 WordPolynomial = dict[Word, Fraction]
+CachedWordPolynomial = tuple[tuple[Word, Fraction], ...]
 PauliWord = tuple[tuple[int, int], ...]
 PauliSummand = tuple[str, PauliWord, complex]
 
@@ -317,7 +318,7 @@ class Zassenhaus(TimeEvolutionBuilder):
 
 
 @cache
-def _zassenhaus_word_factors(num_symbols: int, order: int) -> tuple[WordPolynomial, ...]:
+def _zassenhaus_word_factors(num_symbols: int, order: int) -> tuple[CachedWordPolynomial, ...]:
     """Generate homogeneous Zassenhaus correction factors as word polynomials."""
     if num_symbols <= 1 or order < 2:
         return ()
@@ -336,7 +337,7 @@ def _zassenhaus_word_factors(num_symbols: int, order: int) -> tuple[WordPolynomi
         if correction and degree < order:
             current = _poly_mul(current, _poly_exp(correction, order), order)
 
-    return tuple(factors)
+    return tuple(tuple(factor.items()) for factor in factors)
 
 
 def _poly_add(a: WordPolynomial, b: WordPolynomial, *, scale: Fraction = Fraction(1)) -> WordPolynomial:
@@ -391,7 +392,7 @@ def _hamiltonian_to_pauli_terms(hamiltonian: QubitHamiltonian, atol: float) -> l
 
 
 def _evaluate_word_polynomial(
-    polynomial: WordPolynomial,
+    polynomial: CachedWordPolynomial,
     pauli_blocks: list[list[PauliSummand]],
     *,
     time: float,
@@ -406,7 +407,7 @@ def _evaluate_word_polynomial(
     lets vanishing Pauli commutators short-circuit before sparse multiplication.
     """
     accumulator: dict[PauliWord, complex] = {}
-    for word, rational_coeff in polynomial.items():
+    for word, rational_coeff in polynomial:
         degree = len(word)
         if degree == 0 or any(not pauli_blocks[symbol] for symbol in word):
             continue

--- a/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
+++ b/python/src/qdk_chemistry/algorithms/hamiltonian_unitary_builder/time_evolution/zassenhaus.py
@@ -1,0 +1,542 @@
+"""QDK/Chemistry Zassenhaus time-evolution builder.
+
+References:
+    Wilcox, R. M. "Exponential operators and parameter differentiation in quantum physics."
+    *Journal of Mathematical Physics* 8.4 (1967): 962-982.
+
+    Casas, F., A. Murua, and M. Nadinic. "Efficient computation of the Zassenhaus formula."
+    *Computer Physics Communications* 183.11 (2012): 2386-2391.
+
+    Childs, A. M., et al. "Theory of Trotter Error with Commutator
+    Scaling." *Physical Review X* 11.1 (2021): 011020.
+
+"""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import itertools
+import math
+from fractions import Fraction
+from functools import cache
+
+import numpy as np
+
+from qdk_chemistry.algorithms.hamiltonian_unitary_builder.base import (
+    TimeEvolutionBuilder,
+    TimeEvolutionSettings,
+)
+from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.trotter import Trotter
+from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.trotter_error import (
+    trotter_steps_commutator,
+    trotter_steps_naive,
+)
+from qdk_chemistry.algorithms.term_grouper import FullCommutingTermGrouper
+from qdk_chemistry.data import PauliTermAccumulator, QubitHamiltonian, UnitaryRepresentation
+from qdk_chemistry.data.unitary_representation.containers.pauli_product_formula import (
+    ExponentiatedPauliTerm,
+    PauliProductFormulaContainer,
+)
+from qdk_chemistry.utils import Logger
+from qdk_chemistry.utils.pauli_commutation import does_nested_commutator_vanish
+
+__all__: list[str] = ["Zassenhaus", "ZassenhausSettings"]
+
+Word = tuple[int, ...]
+WordPolynomial = dict[Word, Fraction]
+PauliWord = tuple[tuple[int, int], ...]
+PauliSummand = tuple[str, PauliWord, complex]
+
+
+class ZassenhausSettings(TimeEvolutionSettings):
+    """Settings for the Zassenhaus time-evolution builder."""
+
+    def __init__(self):
+        """Initialize ZassenhausSettings with default values."""
+        super().__init__()
+        self._set_default(
+            "order",
+            "int",
+            2,
+            "Expansion order. The local error scales as O(time^(order + 1)).",
+        )
+        self._set_default(
+            "target_accuracy",
+            "double",
+            0.0,
+            "Target accuracy for automatic division-count estimation (0.0 means disabled).",
+        )
+        self._set_default(
+            "num_divisions",
+            "int",
+            1,
+            "Explicit number of time divisions.",
+        )
+        self._set_default(
+            "error_bound",
+            "string",
+            "commutator",
+            "Strategy for computing the Trotter error bound ('commutator' or 'naive').",
+            ["commutator", "naive"],
+        )
+        self._set_default(
+            "weight_threshold",
+            "float",
+            1e-12,
+            "The absolute threshold for filtering small coefficients.",
+        )
+
+
+class Zassenhaus(TimeEvolutionBuilder):
+    r"""Zassenhaus product-formula Hamiltonian simulation builder.
+
+    The builder constructs a product approximation to
+    :math:`\exp(-iHt)` by first writing one time slice as
+    :math:`\exp(\sum_j X_j)`, with :math:`X_j=-i\Delta t\,H_j`, and then
+    factoring it as
+
+    .. math::
+
+        e^{\sum_j X_j} =
+        \left(\prod_j e^{X_j}\right) e^{C_2} e^{C_3}\cdots e^{C_p}
+        + O(\Delta t^{p+1}).
+
+    The homogeneous correction exponents :math:`C_k` are generated as a
+    formal non-commutative word series and evaluated using the package's
+    existing Pauli multiplication utilities.
+    """
+
+    def __init__(
+        self,
+        order: int = 2,
+        *,
+        time: float = 0.0,
+        target_accuracy: float = 0.0,
+        num_divisions: int = 1,
+        error_bound: str = "commutator",
+        weight_threshold: float = 1e-12,
+        power: int = 1,
+        power_strategy: str = "repeat",
+    ):
+        """Initialize a Zassenhaus time-evolution builder.
+
+        Args:
+            order: Expansion order. Order 1 delegates to the first-order
+                Trotter builder. Defaults to 2.
+            time: Evolution time. Defaults to 0.0.
+            target_accuracy: Optional target accuracy used to choose a
+                conservative number of time divisions. Defaults to 0.0.
+            num_divisions: Manual lower bound on the number of time divisions.
+                Defaults to 1.
+            error_bound: Error bound strategy for automatic division estimation:
+                ``"commutator"`` (default) or ``"naive"``.
+            weight_threshold: Absolute threshold for filtering small
+                coefficients. Defaults to 1e-12.
+            power: Power to raise the unitary to. Defaults to 1.
+            power_strategy: ``"rescale"`` scales time; ``"repeat"`` repeats
+                the resulting product. Defaults to ``"repeat"``.
+
+        """
+        super().__init__()
+        self._settings = ZassenhausSettings()
+        self._settings.set("time", time)
+        self._settings.set("power", power)
+        self._settings.set("power_strategy", power_strategy)
+        self._settings.set("order", order)
+        self._settings.set("target_accuracy", target_accuracy)
+        self._settings.set("num_divisions", num_divisions)
+        self._settings.set("error_bound", error_bound)
+        self._settings.set("weight_threshold", weight_threshold)
+
+    def _run_impl(self, qubit_hamiltonian: QubitHamiltonian) -> UnitaryRepresentation:
+        """Construct a Zassenhaus product-formula unitary representation."""
+        order = self._settings.get("order")
+        if order < 1:
+            raise ValueError(f"Zassenhaus order must be positive, got {order}.")
+
+        if order == 1:
+            return self._run_trotter_order_one(qubit_hamiltonian)
+
+        weight_threshold = self._settings.get("weight_threshold")
+        if not qubit_hamiltonian.is_hermitian(tolerance=weight_threshold):
+            raise ValueError("Non-Hermitian Hamiltonian: coefficients have nonzero imaginary parts.")
+
+        effective_time, power_repetitions = self._resolve_power()
+        num_divisions = self._resolve_num_divisions(qubit_hamiltonian, effective_time, order)
+        delta = effective_time / num_divisions
+
+        blocks = self._hamiltonian_blocks(qubit_hamiltonian, weight_threshold)
+        step_terms = self._decompose_zassenhaus_step(
+            blocks,
+            time=delta,
+            order=order,
+            num_qubits=qubit_hamiltonian.num_qubits,
+            atol=weight_threshold,
+        )
+
+        return UnitaryRepresentation(
+            container=PauliProductFormulaContainer(
+                step_terms=step_terms,
+                step_reps=num_divisions * power_repetitions,
+                num_qubits=qubit_hamiltonian.num_qubits,
+            )
+        )
+
+    def _run_trotter_order_one(self, qubit_hamiltonian: QubitHamiltonian) -> UnitaryRepresentation:
+        """Delegate the first-order Zassenhaus case to the Trotter builder."""
+        return Trotter(
+            order=1,
+            time=self._settings.get("time"),
+            target_accuracy=self._settings.get("target_accuracy"),
+            num_divisions=self._settings.get("num_divisions"),
+            error_bound=self._settings.get("error_bound"),
+            weight_threshold=self._settings.get("weight_threshold"),
+            power=self._settings.get("power"),
+            power_strategy=self._settings.get("power_strategy"),
+        ).run(qubit_hamiltonian)
+
+    def _resolve_num_divisions(self, qubit_hamiltonian: QubitHamiltonian, time: float, order: int) -> int:
+        """Resolve manual and accuracy-driven time divisions.
+
+        Automatic division estimates reuse the same Trotter error-bound helpers
+        used by :class:`Trotter`.  Odd Zassenhaus orders use the highest
+        supported Trotter error order that does not exceed the expansion order.
+        """
+        num_divisions = self._settings.get("num_divisions")
+        if num_divisions <= 0:
+            raise ValueError(f"num_divisions must be a positive integer, got {num_divisions}.")
+        manual = num_divisions
+
+        target_accuracy = self._settings.get("target_accuracy")
+        if target_accuracy <= 0.0:
+            return manual
+
+        error_order = _trotter_error_order(order)
+        weight_threshold = self._settings.get("weight_threshold")
+        error_bound = self._settings.get("error_bound")
+        if error_bound == "commutator":
+            auto = trotter_steps_commutator(
+                hamiltonian=qubit_hamiltonian,
+                time=time,
+                target_accuracy=target_accuracy,
+                order=error_order,
+                weight_threshold=weight_threshold,
+            )
+        else:
+            auto = trotter_steps_naive(
+                hamiltonian=qubit_hamiltonian,
+                time=time,
+                target_accuracy=target_accuracy,
+                order=error_order,
+                weight_threshold=weight_threshold,
+            )
+
+        return max(manual, auto)
+
+    def _hamiltonian_blocks(self, qubit_hamiltonian: QubitHamiltonian, atol: float) -> list[QubitHamiltonian]:
+        """Split the Hamiltonian into exactly exponentiable blocks."""
+        if qubit_hamiltonian.term_partition is None and len(qubit_hamiltonian.pauli_strings) > 1:
+            qubit_hamiltonian = FullCommutingTermGrouper().run(qubit_hamiltonian)
+
+        grouped = Trotter()._group_terms(qubit_hamiltonian)  # noqa: SLF001
+        blocks: list[QubitHamiltonian] = []
+        for group in grouped:
+            for block in group:
+                if any(abs(coeff) > atol for _, coeff in block.get_real_coefficients(tolerance=atol)):
+                    blocks.append(block)
+
+        if not blocks:
+            Logger.warn("No coefficients above the tolerance; returning empty Zassenhaus term list.")
+        return blocks
+
+    def _decompose_zassenhaus_step(
+        self,
+        blocks: list[QubitHamiltonian],
+        *,
+        time: float,
+        order: int,
+        num_qubits: int,
+        atol: float,
+    ) -> list[ExponentiatedPauliTerm]:
+        """Decompose one Zassenhaus time slice into exponentiated Pauli terms."""
+        if not blocks:
+            return []
+
+        factor_terms: list[list[ExponentiatedPauliTerm]] = []
+        trotter = Trotter(order=1)
+
+        for block in blocks:
+            factor_terms.append(trotter._exponentiate_commuting(block, time=time, atol=atol))  # noqa: SLF001
+
+        correction_factors = _zassenhaus_word_factors(len(blocks), order)
+        pauli_blocks = [_hamiltonian_to_pauli_terms(block, atol) for block in blocks]
+
+        for degree, factor in enumerate(correction_factors, start=2):
+            antihermitian_terms = _evaluate_word_polynomial(
+                factor,
+                pauli_blocks,
+                time=time,
+                num_qubits=num_qubits,
+                atol=atol,
+            )
+            correction_hamiltonian = _antihermitian_terms_to_hamiltonian(
+                antihermitian_terms,
+                atol=atol,
+            )
+            if correction_hamiltonian is None:
+                continue
+
+            formula_order = _correction_formula_order(degree, order)
+            factor_terms.append(
+                Trotter(order=formula_order)._decompose_trotter_step(  # noqa: SLF001
+                    correction_hamiltonian,
+                    time=1.0,
+                    atol=atol,
+                )
+            )
+
+        # PauliProductFormulaContainer materializes a term list as
+        # E(last) ... E(first).  The formal Zassenhaus factors above are in
+        # algebraic left-to-right order, so write factor containers in reverse.
+        terms: list[ExponentiatedPauliTerm] = []
+        for sequence in reversed(factor_terms):
+            terms.extend(sequence)
+        return _merge_adjacent_terms(terms, atol=atol)
+
+    def name(self) -> str:
+        """Return the name of the unitary builder."""
+        return "zassenhaus"
+
+    def type_name(self) -> str:
+        """Return hamiltonian_unitary_builder as the algorithm type name."""
+        return "hamiltonian_unitary_builder"
+
+
+@cache
+def _zassenhaus_word_factors(num_symbols: int, order: int) -> tuple[WordPolynomial, ...]:
+    """Generate homogeneous Zassenhaus correction factors as word polynomials."""
+    if num_symbols <= 1 or order < 2:
+        return ()
+
+    target_generator: WordPolynomial = {(i,): Fraction(1) for i in range(num_symbols)}
+    target = _poly_exp(target_generator, order)
+
+    current: WordPolynomial = {(): Fraction(1)}
+    for i in range(num_symbols):
+        current = _poly_mul(current, _poly_exp({(i,): Fraction(1)}, order), order)
+
+    factors: list[WordPolynomial] = []
+    for degree in range(2, order + 1):
+        correction = _poly_homogeneous(_poly_add(target, current, scale=Fraction(-1)), degree)
+        factors.append(correction)
+        if correction and degree < order:
+            current = _poly_mul(current, _poly_exp(correction, order), order)
+
+    return tuple(factors)
+
+
+def _poly_add(a: WordPolynomial, b: WordPolynomial, *, scale: Fraction = Fraction(1)) -> WordPolynomial:
+    result = dict(a)
+    for word, coeff in b.items():
+        value = result.get(word, Fraction(0)) + scale * coeff
+        if value:
+            result[word] = value
+        else:
+            result.pop(word, None)
+    return result
+
+
+def _poly_mul(a: WordPolynomial, b: WordPolynomial, max_degree: int) -> WordPolynomial:
+    result: WordPolynomial = {}
+    for word_a, coeff_a in a.items():
+        for word_b, coeff_b in b.items():
+            word = word_a + word_b
+            if len(word) > max_degree:
+                continue
+            result[word] = result.get(word, Fraction(0)) + coeff_a * coeff_b
+    return {word: coeff for word, coeff in result.items() if coeff}
+
+
+def _poly_exp(poly: WordPolynomial, max_degree: int) -> WordPolynomial:
+    result: WordPolynomial = {(): Fraction(1)}
+    power: WordPolynomial = {(): Fraction(1)}
+    factorial = 1
+    for k in range(1, max_degree + 1):
+        power = _poly_mul(power, poly, max_degree)
+        factorial *= k
+        result = _poly_add(result, {word: coeff / factorial for word, coeff in power.items()})
+        if not power:
+            break
+    return result
+
+
+def _poly_homogeneous(poly: WordPolynomial, degree: int) -> WordPolynomial:
+    return {word: coeff for word, coeff in poly.items() if len(word) == degree and coeff}
+
+
+def _hamiltonian_to_pauli_terms(hamiltonian: QubitHamiltonian, atol: float) -> list[PauliSummand]:
+    terms: dict[PauliWord, complex] = {}
+    for label, coeff in hamiltonian.get_real_coefficients(tolerance=atol):
+        word = _label_to_sparse_word(label)
+        terms[word] = terms.get(word, 0.0) + complex(coeff)
+    return [
+        (_sparse_word_to_label(word, hamiltonian.num_qubits), word, coeff)
+        for word, coeff in terms.items()
+        if abs(coeff) > atol
+    ]
+
+
+def _evaluate_word_polynomial(
+    polynomial: WordPolynomial,
+    pauli_blocks: list[list[PauliSummand]],
+    *,
+    time: float,
+    num_qubits: int,
+    atol: float,
+) -> dict[str, complex]:
+    """Evaluate a homogeneous Lie word polynomial as nested Pauli commutators.
+
+    The generated Zassenhaus corrections are homogeneous Lie polynomials.  The
+    Dynkin-Specht-Wever identity rewrites a degree-n correction as 1/n times
+    the sum of its word coefficients applied to right-nested commutators, which
+    lets vanishing Pauli commutators short-circuit before sparse multiplication.
+    """
+    accumulator: dict[PauliWord, complex] = {}
+    for word, rational_coeff in polynomial.items():
+        degree = len(word)
+        if degree == 0 or any(not pauli_blocks[symbol] for symbol in word):
+            continue
+
+        scale = complex(rational_coeff / degree) * ((-1j * time) ** degree)
+        if degree == 1:
+            for _, pauli_word, term_coeff in pauli_blocks[word[0]]:
+                accumulator[pauli_word] = accumulator.get(pauli_word, 0.0) + scale * term_coeff
+            continue
+
+        for terms in itertools.product(*(pauli_blocks[symbol] for symbol in word)):
+            nested = _evaluate_pauli_nested_commutator(terms)
+            if nested is None:
+                continue
+
+            pauli_word, commutator_coeff = nested
+            coeff = scale * commutator_coeff
+            for _, _, term_coeff in terms:
+                coeff *= term_coeff
+            accumulator[pauli_word] = accumulator.get(pauli_word, 0.0) + coeff
+
+    labels: dict[str, complex] = {}
+    for pauli_word, coeff in accumulator.items():
+        if abs(coeff) <= atol:
+            continue
+        label = _sparse_word_to_label(pauli_word, num_qubits)
+        labels[label] = labels.get(label, 0.0) + coeff
+    return {label: coeff for label, coeff in labels.items() if abs(coeff) > atol}
+
+
+def _evaluate_pauli_nested_commutator(terms: tuple[PauliSummand, ...]) -> tuple[PauliWord, complex] | None:
+    """Evaluate ``[P_1, [P_2, ... P_n]]`` for Pauli summands, or return ``None`` if it vanishes."""
+    labels = tuple(label for label, _, _ in terms)
+    if does_nested_commutator_vanish(*labels):
+        return None
+
+    product_word = terms[0][1]
+    phase = 1.0 + 0.0j
+    for _, word, _ in terms[1:]:
+        step_phase, multiplied_word = PauliTermAccumulator.multiply_uncached(list(product_word), list(word))
+        phase *= complex(step_phase)
+        product_word = tuple((int(q), int(p)) for q, p in multiplied_word)
+
+    return product_word, (2 ** (len(terms) - 1)) * phase
+
+
+def _antihermitian_terms_to_hamiltonian(
+    antihermitian_terms: dict[str, complex],
+    *,
+    atol: float,
+) -> QubitHamiltonian | None:
+    labels: list[str] = []
+    coefficients: list[float] = []
+    for label, coeff in antihermitian_terms.items():
+        if abs(coeff) <= atol:
+            continue
+        real_tolerance = max(10 * atol, 10 * atol * abs(coeff.imag))
+        if abs(coeff.real) > real_tolerance:
+            raise ValueError(f"Zassenhaus correction produced a non-anti-Hermitian coefficient for {label}: {coeff}.")
+        angle = (1j * coeff).real
+        if abs(angle) > atol:
+            labels.append(label)
+            coefficients.append(angle)
+
+    if not labels:
+        return None
+    return QubitHamiltonian(pauli_strings=labels, coefficients=np.asarray(coefficients), encoding=None)
+
+
+def _correction_formula_order(correction_degree: int, target_order: int) -> int:
+    required = max(math.ceil((target_order + 1) / correction_degree) - 1, 1)
+    if required <= 1:
+        return 1
+    if required <= 2:
+        return 2
+    return required if required % 2 == 0 else required + 1
+
+
+def _trotter_error_order(zassenhaus_order: int) -> int:
+    """Map a Zassenhaus order to an order supported by Trotter error bounds."""
+    if zassenhaus_order <= 2 or zassenhaus_order % 2 == 0:
+        return zassenhaus_order
+    return zassenhaus_order - 1
+
+
+def _label_to_sparse_word(label: str) -> PauliWord:
+    word: list[tuple[int, int]] = []
+    for index, char in enumerate(reversed(label)):
+        if char == "I":
+            continue
+        if char == "X":
+            word.append((index, 1))
+        elif char == "Y":
+            word.append((index, 2))
+        elif char == "Z":
+            word.append((index, 3))
+        else:
+            raise ValueError(f"Invalid character {char!r} in Pauli label; expected 'I', 'X', 'Y', or 'Z'.")
+    return tuple(word)
+
+
+def _sparse_word_to_label(word: PauliWord, num_qubits: int) -> str:
+    chars = ["I"] * num_qubits
+    for qubit, pauli in word:
+        if pauli == 1:
+            chars[qubit] = "X"
+        elif pauli == 2:
+            chars[qubit] = "Y"
+        elif pauli == 3:
+            chars[qubit] = "Z"
+        else:
+            raise ValueError(f"Invalid Pauli code {pauli}; expected 1, 2, or 3.")
+    return "".join(reversed(chars))
+
+
+def _merge_adjacent_terms(
+    terms: list[ExponentiatedPauliTerm],
+    *,
+    atol: float,
+) -> list[ExponentiatedPauliTerm]:
+    merged: list[ExponentiatedPauliTerm] = []
+    for term in terms:
+        if abs(term.angle) <= atol:
+            continue
+        if merged and merged[-1].pauli_term == term.pauli_term:
+            angle = merged[-1].angle + term.angle
+            if abs(angle) > atol:
+                merged[-1] = ExponentiatedPauliTerm(pauli_term=term.pauli_term, angle=angle)
+            else:
+                merged.pop()
+        else:
+            merged.append(term)
+    return merged

--- a/python/src/qdk_chemistry/algorithms/registry.py
+++ b/python/src/qdk_chemistry/algorithms/registry.py
@@ -766,6 +766,9 @@ def _register_python_algorithms():
     )
     from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.qdrift import QDrift  # noqa: PLC0415
     from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.trotter import Trotter  # noqa: PLC0415
+    from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus import (  # noqa: PLC0415
+        Zassenhaus,
+    )
     from qdk_chemistry.algorithms.phase_estimation.circuit_builder.iterative_builder import (  # noqa: PLC0415
         QdkIterativeQpeCircuitBuilder,
     )
@@ -795,6 +798,7 @@ def _register_python_algorithms():
     register(lambda: QubitWiseCommutingTermGrouper())
     register(lambda: IdentityTermGrouper())
     register(lambda: Trotter())
+    register(lambda: Zassenhaus())
     register(lambda: QDrift())
     register(lambda: PartiallyRandomized())
     register(lambda: PauliSequenceMapper())

--- a/python/src/qdk_chemistry/utils/phase.py
+++ b/python/src/qdk_chemistry/utils/phase.py
@@ -34,17 +34,20 @@ def qpe_evolution_time_from_hamiltonian(
     *,
     phase_bound: float = np.pi,
 ) -> float:
-    """Choose a QPE evolution time from the Hamiltonian norm bound.
+    """Choose a QPE evolution time from a Hamiltonian spectral-norm bound.
 
-    The Hamiltonian 1-norm bounds the magnitude of every eigenvalue, so
-    ``t = phase_bound / ||H||`` keeps ``|E| t <= phase_bound`` for all
-    eigenvalues. The default ``phase_bound = π`` maximizes phase resolution
-    while staying within the principal QPE branch under that bound.
+    The supplied ``hamiltonian.schatten_norm`` value is treated as a positive
+    upper bound ``B`` on the operator norm ``||H||_2``. For Hermitian ``H``,
+    every eigenvalue satisfies ``|E| <= ||H||_2 <= B``, so
+    ``t = phase_bound / B`` keeps ``|E| t <= phase_bound`` for all eigenvalues.
+    For :class:`~qdk_chemistry.data.QubitHamiltonian`, this bound is the
+    Pauli-coefficient 1-norm and may be loose depending on the decomposition.
+    The default ``phase_bound = π`` maximizes phase resolution while staying
+    within the principal QPE branch under that bound.
 
     Args:
-        hamiltonian: Object exposing ``schatten_norm``; for
-            :class:`~qdk_chemistry.data.QubitHamiltonian`, this is the
-            coefficient 1-norm.
+        hamiltonian: Object exposing ``schatten_norm`` as a positive upper
+            bound on the operator norm.
         phase_bound: Maximum allowed phase magnitude in radians. Must be in
             ``(0, π]``.
 

--- a/python/src/qdk_chemistry/utils/phase.py
+++ b/python/src/qdk_chemistry/utils/phase.py
@@ -6,6 +6,7 @@
 # --------------------------------------------------------------------------------------------
 
 from collections.abc import Iterable, Sequence
+from typing import Protocol
 
 import numpy as np
 
@@ -17,8 +18,54 @@ __all__ = [
     "energy_from_phase",
     "iterative_phase_feedback_update",
     "phase_fraction_from_feedback",
+    "qpe_evolution_time_from_hamiltonian",
     "resolve_energy_aliases",
 ]
+
+
+class _HamiltonianNormBound(Protocol):
+    @property
+    def schatten_norm(self) -> float:
+        ...
+
+
+def qpe_evolution_time_from_hamiltonian(
+    hamiltonian: _HamiltonianNormBound,
+    *,
+    phase_bound: float = np.pi,
+) -> float:
+    """Choose a QPE evolution time from the Hamiltonian norm bound.
+
+    The Hamiltonian 1-norm bounds the magnitude of every eigenvalue, so
+    ``t = phase_bound / ||H||`` keeps ``|E| t <= phase_bound`` for all
+    eigenvalues. The default ``phase_bound = π`` maximizes phase resolution
+    while staying within the principal QPE branch under that bound.
+
+    Args:
+        hamiltonian: Object exposing ``schatten_norm``; for
+            :class:`~qdk_chemistry.data.QubitHamiltonian`, this is the
+            coefficient 1-norm.
+        phase_bound: Maximum allowed phase magnitude in radians. Must be in
+            ``(0, π]``.
+
+    Returns:
+        Evolution time suitable for configuring Hamiltonian time evolution.
+
+    Raises:
+        ValueError: If the Hamiltonian norm or phase bound is non-finite or
+            outside the supported range.
+
+    """
+    Logger.trace_entering()
+    norm = float(hamiltonian.schatten_norm)
+    if not np.isfinite(norm) or norm <= 0.0:
+        raise ValueError(f"Hamiltonian norm must be positive and finite, got {norm}.")
+
+    phase_bound = float(phase_bound)
+    if not np.isfinite(phase_bound) or phase_bound <= 0.0 or phase_bound > np.pi:
+        raise ValueError(f"phase_bound must be positive, finite, and no larger than pi, got {phase_bound}.")
+
+    return float(phase_bound / norm)
 
 
 def energy_from_phase(phase_fraction: float, *, evolution_time: float) -> float:

--- a/python/tests/test_time_evolution_zassenhaus.py
+++ b/python/tests/test_time_evolution_zassenhaus.py
@@ -5,6 +5,7 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from fractions import Fraction
 from functools import cache
 
 import numpy as np
@@ -189,6 +190,16 @@ class TestZassenhaus:
         ).get_container()
 
         assert container.step_reps == 10
+
+    def test_cached_word_factors_are_read_only(self):
+        """Cached formal word factors should not be mutable through callers."""
+        factors = zassenhaus_module._zassenhaus_word_factors(2, 3)
+        original = tuple(dict(factor) for factor in factors)
+
+        with pytest.raises(TypeError):
+            factors[0][(0, 0)] = Fraction(999)
+
+        assert tuple(dict(factor) for factor in zassenhaus_module._zassenhaus_word_factors(2, 3)) == original
 
     def test_vanishing_corrections_short_circuit_before_pauli_multiplication(self, monkeypatch):
         """Commuting correction blocks should be skipped before sparse Pauli multiplication."""

--- a/python/tests/test_time_evolution_zassenhaus.py
+++ b/python/tests/test_time_evolution_zassenhaus.py
@@ -1,0 +1,297 @@
+"""Tests for the Zassenhaus time-evolution builder."""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from functools import cache
+
+import numpy as np
+import pytest
+from scipy.linalg import expm
+
+import qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus as zassenhaus_module
+from qdk_chemistry.algorithms import registry
+from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.trotter import Trotter
+from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus import Zassenhaus
+from qdk_chemistry.data import (
+    AlgorithmRef,
+    Circuit,
+    FlatPartition,
+    MajoranaMapping,
+    QubitHamiltonian,
+    Structure,
+    UnitaryRepresentation,
+)
+from qdk_chemistry.data.unitary_representation.containers.pauli_product_formula import PauliProductFormulaContainer
+from qdk_chemistry.utils.pauli_matrix import pauli_to_dense_matrix
+from qdk_chemistry.utils.phase import qpe_evolution_time_from_hamiltonian, resolve_energy_aliases
+
+
+def _pauli_label(num_qubits: int, ops: dict[int, str]) -> str:
+    chars = ["I"] * num_qubits
+    for qubit, op in ops.items():
+        chars[num_qubits - 1 - qubit] = op
+    return "".join(chars)
+
+
+def _heisenberg_chain(num_sites: int = 4) -> QubitHamiltonian:
+    labels: list[str] = []
+    coefficients: list[float] = []
+    for site in range(num_sites - 1):
+        for axis in ("X", "Y", "Z"):
+            labels.append(_pauli_label(num_sites, {site: axis, site + 1: axis}))
+            coefficients.append(1.0)
+    return QubitHamiltonian(labels, np.asarray(coefficients))
+
+
+@cache
+def _h2_sto3g_hamiltonians():
+    structure = Structure(np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4]]), symbols=["H", "H"])
+    _, wavefunction = registry.create("scf_solver").run(
+        structure,
+        charge=0,
+        spin_multiplicity=1,
+        basis_or_guess="sto-3g",
+    )
+    hamiltonian = registry.create("hamiltonian_constructor").run(wavefunction.get_orbitals())
+    n_spin_orbitals = 2 * hamiltonian.get_orbitals().get_num_molecular_orbitals()
+    qubit_hamiltonian = registry.create("qubit_mapper").run(
+        hamiltonian,
+        MajoranaMapping.jordan_wigner(n_spin_orbitals),
+    )
+    return hamiltonian, qubit_hamiltonian
+
+
+@cache
+def _h2_sto3g_qubit_hamiltonian() -> QubitHamiltonian:
+    _, qubit_hamiltonian = _h2_sto3g_hamiltonians()
+    return qubit_hamiltonian
+
+
+@cache
+def _h2_sto3g_phase_estimation_problem() -> tuple[QubitHamiltonian, Circuit, float]:
+    hamiltonian, qubit_hamiltonian = _h2_sto3g_hamiltonians()
+    _, wavefunction = registry.create("multi_configuration_calculator").run(hamiltonian, 1, 1)
+    state_preparation = registry.create("state_prep", "sparse_isometry_gf2x").run(wavefunction)
+    reference_energy = float(np.linalg.eigvalsh(qubit_hamiltonian.to_matrix()).min())
+    return qubit_hamiltonian, state_preparation, reference_energy
+
+
+def _container_to_unitary(container: PauliProductFormulaContainer) -> np.ndarray:
+    num_qubits = container.num_qubits
+    unitary = np.eye(2**num_qubits, dtype=complex)
+    for term in container.step_terms:
+        label = ["I"] * num_qubits
+        for qubit, op in term.pauli_term.items():
+            label[num_qubits - 1 - qubit] = op
+        pauli = pauli_to_dense_matrix(["".join(label)], np.array([1.0]))
+        unitary = expm(-1j * term.angle * pauli) @ unitary
+    return np.linalg.matrix_power(unitary, container.step_reps)
+
+
+def _error_slope(hamiltonian: QubitHamiltonian, order: int) -> float:
+    times = np.logspace(-3, -1, 7)
+    fit_tail_points = 5
+    exact_hamiltonian = hamiltonian.to_matrix()
+    errors: list[float] = []
+    for time in times:
+        builder = Zassenhaus(order=order, time=float(time), num_divisions=1, weight_threshold=1e-14)
+        approximate = _container_to_unitary(builder.run(hamiltonian).get_container())
+        exact = expm(-1j * exact_hamiltonian * time)
+        errors.append(float(np.linalg.norm(exact - approximate, ord=2)))
+
+    errors_array = np.asarray(errors)
+    if not np.all(np.isfinite(errors_array)) or not np.all(errors_array > 0.0):
+        raise AssertionError(
+            "All sampled Zassenhaus errors must be positive and finite for the log-log fit: "
+            f"{np.array2string(errors_array, precision=3)}"
+        )
+
+    # The smallest H2/STO-3G order-4 samples have true fifth-order errors below
+    # double-precision resolution. Fit the resolved asymptotic tail instead of
+    # letting the numerical floor dominate the log-log regression.
+    return float(np.polyfit(np.log(times[-fit_tail_points:]), np.log(errors_array[-fit_tail_points:]), 1)[0])
+
+
+class TestZassenhaus:
+    """Tests for the Zassenhaus builder."""
+
+    def test_registered(self):
+        """Test that the Zassenhaus builder is available through the registry."""
+        assert "zassenhaus" in registry.available("hamiltonian_unitary_builder")
+
+        builder = registry.create("hamiltonian_unitary_builder", "zassenhaus", order=2, time=0.1)
+        assert builder.name() == "zassenhaus"
+
+    def test_returns_pauli_product_formula_container(self):
+        """Test the output shape required by downstream phase-estimation consumers."""
+        hamiltonian = QubitHamiltonian(["X", "Z"], np.array([1.0, 0.5]))
+        builder = Zassenhaus(order=2, time=0.2, num_divisions=3, power=2)
+
+        unitary = builder.run(hamiltonian)
+        container = unitary.get_container()
+
+        assert isinstance(unitary, UnitaryRepresentation)
+        assert isinstance(container, PauliProductFormulaContainer)
+        assert container.num_qubits == 1
+        assert container.step_reps == 6
+        assert len(container.step_terms) > 0
+
+    def test_order_one_delegates_to_trotter(self):
+        """Order-one Zassenhaus is exactly the first-order Trotter product."""
+        hamiltonian = QubitHamiltonian(["XI", "ZZ"], np.array([2.0, 1.0]))
+
+        zassenhaus_container = Zassenhaus(order=1, time=0.2, num_divisions=4).run(hamiltonian).get_container()
+        trotter_container = Trotter(order=1, time=0.2, num_divisions=4).run(hamiltonian).get_container()
+
+        assert zassenhaus_container.step_reps == trotter_container.step_reps
+        assert zassenhaus_container.step_terms == trotter_container.step_terms
+
+    def test_target_accuracy_uses_commutator_trotter_bound(self):
+        """Zassenhaus automatic divisions reuse Trotter's commutator bound."""
+        hamiltonian = QubitHamiltonian(pauli_strings=["X", "Z"], coefficients=[1.0, 1.0])
+
+        zassenhaus_container = Zassenhaus(order=2, target_accuracy=0.01, time=1.0).run(hamiltonian).get_container()
+        trotter_container = Trotter(order=2, target_accuracy=0.01, time=1.0).run(hamiltonian).get_container()
+
+        assert zassenhaus_container.step_reps == trotter_container.step_reps
+
+    def test_target_accuracy_uses_naive_trotter_bound(self):
+        """Zassenhaus automatic divisions reuse Trotter's naive bound."""
+        hamiltonian = QubitHamiltonian(pauli_strings=["X", "Z"], coefficients=[1.0, 1.0])
+
+        zassenhaus_container = (
+            Zassenhaus(order=2, target_accuracy=0.01, error_bound="naive", time=1.0).run(hamiltonian).get_container()
+        )
+        trotter_container = (
+            Trotter(order=2, target_accuracy=0.01, error_bound="naive", time=1.0).run(hamiltonian).get_container()
+        )
+
+        assert zassenhaus_container.step_reps == trotter_container.step_reps
+
+    def test_target_accuracy_odd_order_uses_supported_trotter_error_order(self):
+        """Odd Zassenhaus orders use the next lower supported Trotter error order."""
+        hamiltonian = QubitHamiltonian(pauli_strings=["X", "Z"], coefficients=[1.0, 1.0])
+
+        zassenhaus_container = Zassenhaus(order=3, target_accuracy=0.01, time=1.0).run(hamiltonian).get_container()
+        trotter_container = Trotter(order=2, target_accuracy=0.01, time=1.0).run(hamiltonian).get_container()
+
+        assert zassenhaus_container.step_reps == trotter_container.step_reps
+
+    def test_target_accuracy_keeps_manual_num_divisions_as_lower_bound(self):
+        """Manual num_divisions remains a lower bound when target_accuracy is set."""
+        hamiltonian = QubitHamiltonian(pauli_strings=["XI", "IX"], coefficients=[1.0, 1.0])
+
+        container = Zassenhaus(order=2, num_divisions=10, target_accuracy=0.01, time=1.0).run(
+            hamiltonian
+        ).get_container()
+
+        assert container.step_reps == 10
+
+    def test_vanishing_corrections_short_circuit_before_pauli_multiplication(self, monkeypatch):
+        """Commuting correction blocks should be skipped before sparse Pauli multiplication."""
+        hamiltonian = QubitHamiltonian(
+            pauli_strings=["XI", "IX"],
+            coefficients=np.array([1.0, 1.0]),
+            term_partition=FlatPartition(strategy="manual", groups=((0,), (1,))),
+        )
+
+        class FailingAccumulator:
+            @staticmethod
+            def multiply_uncached(*_args, **_kwargs):
+                raise AssertionError("vanishing commutators should be skipped before Pauli multiplication")
+
+        monkeypatch.setattr(zassenhaus_module, "PauliTermAccumulator", FailingAccumulator)
+
+        container = Zassenhaus(order=2, time=0.2).run(hamiltonian).get_container()
+
+        assert len(container.step_terms) == 2
+
+    def test_invalid_error_bound_raises(self):
+        """Invalid Zassenhaus error_bound values are rejected by settings."""
+        with pytest.raises(ValueError, match="allowed options"):
+            Zassenhaus(error_bound="invalid")
+
+    @pytest.mark.parametrize("order", [2, 3, 4])
+    def test_x_z_error_scales_as_order_plus_one(self, order: int):
+        """Test Zassenhaus order scaling on a noncommuting one-qubit Hamiltonian."""
+        hamiltonian = QubitHamiltonian(["X", "Z"], np.array([1.0, 1.0]))
+        assert _error_slope(hamiltonian, order) == pytest.approx(order + 1, abs=0.1)
+
+    @pytest.mark.parametrize("order", [2, 3, 4])
+    def test_heisenberg_chain_error_scales_as_order_plus_one(self, order: int):
+        """Test order scaling on the 4-site open Heisenberg chain with J=1."""
+        assert _error_slope(_heisenberg_chain(), order) == pytest.approx(order + 1, abs=0.1)
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("order", [2, 3, 4])
+    def test_h2_sto3g_error_scales_as_order_plus_one(self, order: int):
+        """Test order scaling on H2/STO-3G mapped with Jordan-Wigner."""
+        assert _error_slope(_h2_sto3g_qubit_hamiltonian(), order) == pytest.approx(order + 1, abs=0.1)
+
+    @pytest.mark.slow
+    def test_iterative_phase_estimation_h2_sto3g_chemical_accuracy(self):
+        """Test Zassenhaus-backed PhaseEstimation on H2/STO-3G within chemical accuracy."""
+        hamiltonian, state_preparation, reference_energy = _h2_sto3g_phase_estimation_problem()
+        num_bits = 11
+        evolution_time = qpe_evolution_time_from_hamiltonian(hamiltonian)
+        zassenhaus_order = 3
+        zassenhaus_num_divisions = 4
+
+        first_iteration_power = 2 ** (num_bits - 1)
+        first_iteration_container = Zassenhaus(
+            order=zassenhaus_order,
+            time=evolution_time,
+            num_divisions=zassenhaus_num_divisions,
+            power=first_iteration_power,
+        ).run(hamiltonian).get_container()
+        assert len(first_iteration_container.step_terms) * first_iteration_container.step_reps <= 200_000
+
+        phase_estimation = registry.create("phase_estimation", "qdk_iterative", shots_per_bit=3)
+        phase_estimation.settings().set(
+            "qpe_circuit_builder",
+            AlgorithmRef(
+                "qpe_circuit_builder",
+                "qdk_iterative",
+                num_bits=num_bits,
+                controlled_circuit_mapper=AlgorithmRef("controlled_circuit_mapper", "pauli_sequence"),
+                unitary_builder=AlgorithmRef(
+                    "hamiltonian_unitary_builder",
+                    "zassenhaus",
+                    order=zassenhaus_order,
+                    time=evolution_time,
+                    num_divisions=zassenhaus_num_divisions,
+                ),
+            ),
+        )
+        phase_estimation.settings().set(
+            "circuit_executor",
+            AlgorithmRef("circuit_executor", "qdk_full_state_simulator", seed=42),
+        )
+
+        result = phase_estimation.run(
+            qubit_hamiltonian=hamiltonian,
+            state_preparation=state_preparation,
+        )
+
+        resolved_energy = resolve_energy_aliases(
+            result.raw_energy,
+            evolution_time=evolution_time,
+            reference_energy=reference_energy,
+            shift_range=range(-4, 5),
+        )
+        assert resolved_energy == pytest.approx(reference_energy, abs=1.6e-3)
+
+    def test_rejects_non_hermitian_hamiltonian(self):
+        """Test that non-Hermitian Hamiltonians are rejected."""
+        hamiltonian = QubitHamiltonian(["X"], np.array([1.0 + 1.0j]))
+        with pytest.raises(ValueError, match="Non-Hermitian"):
+            Zassenhaus(order=2, time=0.1).run(hamiltonian)
+
+    def test_rejects_non_positive_num_divisions(self):
+        """Test validation of manual division count."""
+        hamiltonian = QubitHamiltonian(["X"], np.array([1.0]))
+        with pytest.raises(ValueError, match="num_divisions"):
+            Zassenhaus(order=2, time=0.1, num_divisions=0).run(hamiltonian)

--- a/python/tests/test_utils_phase.py
+++ b/python/tests/test_utils_phase.py
@@ -18,6 +18,7 @@ from qdk_chemistry.utils.phase import (
     energy_from_phase,
     iterative_phase_feedback_update,
     phase_fraction_from_feedback,
+    qpe_evolution_time_from_hamiltonian,
     resolve_energy_aliases,
 )
 
@@ -26,6 +27,35 @@ from .reference_tolerances import (
     qpe_energy_tolerance,
     qpe_phase_fraction_tolerance,
 )
+
+
+class _HamiltonianWithNorm:
+    def __init__(self, norm: float) -> None:
+        self.schatten_norm = norm
+
+
+def test_qpe_evolution_time_from_hamiltonian_uses_norm_bound() -> None:
+    """Evolution time should be derived from the Hamiltonian norm."""
+    hamiltonian = _HamiltonianWithNorm(4.0)
+
+    assert qpe_evolution_time_from_hamiltonian(hamiltonian) == pytest.approx(np.pi / 4.0)
+    assert qpe_evolution_time_from_hamiltonian(hamiltonian, phase_bound=np.pi / 2.0) == pytest.approx(
+        np.pi / 8.0
+    )
+
+
+@pytest.mark.parametrize("norm", [0.0, -1.0, np.inf, np.nan])
+def test_qpe_evolution_time_from_hamiltonian_rejects_invalid_norm(norm: float) -> None:
+    """Hamiltonian norm must be positive and finite."""
+    with pytest.raises(ValueError, match="Hamiltonian norm"):
+        qpe_evolution_time_from_hamiltonian(_HamiltonianWithNorm(norm))
+
+
+@pytest.mark.parametrize("phase_bound", [0.0, -1.0, np.pi + 1e-12, np.inf, np.nan])
+def test_qpe_evolution_time_from_hamiltonian_rejects_invalid_phase_bound(phase_bound: float) -> None:
+    """The phase bound must keep the selected time inside the principal branch."""
+    with pytest.raises(ValueError, match="phase_bound"):
+        qpe_evolution_time_from_hamiltonian(_HamiltonianWithNorm(1.0), phase_bound=phase_bound)
 
 
 def test_energy_from_phase_wraps_into_branch() -> None:


### PR DESCRIPTION
Closes #483 

## Summary

The fix is mainly a Zassenhaus time-evolution path for issue #483. It does this:

- A new `"zassenhaus"` Hamiltonian unitary builder was added and registered.
- It plugs into the existing QDK/Chemistry pipeline without changing PhaseEstimation or mapper APIs.
- It outputs the same `PauliProductFormulaContainer` shape as `"trotter"`.
- `order=1` falls back to the existing first-order Trotter implementation.
- Higher orders explicitly add Zassenhaus commutator correction terms, giving expected local error scaling of `O(t^(p+1))`.
- It reuses existing Trotter error-bound logic for automatic `num_divisions` selection.
- It validates important edge cases: non-Hermitian Hamiltonians, invalid division counts, invalid error-bound settings, and tiny generated terms.
- It adds QPE evolution-time helper logic based on `phase_bound / ||H||`.
- Tests cover registry behavior, output compatibility, numerical scaling, H2/STO-3G, and PhaseEstimation chemical accuracy.
- Docs and references were updated for the new builder.

## Validation

All Python tests pass and the test file covers:

- registry availability,
- output container shape,
- order-1 Trotter fallback,
- automatic division-count behavior,
- Zassenhaus error scaling for `p = 2, 3, 4`,
- 4-site Heisenberg chain scaling,
- H2/STO-3G Jordan-Wigner scaling,
- end-to-end H2/STO-3G `PhaseEstimation` within chemical accuracy.

| System                            |   p | Expected slope |     Fitted slope |
| --------------------------------- | --: | -------------: | ---------------: |
| 4-site open Heisenberg chain, J=1 |   2 |              3 | `2.993367112344` |
| 4-site open Heisenberg chain, J=1 |   3 |              4 | `4.015929994746` |
| 4-site open Heisenberg chain, J=1 |   4 |              5 | `5.004733885337` |
| H2/STO-3G, Jordan-Wigner          |   2 |              3 | `2.999771030470` |
| H2/STO-3G, Jordan-Wigner          |   3 |              4 | `3.999999019763` |
| H2/STO-3G, Jordan-Wigner          |   4 |              5 | `4.999985332661` |

All fitted slopes are within `0.1` of the expected `p + 1`.

**PhaseEstimation Result**

Using H2/STO-3G with the new `zassenhaus` builder:

- estimated energy: `-1.852448023145` Hartree
- reference ground energy: `-1.851561658068` Hartree
- absolute error: `8.863650761604e-04` Hartree

So the PhaseEstimation result is within chemical accuracy, because `0.000886365` Hartree is below the required `0.0016` Hartree.