### PR TITLE
GH action to package examples zip with release

### DIFF
--- a/.github/workflows/package-examples.yaml
+++ b/.github/workflows/package-examples.yaml
@@ -32,9 +32,11 @@ jobs:
     - name: Upload release asset
       if: github.event_name == 'release'
       run: |
+        VERSION="${{ github.event.release.tag_name }}"
+        VERSION="${VERSION//\//-}"
         gh release upload \
           "${{ github.event.release.tag_name }}" \
-          "dist/qdk-chemistry-examples-${{ github.event.release.tag_name }}.zip" \
+          "dist/qdk-chemistry-examples-${VERSION}.zip" \
           --clobber
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-examples.yaml
+++ b/.github/workflows/package-examples.yaml
@@ -19,6 +19,7 @@ jobs:
       run: |
         mkdir -p dist
         VERSION="${{ github.event.release.tag_name }}"
+        VERSION="${VERSION:-${{ github.ref_name }}}"
         zip -r "dist/qdk-chemistry-examples-${VERSION}.zip" examples
 
     - name: Upload workflow artifact

--- a/.github/workflows/package-examples.yaml
+++ b/.github/workflows/package-examples.yaml
@@ -20,6 +20,7 @@ jobs:
         mkdir -p dist
         VERSION="${{ github.event.release.tag_name }}"
         VERSION="${VERSION:-${{ github.ref_name }}}"
+        VERSION="${VERSION//\//-}"
         zip -r "dist/qdk-chemistry-examples-${VERSION}.zip" examples
 
     - name: Upload workflow artifact

--- a/.github/workflows/package-examples.yaml
+++ b/.github/workflows/package-examples.yaml
@@ -1,0 +1,38 @@
+name: Package Examples
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  package-examples:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Create zip
+      run: |
+        mkdir -p dist
+        VERSION="${{ github.event.release.tag_name }}"
+        zip -r "dist/qdk-chemistry-examples-${VERSION}.zip" examples
+
+    - name: Upload workflow artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: qdk-chemistry-examples-zip
+        path: dist/*.zip
+
+    - name: Upload release asset
+      if: github.event_name == 'release'
+      run: |
+        gh release upload \
+          "${{ github.event.release.tag_name }}" \
+          "dist/qdk-chemistry-examples-${{ github.event.release.tag_name }}.zip" \
+          --clobber
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/source/user/quickstart.rst
+++ b/docs/source/user/quickstart.rst
@@ -26,7 +26,7 @@ This example walks through the full quantum applications workflow: from building
 The emphasis is on optimizing the quantum resource requirements at every stage, demonstrating how QDK/Chemistry's modular pipeline makes it easy to select the right method for each step.
 
 You can also view a related code sample in a Jupyter notebook format, along with several other examples, in the `examples folder <https://github.com/microsoft/qdk-chemistry/blob/main/examples/>`_ of the GitHub repository.
-To run the examples, either clone the repository or download the packaged examples from the https://github.com/microsoft/qdk-chemistry/releases, as individual examples may depend on accompanying files within the examples directory.
+To run the examples, either clone the repository or download the packaged examples from the `GitHub releases page <https://github.com/microsoft/qdk-chemistry/releases>`_, as individual examples may depend on accompanying files within the examples directory.
 
 .. note::
 

--- a/docs/source/user/quickstart.rst
+++ b/docs/source/user/quickstart.rst
@@ -26,7 +26,7 @@ This example walks through the full quantum applications workflow: from building
 The emphasis is on optimizing the quantum resource requirements at every stage, demonstrating how QDK/Chemistry's modular pipeline makes it easy to select the right method for each step.
 
 You can also view a related code sample in a Jupyter notebook format, along with several other examples, in the `examples folder <https://github.com/microsoft/qdk-chemistry/blob/main/examples/>`_ of the GitHub repository.
-To run the examples, one should either clone the whole repository or download the packaged examples from the `Releases page <https://github.com/microsoft/qdk-chemistry/releases>`_, as some notebooks import helper modules from the ``examples`` directory.
+To run the examples, either clone the repository or download the packaged examples from the https://github.com/microsoft/qdk-chemistry/releases, as individual examples may depend on accompanying files within the examples directory.
 
 .. note::
 

--- a/docs/source/user/quickstart.rst
+++ b/docs/source/user/quickstart.rst
@@ -26,7 +26,7 @@ This example walks through the full quantum applications workflow: from building
 The emphasis is on optimizing the quantum resource requirements at every stage, demonstrating how QDK/Chemistry's modular pipeline makes it easy to select the right method for each step.
 
 You can also view a related code sample in a Jupyter notebook format, along with several other examples, in the `examples folder <https://github.com/microsoft/qdk-chemistry/blob/main/examples/>`_ of the GitHub repository.
-Companion chemistry datasets and supporting assets are also available in `microsoft/qdk-chemistry-data <https://github.com/microsoft/qdk-chemistry-data>`_.
+To run the examples, one should either clone the whole repository or download the packaged examples from the `Releases page <https://github.com/microsoft/qdk-chemistry/releases>`_, as some notebooks import helper modules from the ``examples`` directory.
 
 .. note::
 
@@ -40,6 +40,8 @@ Companion chemistry datasets and supporting assets are also available in `micros
       git clone --branch stable/1.0 https://github.com/microsoft/qdk-chemistry.git
 
    See the `examples README <https://github.com/microsoft/qdk-chemistry/blob/main/examples/README.md>`_ for details.
+
+Companion chemistry datasets and supporting assets are also available in `microsoft/qdk-chemistry-data <https://github.com/microsoft/qdk-chemistry-data>`_.
 
 Create a Structure object
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,7 +40,11 @@ python -m pip install pennylane rdkit
 
 ## Standalone examples and data
 
+Some notebooks import helper modules from the `utils/` directory.
+Download or clone the full `examples/` directory structure to run the examples.
+
 - `data`: Data directory for examples
+- `utils`: Shared helper modules used by some notebooks and scripts in this directory
 - `factory_list.ipynb`: Jupyter notebook that lists available factory methods in QDK/Chemistry along with their descriptions and settings
 - `language/cpp`: C++ example programs using the QDK/Chemistry C++ API
 - `language/sample_sci_workflow.py`: Python script demonstrating a sample classical workflow for selected CI quantum chemistry calculations.


### PR DESCRIPTION
Added a GitHub Actions workflow that packages the examples/ directory and uploads it as a release asset.

The workflow can also be run manually for testing, uploading the package as a workflow artifact.

Updated the documentation accordingly.

Addresses #490

Edit: This workflow is automatically ran after a Github release is made (no matter how).