### PR TITLE
Structure: support xyz string w/o header

### DIFF
--- a/cpp/include/qdk/chemistry/data/structure.hpp
+++ b/cpp/include/qdk/chemistry/data/structure.hpp
@@ -301,6 +301,11 @@ class Structure : public DataClass,
 
   /**
    * @brief Load structure from XYZ format string
+   *
+   * Accepts either a standard XYZ string (atom-count + comment header followed
+   * by `symbol x y z` lines) or a bare coordinate block (atom lines only).
+   * Blank lines are ignored.
+   *
    * @param xyz_string XYZ format string with coordinates in Angstrom
    * @return Structure object created from XYZ string
    * @throws std::runtime_error if XYZ format is invalid

--- a/cpp/src/qdk/chemistry/data/structure.cpp
+++ b/cpp/src/qdk/chemistry/data/structure.cpp
@@ -608,8 +608,7 @@ std::shared_ptr<Structure> Structure::from_xyz(const std::string& xyz_string) {
   }
 
   bool has_header = false;
-  unsigned expected_num_atoms = 0;
-  if (parse_count_line(first_line, expected_num_atoms)) {
+  size_t expected_num_atoms = 0;
     has_header = true;
     // The line immediately following the count is the comment line and is
     // skipped regardless of its content.

--- a/cpp/src/qdk/chemistry/data/structure.cpp
+++ b/cpp/src/qdk/chemistry/data/structure.cpp
@@ -579,7 +579,7 @@ std::shared_ptr<Structure> Structure::from_xyz(const std::string& xyz_string) {
   // non-negative integer with no trailing tokens.
   auto parse_count_line = [](const std::string& s, size_t& count) {
     std::istringstream ss(s);
-    size_t value;
+    unsigned value;
     if (!(ss >> value)) {
       return false;
     }
@@ -609,6 +609,7 @@ std::shared_ptr<Structure> Structure::from_xyz(const std::string& xyz_string) {
 
   bool has_header = false;
   size_t expected_num_atoms = 0;
+  if (parse_count_line(first_line, expected_num_atoms)) {
     has_header = true;
     // The line immediately following the count is the comment line and is
     // skipped regardless of its content.

--- a/cpp/src/qdk/chemistry/data/structure.cpp
+++ b/cpp/src/qdk/chemistry/data/structure.cpp
@@ -579,15 +579,15 @@ std::shared_ptr<Structure> Structure::from_xyz(const std::string& xyz_string) {
   // non-negative integer with no trailing tokens.
   auto parse_count_line = [](const std::string& s, unsigned& count) {
     std::istringstream ss(s);
-    long long value;
-    if (!(ss >> value) || value < 0) {
+    unsigned value;
+    if (!(ss >> value)) {
       return false;
     }
     std::string extra;
     if (ss >> extra) {
       return false;  // additional tokens => not a pure count line
     }
-    count = static_cast<unsigned>(value);
+    count = value;
     return true;
   };
 

--- a/cpp/src/qdk/chemistry/data/structure.cpp
+++ b/cpp/src/qdk/chemistry/data/structure.cpp
@@ -577,9 +577,9 @@ std::shared_ptr<Structure> Structure::from_xyz(const std::string& xyz_string) {
 
   // A line is a header (atom count) line if it parses fully as a single
   // non-negative integer with no trailing tokens.
-  auto parse_count_line = [](const std::string& s, unsigned& count) {
+  auto parse_count_line = [](const std::string& s, size_t& count) {
     std::istringstream ss(s);
-    unsigned value;
+    size_t value;
     if (!(ss >> value)) {
       return false;
     }

--- a/cpp/src/qdk/chemistry/data/structure.cpp
+++ b/cpp/src/qdk/chemistry/data/structure.cpp
@@ -660,6 +660,12 @@ std::shared_ptr<Structure> Structure::from_xyz(const std::string& xyz_string) {
       continue;
     }
     parse_atom_line(line, atom_index++);
+    if (has_header && symbols.size() > expected_num_atoms) {
+      throw std::runtime_error("Invalid XYZ format: declared atom count (" +
+                               std::to_string(expected_num_atoms) +
+                               ") does not match number of atom lines (" +
+                               std::to_string(symbols.size()) + ")");
+    }
   }
 
   // When a header is present, validate that the declared atom count matches the

--- a/cpp/src/qdk/chemistry/data/structure.cpp
+++ b/cpp/src/qdk/chemistry/data/structure.cpp
@@ -570,54 +570,105 @@ std::shared_ptr<Structure> Structure::from_xyz(const std::string& xyz_string) {
   std::istringstream iss(xyz_string);
   std::string line;
 
-  // Read number of atoms
-  if (!std::getline(iss, line)) {
-    throw std::runtime_error("Invalid XYZ format: missing number of atoms");
+  // A line is considered blank if it contains no non-whitespace characters.
+  auto is_blank = [](const std::string& s) {
+    return s.find_first_not_of(" \t\r\n\f\v") == std::string::npos;
+  };
+
+  // A line is a header (atom count) line if it parses fully as a single
+  // non-negative integer with no trailing tokens.
+  auto parse_count_line = [](const std::string& s, unsigned& count) {
+    std::istringstream ss(s);
+    long long value;
+    if (!(ss >> value) || value < 0) {
+      return false;
+    }
+    std::string extra;
+    if (ss >> extra) {
+      return false;  // additional tokens => not a pure count line
+    }
+    count = static_cast<unsigned>(value);
+    return true;
+  };
+
+  // Find the first non-blank line to determine the input format. This supports
+  // both the standard XYZ format (atom count + comment header) and a bare
+  // coordinate block (atom lines only).
+  std::string first_line;
+  bool have_first_line = false;
+  while (std::getline(iss, line)) {
+    if (!is_blank(line)) {
+      first_line = line;
+      have_first_line = true;
+      break;
+    }
+  }
+  if (!have_first_line) {
+    throw std::runtime_error("Invalid XYZ format: empty input");
   }
 
-  unsigned num_atoms;
-  try {
-    num_atoms = std::stoul(line);
-  } catch (const std::exception&) {
-    throw std::runtime_error(
-        "Invalid XYZ format: cannot parse number of atoms");
+  bool has_header = false;
+  unsigned expected_num_atoms = 0;
+  if (parse_count_line(first_line, expected_num_atoms)) {
+    has_header = true;
+    // The line immediately following the count is the comment line and is
+    // skipped regardless of its content.
+    if (!std::getline(iss, line)) {
+      throw std::runtime_error("Invalid XYZ format: missing comment line");
+    }
   }
 
-  // Skip comment line
-  if (!std::getline(iss, line)) {
-    throw std::runtime_error("Invalid XYZ format: missing comment line");
-  }
-
-  // Prepare data for construction
+  // Prepare data for construction.
   std::vector<Eigen::Vector3d> coordinates;
   std::vector<std::string> symbols;
-  coordinates.reserve(num_atoms);
-  symbols.reserve(num_atoms);
+  if (has_header) {
+    coordinates.reserve(expected_num_atoms);
+    symbols.reserve(expected_num_atoms);
+  }
 
-  // Read atom data (XYZ expected in Angstrom)
-  for (unsigned i = 0; i < num_atoms; ++i) {
-    if (!std::getline(iss, line)) {
-      throw std::runtime_error(
-          "Invalid XYZ format: missing atom data for atom " +
-          std::to_string(i));
-    }
+  // Reuse a single stream across lines to avoid per-line allocations.
+  std::istringstream line_stream;
 
-    std::istringstream line_stream(line);
+  // Parse a single atom line (XYZ expected in Angstrom) and append the result.
+  auto parse_atom_line = [&](const std::string& atom_line, size_t atom_index) {
+    line_stream.clear();
+    line_stream.str(atom_line);
+
     std::string symbol;
     double x, y, z;
-
     if (!(line_stream >> symbol >> x >> y >> z)) {
       throw std::runtime_error(
           "Invalid XYZ format: cannot parse atom data for atom " +
-          std::to_string(i));
+          std::to_string(atom_index));
     }
 
     Eigen::Vector3d coords_ang(x, y, z);
-    Eigen::Vector3d coords_bohr =
-        coords_ang * qdk::chemistry::constants::angstrom_to_bohr;
-
-    coordinates.push_back(coords_bohr);
+    coordinates.push_back(coords_ang *
+                          qdk::chemistry::constants::angstrom_to_bohr);
     symbols.push_back(symbol);
+  };
+
+  size_t atom_index = 0;
+  // When there is no header, the first non-blank line is already an atom line.
+  if (!has_header) {
+    parse_atom_line(first_line, atom_index++);
+  }
+
+  // Read the remaining atom lines, skipping any blank lines.
+  while (std::getline(iss, line)) {
+    if (is_blank(line)) {
+      continue;
+    }
+    parse_atom_line(line, atom_index++);
+  }
+
+  // When a header is present, validate that the declared atom count matches the
+  // number of parsed atom lines.
+  if (has_header && symbols.size() != expected_num_atoms) {
+    throw std::runtime_error("Invalid XYZ format: declared atom count (" +
+                             std::to_string(expected_num_atoms) +
+                             ") does not match number of atom lines (" +
+                             std::to_string(symbols.size()) + ")");
   }
 
   return std::make_shared<Structure>(coordinates, symbols);

--- a/cpp/tests/test_structure.cpp
+++ b/cpp/tests/test_structure.cpp
@@ -89,6 +89,50 @@ TEST_F(StructureBasicTest, XYZSerialization) {
   EXPECT_EQ(s2->get_atom_symbol(1), "H");
 }
 
+// Test XYZ parsing of a bare coordinate block (no atom-count/comment header)
+TEST_F(StructureBasicTest, XYZCoordinateBlock) {
+  // No header: just `symbol x y z` lines.
+  std::string block = "O 0.0 0.0 0.0\nH 0.0 0.0 0.96\nH 0.93 0.0 -0.26";
+
+  auto s = Structure::from_xyz(block);
+  EXPECT_EQ(s->get_num_atoms(), 3);
+  EXPECT_EQ(s->get_atom_symbol(0), "O");
+  EXPECT_EQ(s->get_atom_symbol(1), "H");
+  EXPECT_EQ(s->get_atom_symbol(2), "H");
+
+  // A single-atom block (which could be confused with a count line) is parsed
+  // correctly because the line has trailing coordinate tokens.
+  auto single = Structure::from_xyz("H 0.0 0.0 0.0");
+  EXPECT_EQ(single->get_num_atoms(), 1);
+  EXPECT_EQ(single->get_atom_symbol(0), "H");
+
+  // Blank lines are ignored, including leading and trailing ones.
+  auto padded = Structure::from_xyz("\n\nH 0.0 0.0 0.0\n\nH 0.0 0.0 0.74\n\n");
+  EXPECT_EQ(padded->get_num_atoms(), 2);
+}
+
+// Test that the declared atom count is validated when a header is present
+TEST_F(StructureBasicTest, XYZHeaderCountValidation) {
+  // Matching count parses successfully.
+  std::string ok = "2\nH2 molecule\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74";
+  auto s = Structure::from_xyz(ok);
+  EXPECT_EQ(s->get_num_atoms(), 2);
+
+  // Too few atom lines for the declared count.
+  std::string too_few = "3\nthree atoms\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74";
+  EXPECT_THROW(Structure::from_xyz(too_few), std::runtime_error);
+
+  // Too many atom lines for the declared count.
+  std::string too_many =
+      "1\none atom\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74\nH 0.0 0.0 1.48";
+  EXPECT_THROW(Structure::from_xyz(too_many), std::runtime_error);
+
+  // Header with blank padding still validates against the declared count.
+  std::string padded = "2\ncomment\n\nH 0.0 0.0 0.0\n\nH 0.0 0.0 0.74\n";
+  auto padded_structure = Structure::from_xyz(padded);
+  EXPECT_EQ(padded_structure->get_num_atoms(), 2);
+}
+
 // Test JSON serialization
 TEST_F(StructureBasicTest, JSONSerialization) {
   std::vector<Eigen::Vector3d> coords = {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.74}};

--- a/python/src/pybind11/data/structure.cpp
+++ b/python/src/pybind11/data/structure.cpp
@@ -585,6 +585,17 @@ Examples:
                        R"(
 Load structure from XYZ format string (static method).
 
+Accepts two input layouts:
+
+* Standard XYZ: an atom-count line followed by a comment line, then one
+  ``symbol x y z`` line per atom. When this header is present, the declared
+  atom count must match the number of atom lines.
+* Bare coordinate block: ``symbol x y z`` lines only, with no leading
+  atom-count and comment lines.
+
+The format is detected automatically based on whether the first non-blank
+line parses as a single non-negative integer. Blank lines are ignored.
+
 Args:
     xyz_string (str): XYZ format string with coordinates in Angstrom
 
@@ -601,6 +612,11 @@ Examples:
     ... H  0.757000  0.586000  0.000000
     ... H -0.757000  0.586000  0.000000'''
     >>> water = Structure.from_xyz(xyz_str)
+    >>> # A bare coordinate block (no header) is also accepted
+    >>> block = '''O  0.000000  0.000000  0.000000
+    ... H  0.757000  0.586000  0.000000
+    ... H -0.757000  0.586000  0.000000'''
+    >>> water = Structure.from_xyz(block)
 )",
                        py::arg("xyz_string"));
 

--- a/python/tests/test_structure.py
+++ b/python/tests/test_structure.py
@@ -125,6 +125,39 @@ class TestStructure:
                 atol=xyz_file_structure_tolerance,
             )
 
+    def test_xyz_coordinate_block(self):
+        """Test parsing a bare coordinate block without an XYZ header."""
+        block = "O 0.0 0.0 0.0\nH 0.0 0.0 0.96\nH 0.93 0.0 -0.26"
+        structure = Structure.from_xyz(block)
+        assert structure.get_num_atoms() == 3
+        assert structure.get_atom_symbol(0) == "O"
+        assert structure.get_atom_symbol(1) == "H"
+        assert structure.get_atom_symbol(2) == "H"
+
+        # Single-atom block is parsed as coordinates, not as a count line.
+        single = Structure.from_xyz("H 0.0 0.0 0.0")
+        assert single.get_num_atoms() == 1
+        assert single.get_atom_symbol(0) == "H"
+
+        # Blank lines are ignored.
+        padded = Structure.from_xyz("\n\nH 0.0 0.0 0.0\n\nH 0.0 0.0 0.74\n\n")
+        assert padded.get_num_atoms() == 2
+
+    def test_xyz_header_count_validation(self):
+        """Test that the declared atom count is validated when a header is present."""
+        # Matching count parses successfully.
+        ok = "2\nH2 molecule\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74"
+        structure = Structure.from_xyz(ok)
+        assert structure.get_num_atoms() == 2
+
+        # Too few atom lines for the declared count.
+        with pytest.raises(RuntimeError):
+            Structure.from_xyz("3\nthree atoms\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74")
+
+        # Too many atom lines for the declared count.
+        with pytest.raises(RuntimeError):
+            Structure.from_xyz("1\none atom\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74")
+
     def test_xyz_file_io(self):
         """Test XYZ file I/O."""
         coordinates = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.74]])


### PR DESCRIPTION
Added support for a bare xyz coordinate block, so:

```python
water = Structure.from_xyz('''
O  0.000000  0.000000  0.000000
H  0.757000  0.586000  0.000000
H -0.757000  0.586000  0.000000
''')
```

I think it looks cleaner and easier to quickly modify (add or remove atoms) than the full xyz string with a header.

At the moment, both this and the full xyz formats are supported under the same `from_xyz` method, detecting based on whether you have a single integer on the first line. At the moment, this now also extends to xyz files, which might be a downside.

Potentially it might make sense to separate the bare xyz coordinate input into a separate method, e.g. `from_xyz_coords`, `from_xyz_block` or similar.

Happy to discuss.