### PR TITLE
Docs: switch default example tab from C++ to Python

### DIFF
--- a/docs/source/user/comprehensive/algorithms/active_space.rst
+++ b/docs/source/user/comprehensive/algorithms/active_space.rst
@@ -47,13 +47,6 @@ Wavefunction
 
 .. rubric:: Creating an active space selector
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/active_space_selector.cpp
-      :language: cpp
-      :start-after: // start-cell-create
-      :end-before: // end-cell-create
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/active_space_selector.py
@@ -61,17 +54,17 @@ Wavefunction
       :start-after: # start-cell-create
       :end-before: # end-cell-create
 
-.. rubric:: Configuring settings
-
-Settings can be modified using the ``settings()`` object.
-See `Available implementations`_ below for implementation-specific options.
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/active_space_selector.cpp
       :language: cpp
-      :start-after: // start-cell-configure
-      :end-before: // end-cell-configure
+      :start-after: // start-cell-create
+      :end-before: // end-cell-create
+
+.. rubric:: Configuring settings
+
+Settings can be modified using the ``settings()`` object.
+See `Available implementations`_ below for implementation-specific options.
 
 .. tab:: Python API
 
@@ -80,14 +73,14 @@ See `Available implementations`_ below for implementation-specific options.
       :start-after: # start-cell-configure
       :end-before: # end-cell-configure
 
-.. rubric:: Running the selection
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/active_space_selector.cpp
       :language: cpp
-      :start-after: // start-cell-run
-      :end-before: // end-cell-run
+      :start-after: // start-cell-configure
+      :end-before: // end-cell-configure
+
+.. rubric:: Running the selection
 
 .. tab:: Python API
 
@@ -96,18 +89,18 @@ See `Available implementations`_ below for implementation-specific options.
       :start-after: # start-cell-run
       :end-before: # end-cell-run
 
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/active_space_selector.cpp
+      :language: cpp
+      :start-after: // start-cell-run
+      :end-before: // end-cell-run
+
 Available implementations
 -------------------------
 
 QDK/Chemistry's :class:`~qdk_chemistry.algorithms.ActiveSpaceSelector` provides implementations for various selection strategies.
 You can discover available implementations programmatically:
-
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/active_space_selector.cpp
-      :language: cpp
-      :start-after: // start-cell-list-implementations
-      :end-before: // end-cell-list-implementations
 
 .. tab:: Python API
 
@@ -115,6 +108,13 @@ You can discover available implementations programmatically:
       :language: python
       :start-after: # start-cell-list-implementations
       :end-before: # end-cell-list-implementations
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/active_space_selector.cpp
+      :language: cpp
+      :start-after: // start-cell-list-implementations
+      :end-before: // end-cell-list-implementations
 
 QDK Valence
 ~~~~~~~~~~~
@@ -295,19 +295,19 @@ The resulting entropies are typically sufficient to identify strongly correlated
 .. note::
   The number of valence orbitals and electrons can be automatically determined using the utility function :func:`~qdk_chemistry.utils.compute_valence_space_parameters`.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/active_space_selector.cpp
-      :language: cpp
-      :start-after: // start-cell-autocas
-      :end-before: // end-cell-autocas
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/active_space_selector.py
       :language: python
       :start-after: # start-cell-autocas
       :end-before: # end-cell-autocas
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/active_space_selector.cpp
+      :language: cpp
+      :start-after: // start-cell-autocas
+      :end-before: // end-cell-autocas
 
 .. _pyscf-avas-plugin:
 

--- a/docs/source/user/comprehensive/algorithms/factory_pattern.rst
+++ b/docs/source/user/comprehensive/algorithms/factory_pattern.rst
@@ -83,19 +83,19 @@ To create an algorithm instance, call the appropriate factory method with an opt
 If no name is provided, the default implementation is used.
 See :ref:`discovering-implementations` below for how to list available implementations programmatically.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/factory_pattern.cpp
-      :language: cpp
-      :start-after: // start-cell-scf-localizer
-      :end-before: // end-cell-scf-localizer
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/factory_pattern.py
       :language: python
       :start-after: # start-cell-scf-localizer
       :end-before: # end-cell-scf-localizer
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/factory_pattern.cpp
+      :language: cpp
+      :start-after: // start-cell-scf-localizer
+      :end-before: // end-cell-scf-localizer
 
 .. _discovering-implementations:
 
@@ -108,19 +108,19 @@ This is useful for exploring what's available at runtime, building dynamic UIs, 
 Listing algorithm types and implementations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/factory_pattern.cpp
-      :language: cpp
-      :start-after: // start-cell-list-algorithms
-      :end-before: // end-cell-list-algorithms
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/factory_pattern.py
       :language: python
       :start-after: # start-cell-list-algorithms
       :end-before: # end-cell-list-algorithms
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/factory_pattern.cpp
+      :language: cpp
+      :start-after: // start-cell-list-algorithms
+      :end-before: // end-cell-list-algorithms
 
 Inspecting settings
 ~~~~~~~~~~~~~~~~~~~
@@ -129,19 +129,19 @@ Each algorithm implementation has configurable settings.
 You can discover available settings programmatically as shown below.
 For comprehensive documentation on working with settings, see :doc:`settings`.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/factory_pattern.cpp
-      :language: cpp
-      :start-after: // start-cell-inspect-settings
-      :end-before: // end-cell-inspect-settings
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/factory_pattern.py
       :language: python
       :start-after: # start-cell-inspect-settings
       :end-before: # end-cell-inspect-settings
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/factory_pattern.cpp
+      :language: cpp
+      :start-after: // start-cell-inspect-settings
+      :end-before: // end-cell-inspect-settings
 
 Connection to the plugin system
 -------------------------------

--- a/docs/source/user/comprehensive/algorithms/hamiltonian_constructor.rst
+++ b/docs/source/user/comprehensive/algorithms/hamiltonian_constructor.rst
@@ -31,19 +31,19 @@ Orbitals
 
 .. rubric:: Creating a constructor
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/hamiltonian_constructor.cpp
-      :language: cpp
-      :start-after: // start-cell-create
-      :end-before: // end-cell-create
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/hamiltonian_constructor.py
       :language: python
       :start-after: # start-cell-create
       :end-before: # end-cell-create
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/hamiltonian_constructor.cpp
+      :language: cpp
+      :start-after: // start-cell-create
+      :end-before: // end-cell-create
 
 .. rubric:: Configuring settings
 
@@ -53,13 +53,6 @@ See `Available implementations`_ below for implementation-specific options.
 .. note::
    All orbital indices in QDK/Chemistry are 0-based, following the convention used in most programming languages.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/hamiltonian_constructor.cpp
-      :language: cpp
-      :start-after: // start-cell-configure
-      :end-before: // end-cell-configure
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/hamiltonian_constructor.py
@@ -67,14 +60,14 @@ See `Available implementations`_ below for implementation-specific options.
       :start-after: # start-cell-configure
       :end-before: # end-cell-configure
 
-.. rubric:: Running the calculation
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/hamiltonian_constructor.cpp
       :language: cpp
-      :start-after: // start-cell-construct
-      :end-before: // end-cell-construct
+      :start-after: // start-cell-configure
+      :end-before: // end-cell-configure
+
+.. rubric:: Running the calculation
 
 .. tab:: Python API
 
@@ -83,18 +76,18 @@ See `Available implementations`_ below for implementation-specific options.
       :start-after: # start-cell-construct
       :end-before: # end-cell-construct
 
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/hamiltonian_constructor.cpp
+      :language: cpp
+      :start-after: // start-cell-construct
+      :end-before: // end-cell-construct
+
 Available implementations
 -------------------------
 
 QDK/Chemistry's ``HamiltonianConstructor`` provides a unified interface for Hamiltonian construction methods.
 You can discover available implementations programmatically:
-
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/hamiltonian_constructor.cpp
-      :language: cpp
-      :start-after: // start-cell-list-implementations
-      :end-before: // end-cell-list-implementations
 
 .. tab:: Python API
 
@@ -102,6 +95,13 @@ You can discover available implementations programmatically:
       :language: python
       :start-after: # start-cell-list-implementations
       :end-before: # end-cell-list-implementations
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/hamiltonian_constructor.cpp
+      :language: cpp
+      :start-after: // start-cell-list-implementations
+      :end-before: // end-cell-list-implementations
 
 QDK (Native)
 ~~~~~~~~~~~~

--- a/docs/source/user/comprehensive/algorithms/index.rst
+++ b/docs/source/user/comprehensive/algorithms/index.rst
@@ -116,18 +116,18 @@ Discovering implementations
 Each algorithm class exposes multiple implementations that can be discovered at runtime.
 Use ``available()`` to list registered implementations:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/interfaces.cpp
-      :language: cpp
-      :start-after: // start-cell-discover-implementations
-      :end-before: // end-cell-discover-implementations
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/interfaces.py
       :language: python
       :start-after: # start-cell-discover-implementations
       :end-before: # end-cell-discover-implementations
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/interfaces.cpp
+      :language: cpp
+      :start-after: // start-cell-discover-implementations
+      :end-before: // end-cell-discover-implementations
 
 For details on creating, loading, and using custom algorithm implementations, see the :doc:`plugin system <../plugins>` and :doc:`factory pattern <factory_pattern>` documentation.

--- a/docs/source/user/comprehensive/algorithms/localizer.rst
+++ b/docs/source/user/comprehensive/algorithms/localizer.rst
@@ -51,13 +51,6 @@ Beta orbital indices (``loc_indices_b``)
 
 .. rubric:: Creating a localizer
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/localizer.cpp
-      :language: cpp
-      :start-after: // start-cell-create
-      :end-before: // end-cell-create
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/localizer.py
@@ -65,17 +58,17 @@ Beta orbital indices (``loc_indices_b``)
       :start-after: # start-cell-create
       :end-before: # end-cell-create
 
-.. rubric:: Configuring settings
-
-Settings can be modified using the ``settings()`` object.
-See `Available implementations`_ below for implementation-specific options.
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/localizer.cpp
       :language: cpp
-      :start-after: // start-cell-configure
-      :end-before: // end-cell-configure
+      :start-after: // start-cell-create
+      :end-before: // end-cell-create
+
+.. rubric:: Configuring settings
+
+Settings can be modified using the ``settings()`` object.
+See `Available implementations`_ below for implementation-specific options.
 
 .. tab:: Python API
 
@@ -84,17 +77,17 @@ See `Available implementations`_ below for implementation-specific options.
       :start-after: # start-cell-configure
       :end-before: # end-cell-configure
 
-.. rubric:: Running localization
-
-.. note::
-   For restricted calculations, ``loc_indices_a`` and ``loc_indices_b`` must be identical.
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/localizer.cpp
       :language: cpp
-      :start-after: // start-cell-localize
-      :end-before: // end-cell-localize
+      :start-after: // start-cell-configure
+      :end-before: // end-cell-configure
+
+.. rubric:: Running localization
+
+.. note::
+   For restricted calculations, ``loc_indices_a`` and ``loc_indices_b`` must be identical.
 
 .. tab:: Python API
 
@@ -103,18 +96,18 @@ See `Available implementations`_ below for implementation-specific options.
       :start-after: # start-cell-localize
       :end-before: # end-cell-localize
 
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/localizer.cpp
+      :language: cpp
+      :start-after: // start-cell-localize
+      :end-before: // end-cell-localize
+
 Available implementations
 -------------------------
 
 QDK/Chemistry's :class:`~qdk_chemistry.algorithms.OrbitalLocalizer` provides a unified interface to orbital localization methods.
 You can discover available implementations programmatically:
-
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/localizer.cpp
-      :language: cpp
-      :start-after: // start-cell-list-implementations
-      :end-before: // end-cell-list-implementations
 
 .. tab:: Python API
 
@@ -122,6 +115,13 @@ You can discover available implementations programmatically:
       :language: python
       :start-after: # start-cell-list-implementations
       :end-before: # end-cell-list-implementations
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/localizer.cpp
+      :language: cpp
+      :start-after: // start-cell-list-implementations
+      :end-before: // end-cell-list-implementations
 
 .. _localizer-qdk-pipek-mezey:
 

--- a/docs/source/user/comprehensive/algorithms/mc_calculator.rst
+++ b/docs/source/user/comprehensive/algorithms/mc_calculator.rst
@@ -37,13 +37,6 @@ Number of beta electrons
 
 .. rubric:: Creating an MC calculator
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/mc_calculator.cpp
-      :language: cpp
-      :start-after: // start-cell-create
-      :end-before: // end-cell-create
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/mc_calculator.py
@@ -51,17 +44,17 @@ Number of beta electrons
       :start-after: # start-cell-create
       :end-before: # end-cell-create
 
-.. rubric:: Configuring settings
-
-Settings can be modified using the ``settings()`` object.
-See `Available implementations`_ below for implementation-specific options.
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/mc_calculator.cpp
       :language: cpp
-      :start-after: // start-cell-configure
-      :end-before: // end-cell-configure
+      :start-after: // start-cell-create
+      :end-before: // end-cell-create
+
+.. rubric:: Configuring settings
+
+Settings can be modified using the ``settings()`` object.
+See `Available implementations`_ below for implementation-specific options.
 
 .. tab:: Python API
 
@@ -70,14 +63,14 @@ See `Available implementations`_ below for implementation-specific options.
       :start-after: # start-cell-configure
       :end-before: # end-cell-configure
 
-.. rubric:: Running the calculation
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/mc_calculator.cpp
       :language: cpp
-      :start-after: // start-cell-run
-      :end-before: // end-cell-run
+      :start-after: // start-cell-configure
+      :end-before: // end-cell-configure
+
+.. rubric:: Running the calculation
 
 .. tab:: Python API
 
@@ -85,6 +78,13 @@ See `Available implementations`_ below for implementation-specific options.
       :language: python
       :start-after: # start-cell-run
       :end-before: # end-cell-run
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/mc_calculator.cpp
+      :language: cpp
+      :start-after: // start-cell-run
+      :end-before: // end-cell-run
 
 Available settings
 ------------------
@@ -129,19 +129,19 @@ Available implementations
 QDK/Chemistry's :class:`~qdk_chemistry.algorithms.MultiConfigurationCalculator` provides a unified interface for multi-configurational calculations.
 You can discover available implementations programmatically:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/mc_calculator.cpp
-      :language: cpp
-      :start-after: // start-cell-list-implementations
-      :end-before: // end-cell-list-implementations
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/mc_calculator.py
       :language: python
       :start-after: # start-cell-list-implementations
       :end-before: # end-cell-list-implementations
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/mc_calculator.cpp
+      :language: cpp
+      :start-after: // start-cell-list-implementations
+      :end-before: // end-cell-list-implementations
 
 MACIS CAS
 ~~~~~~~~~

--- a/docs/source/user/comprehensive/algorithms/pmc.rst
+++ b/docs/source/user/comprehensive/algorithms/pmc.rst
@@ -36,13 +36,6 @@ Configurations
 
 .. rubric:: Creating a PMC calculator
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/pmc.cpp
-      :language: cpp
-      :start-after: // start-cell-create
-      :end-before: // end-cell-create
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/pmc.py
@@ -50,17 +43,17 @@ Configurations
       :start-after: # start-cell-create
       :end-before: # end-cell-create
 
-.. rubric:: Configuring settings
-
-Settings can be modified using the ``settings()`` object.
-See `Available implementations`_ below for implementation-specific options.
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/pmc.cpp
       :language: cpp
-      :start-after: // start-cell-configure
-      :end-before: // end-cell-configure
+      :start-after: // start-cell-create
+      :end-before: // end-cell-create
+
+.. rubric:: Configuring settings
+
+Settings can be modified using the ``settings()`` object.
+See `Available implementations`_ below for implementation-specific options.
 
 .. tab:: Python API
 
@@ -69,14 +62,14 @@ See `Available implementations`_ below for implementation-specific options.
       :start-after: # start-cell-configure
       :end-before: # end-cell-configure
 
-.. rubric:: Running the calculation
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/pmc.cpp
       :language: cpp
-      :start-after: // start-cell-run
-      :end-before: // end-cell-run
+      :start-after: // start-cell-configure
+      :end-before: // end-cell-configure
+
+.. rubric:: Running the calculation
 
 .. tab:: Python API
 
@@ -84,6 +77,13 @@ See `Available implementations`_ below for implementation-specific options.
       :language: python
       :start-after: # start-cell-run
       :end-before: # end-cell-run
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/pmc.cpp
+      :language: cpp
+      :start-after: // start-cell-run
+      :end-before: // end-cell-run
 
 Available settings
 ------------------
@@ -128,19 +128,19 @@ Available implementations
 QDK/Chemistry's :class:`~qdk_chemistry.algorithms.ProjectedMultiConfigurationCalculator` provides a unified interface for projected multi-configurational calculations.
 You can discover available implementations programmatically:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/pmc.cpp
-      :language: cpp
-      :start-after: // start-cell-list-implementations
-      :end-before: // end-cell-list-implementations
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/pmc.py
       :language: python
       :start-after: # start-cell-list-implementations
       :end-before: # end-cell-list-implementations
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/pmc.cpp
+      :language: cpp
+      :start-after: // start-cell-list-implementations
+      :end-before: // end-cell-list-implementations
 
 MACIS PMC
 ~~~~~~~~~

--- a/docs/source/user/comprehensive/algorithms/scf_solver.rst
+++ b/docs/source/user/comprehensive/algorithms/scf_solver.rst
@@ -52,13 +52,6 @@ Basis set or initial guess
 
 .. rubric:: Creating a :term:`SCF` solver
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/scf_solver.cpp
-      :language: cpp
-      :start-after: // start-cell-create
-      :end-before: // end-cell-create
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/scf_solver.py
@@ -66,17 +59,17 @@ Basis set or initial guess
       :start-after: # start-cell-create
       :end-before: # end-cell-create
 
-.. rubric:: Configuring settings
-
-Settings can be modified using the ``settings()`` object.
-See `Available settings`_ below for a complete list of options.
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/scf_solver.cpp
       :language: cpp
-      :start-after: // start-cell-configure
-      :end-before: // end-cell-configure
+      :start-after: // start-cell-create
+      :end-before: // end-cell-create
+
+.. rubric:: Configuring settings
+
+Settings can be modified using the ``settings()`` object.
+See `Available settings`_ below for a complete list of options.
 
 .. tab:: Python API
 
@@ -85,14 +78,14 @@ See `Available settings`_ below for a complete list of options.
       :start-after: # start-cell-configure
       :end-before: # end-cell-configure
 
-.. rubric:: Running the calculation
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/scf_solver.cpp
       :language: cpp
-      :start-after: // start-cell-run
-      :end-before: // end-cell-run
+      :start-after: // start-cell-configure
+      :end-before: // end-cell-configure
+
+.. rubric:: Running the calculation
 
 .. tab:: Python API
 
@@ -101,16 +94,16 @@ See `Available settings`_ below for a complete list of options.
       :start-after: # start-cell-run
       :end-before: # end-cell-run
 
-.. rubric:: Alternative run options
-
-The ``run`` method also accepts either :doc:`Orbitals <../data/orbitals>` as an initial guess or a :doc:`BasisSet <../data/basis_set>` object.
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/scf_solver.cpp
       :language: cpp
-      :start-after: // start-cell-alternative-run
-      :end-before: // end-cell-alternative-run
+      :start-after: // start-cell-run
+      :end-before: // end-cell-run
+
+.. rubric:: Alternative run options
+
+The ``run`` method also accepts either :doc:`Orbitals <../data/orbitals>` as an initial guess or a :doc:`BasisSet <../data/basis_set>` object.
 
 .. tab:: Python API
 
@@ -118,6 +111,13 @@ The ``run`` method also accepts either :doc:`Orbitals <../data/orbitals>` as an 
       :language: python
       :start-after: # start-cell-alternative-run
       :end-before: # end-cell-alternative-run
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/scf_solver.cpp
+      :language: cpp
+      :start-after: // start-cell-alternative-run
+      :end-before: // end-cell-alternative-run
 
 
 Available settings
@@ -155,19 +155,19 @@ Available implementations
 QDK/Chemistry's :class:`~qdk_chemistry.algorithms.ScfSolver` provides a unified interface to :term:`SCF` calculations across various quantum chemistry packages.
 You can discover available implementations programmatically:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/scf_solver.cpp
-      :language: cpp
-      :start-after: // start-cell-list-implementations
-      :end-before: // end-cell-list-implementations
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/scf_solver.py
       :language: python
       :start-after: # start-cell-list-implementations
       :end-before: # end-cell-list-implementations
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/scf_solver.cpp
+      :language: cpp
+      :start-after: // start-cell-list-implementations
+      :end-before: // end-cell-list-implementations
 
 .. _qdk-scf-native:
 

--- a/docs/source/user/comprehensive/algorithms/settings.rst
+++ b/docs/source/user/comprehensive/algorithms/settings.rst
@@ -22,19 +22,19 @@ Runtime inspection
 
 The following example demonstrates how to discover available algorithms and inspect their settings:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/settings.cpp
-      :language: cpp
-      :start-after: // start-cell-discover-settings
-      :end-before: // end-cell-discover-settings
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/settings.py
       :language: python
       :start-after: # start-cell-discover-settings
       :end-before: # end-cell-discover-settings
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/settings.cpp
+      :language: cpp
+      :start-after: // start-cell-discover-settings
+      :end-before: // end-cell-discover-settings
 
 Working with settings
 ---------------------
@@ -57,18 +57,6 @@ Settings are validated at execution time, allowing modifications at any point be
 
 .. rubric:: Accessing and modifying settings
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/settings.cpp
-      :language: cpp
-      :start-after: // start-cell-get-settings
-      :end-before: // end-cell-get-settings
-
-   .. literalinclude:: ../../../_static/examples/cpp/settings.cpp
-      :language: cpp
-      :start-after: // start-cell-set-settings
-      :end-before: // end-cell-set-settings
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/settings.py
@@ -80,6 +68,18 @@ Settings are validated at execution time, allowing modifications at any point be
       :language: python
       :start-after: # start-cell-set-settings
       :end-before: # end-cell-set-settings
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/settings.cpp
+      :language: cpp
+      :start-after: // start-cell-get-settings
+      :end-before: // end-cell-get-settings
+
+   .. literalinclude:: ../../../_static/examples/cpp/settings.cpp
+      :language: cpp
+      :start-after: // start-cell-set-settings
+      :end-before: // end-cell-set-settings
 
 .. rubric:: Passing settings at creation time (Python only)
 
@@ -99,13 +99,6 @@ The C++ API does not provide this shorthand; settings must be configured explici
 The :class:`~qdk_chemistry.data.Settings` class provides methods for safely checking and retrieving values.
 Use ``has()`` to verify existence, ``get()`` for direct access (raises an exception if the key is missing), or ``get_or_default()`` to specify a fallback value.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/settings.cpp
-      :language: cpp
-      :start-after: // start-cell-misc-settings
-      :end-before: // end-cell-misc-settings
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/settings.py
@@ -113,18 +106,18 @@ Use ``has()`` to verify existence, ``get()`` for direct access (raises an except
       :start-after: # start-cell-misc-settings
       :end-before: # end-cell-misc-settings
 
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/settings.cpp
+      :language: cpp
+      :start-after: // start-cell-misc-settings
+      :end-before: // end-cell-misc-settings
+
 Serialization
 -------------
 
 Settings can be serialized to JSON (human-readable) or HDF5 (efficient, type-preserving) formats to support reproducibility and configuration sharing.
 For additional information on data persistence, see :doc:`Serialization <../data/serialization>`.
-
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/settings.cpp
-      :language: cpp
-      :start-after: // start-cell-serialization
-      :end-before: // end-cell-serialization
 
 .. tab:: Python API
 
@@ -132,6 +125,13 @@ For additional information on data persistence, see :doc:`Serialization <../data
       :language: python
       :start-after: # start-cell-serialization
       :end-before: # end-cell-serialization
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/settings.cpp
+      :language: cpp
+      :start-after: // start-cell-serialization
+      :end-before: // end-cell-serialization
 
 .. rubric:: Example formats
 
@@ -161,19 +161,19 @@ Algorithm developers can create specialized settings classes by extending :class
 Default values are established during construction using the ``set_default`` method, ensuring that configurations are discoverable and well-documented.
 This pattern integrates with the :doc:`Factory Pattern <factory_pattern>` and :ref:`plugin system <plugin-system>`.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/settings.cpp
-      :language: cpp
-      :start-after: // start-cell-extend-settings
-      :end-before: // end-cell-extend-settings
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/settings.py
       :language: python
       :start-after: # start-cell-extend-settings
       :end-before: # end-cell-extend-settings
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/settings.cpp
+      :language: cpp
+      :start-after: // start-cell-extend-settings
+      :end-before: // end-cell-extend-settings
 
 Supported types
 ---------------
@@ -252,19 +252,19 @@ Constraints are established when algorithm developers define settings using ``se
 
 Constraints can be queried using ``has_limits()`` and ``get_limits()``:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/settings.cpp
-      :language: cpp
-      :start-after: // start-cell-inspect-constraints
-      :end-before: // end-cell-inspect-constraints
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/settings.py
       :language: python
       :start-after: # start-cell-inspect-constraints
       :end-before: # end-cell-inspect-constraints
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/settings.cpp
+      :language: cpp
+      :start-after: // start-cell-inspect-constraints
+      :end-before: // end-cell-inspect-constraints
 
 The ``print_settings()`` and ``inspect_settings()`` functions include constraint information in their output, making it easy to understand the valid configuration options for any algorithm.
 
@@ -277,19 +277,19 @@ The :class:`~qdk_chemistry.data.Settings` class raises descriptive exceptions to
 - ``SettingTypeMismatch``: Raised when the key exists but the requested type does not match the stored type.
 - ``SettingsAreLocked``: Raised when attempting to modify settings after ``run()`` has been called.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/settings.cpp
-      :language: cpp
-      :start-after: // start-cell-settings-errors
-      :end-before: // end-cell-settings-errors
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/settings.py
       :language: python
       :start-after: # start-cell-settings-errors
       :end-before: # end-cell-settings-errors
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/settings.cpp
+      :language: cpp
+      :start-after: // start-cell-settings-errors
+      :end-before: // end-cell-settings-errors
 
 See also
 --------

--- a/docs/source/user/comprehensive/algorithms/stability_checker.rst
+++ b/docs/source/user/comprehensive/algorithms/stability_checker.rst
@@ -55,13 +55,6 @@ Wavefunction
 
 .. rubric:: Creating a stability checker
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/stability_checker_workflow.cpp
-      :language: cpp
-      :start-after: // start-cell-create
-      :end-before: // end-cell-create
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/stability_checker_workflow.py
@@ -69,18 +62,18 @@ Wavefunction
       :start-after: # start-cell-create
       :end-before: # end-cell-create
 
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/stability_checker_workflow.cpp
+      :language: cpp
+      :start-after: // start-cell-create
+      :end-before: // end-cell-create
+
 .. rubric:: Configuring settings
 
 Settings can be modified using the ``settings()`` object.
 See `Available settings`_ below for a complete list of options.
 Key settings include whether to perform internal and external stability checks, and the tolerance for determining stability.
-
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/stability_checker_workflow.cpp
-      :language: cpp
-      :start-after: // start-cell-configure
-      :end-before: // end-cell-configure
 
 .. tab:: Python API
 
@@ -88,6 +81,13 @@ Key settings include whether to perform internal and external stability checks, 
       :language: python
       :start-after: # start-cell-configure
       :end-before: # end-cell-configure
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/stability_checker_workflow.cpp
+      :language: cpp
+      :start-after: // start-cell-configure
+      :end-before: // end-cell-configure
 
 .. rubric:: Running the stability check and iterative workflow
 
@@ -97,19 +97,19 @@ This includes running an initial :term:`SCF` calculation, checking stability, an
 The workflow handles both internal instabilities (requiring orbital rotation within the same calculation type) and external instabilities (requiring a switch from restricted to unrestricted calculation).
 Note that the Davidson eigenvalue solver used in stability analysis may occasionally fail to converge; when this occurs, increasing ``max_subspace`` or adjusting ``davidson_tolerance`` can help.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/stability_checker_workflow.cpp
-      :language: cpp
-      :start-after: // start-cell-run
-      :end-before: // end-cell-run
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/stability_checker_workflow.py
       :language: python
       :start-after: # start-cell-run
       :end-before: # end-cell-run
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/stability_checker_workflow.cpp
+      :language: cpp
+      :start-after: // start-cell-run
+      :end-before: // end-cell-run
 
 
 Available settings
@@ -159,19 +159,19 @@ Available implementations
 QDK/Chemistry's :class:`~qdk_chemistry.algorithms.StabilityChecker` provides a unified interface to stability analysis across various quantum chemistry packages.
 You can discover available implementations programmatically:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/stability_checker_workflow.cpp
-      :language: cpp
-      :start-after: // start-cell-list-implementations
-      :end-before: // end-cell-list-implementations
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/stability_checker_workflow.py
       :language: python
       :start-after: # start-cell-list-implementations
       :end-before: # end-cell-list-implementations
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/stability_checker_workflow.cpp
+      :language: cpp
+      :start-after: // start-cell-list-implementations
+      :end-before: // end-cell-list-implementations
 
 .. _qdk-stability-native:
 

--- a/docs/source/user/comprehensive/data/ansatz.rst
+++ b/docs/source/user/comprehensive/data/ansatz.rst
@@ -31,13 +31,6 @@ Creating an ansatz
 
 An :class:`~qdk_chemistry.data.Ansatz` object can be created from existing Hamiltonian and Wavefunction objects:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/ansatz.cpp
-      :language: cpp
-      :start-after: // start-cell-create
-      :end-before: // end-cell-create
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/ansatz.py
@@ -45,17 +38,17 @@ An :class:`~qdk_chemistry.data.Ansatz` object can be created from existing Hamil
       :start-after: # start-cell-create
       :end-before: # end-cell-create
 
-Accessing ansatz data
----------------------
-
-The :class:`~qdk_chemistry.data.Ansatz` class provides methods to access its components and perform calculations:
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/ansatz.cpp
       :language: cpp
-      :start-after: // start-cell-access
-      :end-before: // end-cell-access
+      :start-after: // start-cell-create
+      :end-before: // end-cell-create
+
+Accessing ansatz data
+---------------------
+
+The :class:`~qdk_chemistry.data.Ansatz` class provides methods to access its components and perform calculations:
 
 .. tab:: Python API
 
@@ -63,6 +56,13 @@ The :class:`~qdk_chemistry.data.Ansatz` class provides methods to access its com
       :language: python
       :start-after: # start-cell-access
       :end-before: # end-cell-access
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/ansatz.cpp
+      :language: cpp
+      :start-after: // start-cell-access
+      :end-before: // end-cell-access
 
 
 Further reading

--- a/docs/source/user/comprehensive/data/basis_set.rst
+++ b/docs/source/user/comprehensive/data/basis_set.rst
@@ -81,19 +81,19 @@ The library supports three methods for loading basis sets:
 .. note::
    If a basis set includes an :term:`ECP` (Effective Core Potential), it will be automatically loaded. ECPs are commonly used to replace core electrons with pseudopotentials, particularly for heavy atoms.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/basis_set.cpp
-      :language: cpp
-      :start-after: // start-cell-loading
-      :end-before: // end-cell-loading
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/basis_set.py
       :language: python
       :start-after: # start-cell-loading
       :end-before: # end-cell-loading
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/basis_set.cpp
+      :language: cpp
+      :start-after: // start-cell-loading
+      :end-before: // end-cell-loading
 
 .. seealso::
    For a complete list of available basis sets, see the :doc:`Supported Basis Sets <../basis_functionals>` documentation.
@@ -105,19 +105,19 @@ Creating a basis set
    In most cases, you should use the built-in basis set library rather than creating basis sets manually.
    Manual creation is primarily for advanced use cases or when working with custom basis sets not available in the library.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/basis_set.cpp
-      :language: cpp
-      :start-after: // start-cell-create
-      :end-before: // end-cell-create
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/basis_set.py
       :language: python
       :start-after: # start-cell-create
       :end-before: # end-cell-create
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/basis_set.cpp
+      :language: cpp
+      :start-after: // start-cell-create
+      :end-before: // end-cell-create
 
 Accessing basis set data
 ------------------------
@@ -129,13 +129,6 @@ This ensures that the basis set data remains consistent and prevents accidental 
    If you need to modify a basis set after creation, you should create a new BasisSet object with the desired
    changes rather than trying to modify an existing one.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/basis_set.cpp
-      :language: cpp
-      :start-after: // start-cell-access
-      :end-before: // end-cell-access
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/basis_set.py
@@ -143,17 +136,17 @@ This ensures that the basis set data remains consistent and prevents accidental 
       :start-after: # start-cell-access
       :end-before: # end-cell-access
 
-Working with shells
--------------------
-
-The ``Shell`` structure contains information about a group of basis functions:
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/basis_set.cpp
       :language: cpp
-      :start-after: // start-cell-shells
-      :end-before: // end-cell-shells
+      :start-after: // start-cell-access
+      :end-before: // end-cell-access
+
+Working with shells
+-------------------
+
+The ``Shell`` structure contains information about a group of basis functions:
 
 .. tab:: Python API
 
@@ -161,6 +154,13 @@ The ``Shell`` structure contains information about a group of basis functions:
       :language: python
       :start-after: # start-cell-shells
       :end-before: # end-cell-shells
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/basis_set.cpp
+      :language: cpp
+      :start-after: // start-cell-shells
+      :end-before: // end-cell-shells
 
 Serialization
 -------------
@@ -230,13 +230,6 @@ HDF5 representation of a :class:`~qdk_chemistry.data.BasisSet` has the following
    └── metadata/           # Group
        └── name            # Attribute: string value of the basis set name
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/basis_set.cpp
-      :language: cpp
-      :start-after: // start-cell-serialization
-      :end-before: // end-cell-serialization
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/basis_set.py
@@ -244,17 +237,17 @@ HDF5 representation of a :class:`~qdk_chemistry.data.BasisSet` has the following
       :start-after: # start-cell-serialization
       :end-before: # end-cell-serialization
 
-Utility functions
------------------
-
-The :class:`~qdk_chemistry.data.BasisSet` class provides several static utility functions:
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/basis_set.cpp
       :language: cpp
-      :start-after: // start-cell-utility-functions
-      :end-before: // end-cell-utility-functions
+      :start-after: // start-cell-serialization
+      :end-before: // end-cell-serialization
+
+Utility functions
+-----------------
+
+The :class:`~qdk_chemistry.data.BasisSet` class provides several static utility functions:
 
 .. tab:: Python API
 
@@ -263,6 +256,13 @@ The :class:`~qdk_chemistry.data.BasisSet` class provides several static utility 
       :start-after: # start-cell-utility-functions
       :end-before: # end-cell-utility-functions
 
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/basis_set.cpp
+      :language: cpp
+      :start-after: // start-cell-utility-functions
+      :end-before: // end-cell-utility-functions
+
 Predefined basis sets
 ---------------------
 
@@ -270,19 +270,19 @@ QDK/Chemistry provides access to a library of standard basis sets commonly used 
 These predefined basis sets can be easily loaded without having to manually specify the basis functions.
 For a complete list of available basis sets and their specifications, see the :doc:`Supported Basis Sets <../basis_functionals>` documentation.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/basis_set.cpp
-      :language: cpp
-      :start-after: // start-cell-library
-      :end-before: // end-cell-library
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/basis_set.py
       :language: python
       :start-after: # start-cell-library
       :end-before: # end-cell-library
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/basis_set.cpp
+      :language: cpp
+      :start-after: // start-cell-library
+      :end-before: // end-cell-library
 
 .. note::
    The basis set library includes popular basis sets such as :term:`STO`-nG, Pople basis sets (3-21G, 6-31G, etc.), correlation-consistent basis sets (cc-pVDZ, cc-pVTZ, etc.), and more.

--- a/docs/source/user/comprehensive/data/hamiltonian.rst
+++ b/docs/source/user/comprehensive/data/hamiltonian.rst
@@ -68,19 +68,19 @@ Creating a Hamiltonian object
 The :class:`~qdk_chemistry.data.Hamiltonian` object is typically created using the :doc:`HamiltonianConstructor <../algorithms/hamiltonian_constructor>` algorithm (recommended approach for molecular systems), the :doc:`model Hamiltonian <../model_hamiltonians>` builders (for lattice models such as Hubbard or PPP), or directly with the appropriate integral data.
 Once properly constructed with all required data, the Hamiltonian object should be considered constant and not modified:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/hamiltonian.cpp
-      :language: cpp
-      :start-after: // start-cell-hamiltonian-creation
-      :end-before: // end-cell-hamiltonian-creation
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/hamiltonian.py
       :language: python
       :start-after: # start-cell-hamiltonian-creation
       :end-before: # end-cell-hamiltonian-creation
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/hamiltonian.cpp
+      :language: cpp
+      :start-after: // start-cell-hamiltonian-creation
+      :end-before: // end-cell-hamiltonian-creation
 
 Accessing Hamiltonian data
 --------------------------
@@ -120,19 +120,19 @@ From a theoretical perspective, these symmetries can be expressed as:
 These permutational symmetries arise from the mathematical properties of the two-electron repulsion integrals.
 When accessing specific elements with ``get_two_body_element(i, j, k, l)``, the function handles the appropriate index mapping to retrieve the correct value based on the implementation's storage format.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/hamiltonian.cpp
-      :language: cpp
-      :start-after: // start-cell-properties
-      :end-before: // end-cell-properties
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/hamiltonian.py
       :language: python
       :start-after: # start-cell-properties
       :end-before: # end-cell-properties
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/hamiltonian.cpp
+      :language: cpp
+      :start-after: // start-cell-properties
+      :end-before: // end-cell-properties
 
 Serialization
 -------------
@@ -152,13 +152,6 @@ Validation methods
 
 The :class:`~qdk_chemistry.data.Hamiltonian` class provides methods to check the validity and consistency of its data:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/hamiltonian.cpp
-      :language: cpp
-      :start-after: // start-cell-validation
-      :end-before: // end-cell-validation
-
 .. tab:: Python API
 
    .. note::
@@ -168,6 +161,13 @@ The :class:`~qdk_chemistry.data.Hamiltonian` class provides methods to check the
       :language: python
       :start-after: # start-cell-validation
       :end-before: # end-cell-validation
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/hamiltonian.cpp
+      :language: cpp
+      :start-after: // start-cell-validation
+      :end-before: // end-cell-validation
 
 Related classes
 ---------------

--- a/docs/source/user/comprehensive/data/lattice_graph.rst
+++ b/docs/source/user/comprehensive/data/lattice_graph.rst
@@ -89,19 +89,19 @@ Setting ``periodic=True`` adds an edge between the first and last site to form a
    Ring (n=6):   0 --- 1 --- 2 --- 3 --- 4 --- 5
                  |_____________________________|
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/lattice_graph.cpp
-      :language: cpp
-      :start-after: // start-cell-create-chain
-      :end-before: // end-cell-create-chain
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/lattice_graph.py
       :language: python
       :start-after: # start-cell-create-chain
       :end-before: # end-cell-create-chain
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/lattice_graph.cpp
+      :language: cpp
+      :start-after: // start-cell-create-chain
+      :end-before: // end-cell-create-chain
 
 Two-dimensional lattices
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -185,13 +185,6 @@ With periodic boundary conditions, the inter-cell bonds that form the down-trian
    / \     / \      / \
   0---1---3---4----6---7
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/lattice_graph.cpp
-      :language: cpp
-      :start-after: // start-cell-create-2d
-      :end-before: // end-cell-create-2d
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/lattice_graph.py
@@ -199,17 +192,17 @@ With periodic boundary conditions, the inter-cell bonds that form the down-trian
       :start-after: # start-cell-create-2d
       :end-before: # end-cell-create-2d
 
-Creating from adjacency data
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For geometries not covered by the built-in methods, you can construct a :class:`~qdk_chemistry.data.LatticeGraph` from a dense adjacency matrix, a sparse adjacency matrix, or an edge-weight dictionary.
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/lattice_graph.cpp
       :language: cpp
-      :start-after: // start-cell-from-matrix
-      :end-before: // end-cell-from-matrix
+      :start-after: // start-cell-create-2d
+      :end-before: // end-cell-create-2d
+
+Creating from adjacency data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For geometries not covered by the built-in methods, you can construct a :class:`~qdk_chemistry.data.LatticeGraph` from a dense adjacency matrix, a sparse adjacency matrix, or an edge-weight dictionary.
 
 .. tab:: Python API
 
@@ -217,6 +210,13 @@ For geometries not covered by the built-in methods, you can construct a :class:`
       :language: python
       :start-after: # start-cell-from-matrix
       :end-before: # end-cell-from-matrix
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/lattice_graph.cpp
+      :language: cpp
+      :start-after: // start-cell-from-matrix
+      :end-before: // end-cell-from-matrix
 
 .. _lattice-periodic-boundary-conditions:
 
@@ -250,13 +250,6 @@ The ``~~~`` edges show the wrap-around connections that turn the open lattice in
      ~     ~     ~     ~
      8     9    10    11
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/lattice_graph.cpp
-      :language: cpp
-      :start-after: // start-cell-periodic
-      :end-before: // end-cell-periodic
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/lattice_graph.py
@@ -264,17 +257,17 @@ The ``~~~`` edges show the wrap-around connections that turn the open lattice in
       :start-after: # start-cell-periodic
       :end-before: # end-cell-periodic
 
-Accessing lattice data
-----------------------
-
-The :class:`~qdk_chemistry.data.LatticeGraph` class provides methods to query connectivity, edge weights, and structural properties.
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/lattice_graph.cpp
       :language: cpp
-      :start-after: // start-cell-properties
-      :end-before: // end-cell-properties
+      :start-after: // start-cell-periodic
+      :end-before: // end-cell-periodic
+
+Accessing lattice data
+----------------------
+
+The :class:`~qdk_chemistry.data.LatticeGraph` class provides methods to query connectivity, edge weights, and structural properties.
 
 .. tab:: Python API
 
@@ -282,6 +275,13 @@ The :class:`~qdk_chemistry.data.LatticeGraph` class provides methods to query co
       :language: python
       :start-after: # start-cell-properties
       :end-before: # end-cell-properties
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/lattice_graph.cpp
+      :language: cpp
+      :start-after: // start-cell-properties
+      :end-before: // end-cell-properties
 
 Serialization
 -------------
@@ -292,19 +292,19 @@ For detailed information about serialization in QDK/Chemistry, see the :doc:`Ser
 .. note::
    Lattice graph files use the ``.lattice_graph`` suffix before the file type extension, for example ``chain.lattice_graph.json`` and ``square.lattice_graph.hdf5``.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/lattice_graph.cpp
-      :language: cpp
-      :start-after: // start-cell-serialization
-      :end-before: // end-cell-serialization
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/lattice_graph.py
       :language: python
       :start-after: # start-cell-serialization
       :end-before: # end-cell-serialization
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/lattice_graph.cpp
+      :language: cpp
+      :start-after: // start-cell-serialization
+      :end-before: // end-cell-serialization
 
 Edge coloring
 -------------

--- a/docs/source/user/comprehensive/data/orbitals.rst
+++ b/docs/source/user/comprehensive/data/orbitals.rst
@@ -105,13 +105,6 @@ Hamiltonian Construction
 
 The below example illustrates the typical access to Orbitals (via a :term:`SCF`):
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/orbitals.cpp
-      :language: cpp
-      :start-after: // start-cell-create
-      :end-before: // end-cell-create
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/orbitals.py
@@ -119,14 +112,14 @@ The below example illustrates the typical access to Orbitals (via a :term:`SCF`)
       :start-after: # start-cell-create
       :end-before: # end-cell-create
 
-Similar patterns are described below for ModelOrbitals.
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/orbitals.cpp
       :language: cpp
-      :start-after: // start-cell-model-orbitals-create
-      :end-before: // end-cell-model-orbitals-create
+      :start-after: // start-cell-create
+      :end-before: // end-cell-create
+
+Similar patterns are described below for ModelOrbitals.
 
 .. tab:: Python API
 
@@ -135,6 +128,13 @@ Similar patterns are described below for ModelOrbitals.
       :start-after: # start-cell-model-orbitals-create
       :end-before: # end-cell-model-orbitals-create
 
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/orbitals.cpp
+      :language: cpp
+      :start-after: // start-cell-model-orbitals-create
+      :end-before: // end-cell-model-orbitals-create
+
 Accessing Orbital data
 ----------------------
 
@@ -142,19 +142,19 @@ The :class:`~qdk_chemistry.data.Orbitals` class provides methods to access orbit
 Following the :doc:`immutable design principle <../design/index>` used throughout QDK/Chemistry, all getter methods return const references or copies of the data.
 For spin-dependent properties, methods return pairs of (alpha, beta) data.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/orbitals.cpp
-      :language: cpp
-      :start-after: // start-cell-access
-      :end-before: // end-cell-access
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/orbitals.py
       :language: python
       :start-after: # start-cell-access
       :end-before: # end-cell-access
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/orbitals.cpp
+      :language: cpp
+      :start-after: // start-cell-access
+      :end-before: // end-cell-access
 
 
 Orbital transformations and applications

--- a/docs/source/user/comprehensive/data/pauli_operator.rst
+++ b/docs/source/user/comprehensive/data/pauli_operator.rst
@@ -9,13 +9,6 @@ Creating Operators
 
 Use factory methods to create Pauli operators on specific qubits:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/pauli_operator.cpp
-      :language: cpp
-      :start-after: // start-cell-creation
-      :end-before: // end-cell-creation
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/pauli_operator.py
@@ -23,17 +16,17 @@ Use factory methods to create Pauli operators on specific qubits:
       :start-after: # start-cell-creation
       :end-before: # end-cell-creation
 
-Building Expressions
---------------------
-
-Combine operators using arithmetic to build expressions:
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/pauli_operator.cpp
       :language: cpp
-      :start-after: // start-cell-expressions
-      :end-before: // end-cell-expressions
+      :start-after: // start-cell-creation
+      :end-before: // end-cell-creation
+
+Building Expressions
+--------------------
+
+Combine operators using arithmetic to build expressions:
 
 .. tab:: Python API
 
@@ -42,18 +35,18 @@ Combine operators using arithmetic to build expressions:
       :start-after: # start-cell-expressions
       :end-before: # end-cell-expressions
 
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/pauli_operator.cpp
+      :language: cpp
+      :start-after: // start-cell-expressions
+      :end-before: // end-cell-expressions
+
 Simplifying Expressions
 -----------------------
 
 The ``simplify()`` method applies Pauli algebra rules and combines like terms.
 The ``distribute()`` method expands products over sums.
-
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/pauli_operator.cpp
-      :language: cpp
-      :start-after: // start-cell-simplify
-      :end-before: // end-cell-simplify
 
 .. tab:: Python API
 
@@ -62,17 +55,17 @@ The ``distribute()`` method expands products over sums.
       :start-after: # start-cell-simplify
       :end-before: # end-cell-simplify
 
-Canonical Representation
-------------------------
-
-Use ``to_canonical_string()`` to get a circuit-compatible string format, or ``to_canonical_terms()`` to get coefficient-string pairs:
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/pauli_operator.cpp
       :language: cpp
-      :start-after: // start-cell-canonical
-      :end-before: // end-cell-canonical
+      :start-after: // start-cell-simplify
+      :end-before: // end-cell-simplify
+
+Canonical Representation
+------------------------
+
+Use ``to_canonical_string()`` to get a circuit-compatible string format, or ``to_canonical_terms()`` to get coefficient-string pairs:
 
 .. tab:: Python API
 
@@ -80,6 +73,13 @@ Use ``to_canonical_string()`` to get a circuit-compatible string format, or ``to
       :language: python
       :start-after: # start-cell-canonical
       :end-before: # end-cell-canonical
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/pauli_operator.cpp
+      :language: cpp
+      :start-after: // start-cell-canonical
+      :end-before: // end-cell-canonical
 
 Further Reading
 ---------------

--- a/docs/source/user/comprehensive/data/serialization.rst
+++ b/docs/source/user/comprehensive/data/serialization.rst
@@ -40,13 +40,6 @@ All QDK/Chemistry data classes implement a consistent serialization interface as
 JSON serialization
 ~~~~~~~~~~~~~~~~~~
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/serialization.cpp
-      :language: cpp
-      :start-after: // start-cell-json
-      :end-before: // end-cell-json
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/serialization.py
@@ -54,15 +47,15 @@ JSON serialization
       :start-after: # start-cell-json
       :end-before: # end-cell-json
 
-HDF5 serialization
-~~~~~~~~~~~~~~~~~~
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/serialization.cpp
       :language: cpp
-      :start-after: // start-cell-hdf5
-      :end-before: // end-cell-hdf5
+      :start-after: // start-cell-json
+      :end-before: // end-cell-json
+
+HDF5 serialization
+~~~~~~~~~~~~~~~~~~
 
 .. tab:: Python API
 
@@ -70,6 +63,13 @@ HDF5 serialization
       :language: python
       :start-after: # start-cell-hdf5
       :end-before: # end-cell-hdf5
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/serialization.cpp
+      :language: cpp
+      :start-after: // start-cell-hdf5
+      :end-before: // end-cell-hdf5
 
 File extensions
 ---------------

--- a/docs/source/user/comprehensive/data/structure.rst
+++ b/docs/source/user/comprehensive/data/structure.rst
@@ -46,19 +46,19 @@ Creating a structure object
 
 A :class:`~qdk_chemistry.data.Structure` object can be created by specifying coordinates explicitly (in Bohr):
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/structure.cpp
-      :language: cpp
-      :start-after: // start-cell-create
-      :end-before: // end-cell-create
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/structure.py
       :language: python
       :start-after: # start-cell-create
       :end-before: # end-cell-create
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/structure.cpp
+      :language: cpp
+      :start-after: // start-cell-create
+      :end-before: // end-cell-create
 
 Loading a structure from file
 -----------------------------
@@ -67,19 +67,19 @@ A :class:`~qdk_chemistry.data.Structure` object can also be loaded from a file.
 When loading from an XYZ file, coordinates are automatically converted from Angstrom to Bohr.
 When loading from a JSON file, coordinates are assumed to already be in Bohr.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/structure.cpp
-      :language: cpp
-      :start-after: // start-cell-from-file
-      :end-before: // end-cell-from-file
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/structure.py
       :language: python
       :start-after: # start-cell-from-file
       :end-before: # end-cell-from-file
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/structure.cpp
+      :language: cpp
+      :start-after: // start-cell-from-file
+      :end-before: // end-cell-from-file
 
 Accessing structure data
 ------------------------
@@ -90,19 +90,19 @@ Functions that deal with specific atoms include the word "atom" in their name (e
 All atomic data is const and immutable once set, following QDK/Chemistry's :doc:`immutable data pattern <../design/index>`.
 If you need to modify coordinates or other properties, you must create a new Structure object with the desired changes.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/structure.cpp
-      :language: cpp
-      :start-after: // start-cell-data
-      :end-before: // end-cell-data
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/structure.py
       :language: python
       :start-after: # start-cell-data
       :end-before: # end-cell-data
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/structure.cpp
+      :language: cpp
+      :start-after: // start-cell-data
+      :end-before: // end-cell-data
 
 Serialization
 -------------

--- a/docs/source/user/comprehensive/data/wavefunction.rst
+++ b/docs/source/user/comprehensive/data/wavefunction.rst
@@ -41,13 +41,6 @@ Slater determinant container
 
 Single-determinant wavefunctions (e.g., from Hartree-Fock calculations).
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/wavefunction_container.cpp
-      :language: cpp
-      :start-after: // start-cell-create-slater
-      :end-before: // end-cell-create-slater
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/wavefunction_container.py
@@ -55,17 +48,17 @@ Single-determinant wavefunctions (e.g., from Hartree-Fock calculations).
       :start-after: # start-cell-create-slater
       :end-before: # end-cell-create-slater
 
-SCI wavefunction container
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Sparse multi-determinant wavefunctions for Selected Configuration Interaction methods.
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/wavefunction_container.cpp
       :language: cpp
-      :start-after: // start-cell-create-sci
-      :end-before: // end-cell-create-sci
+      :start-after: // start-cell-create-slater
+      :end-before: // end-cell-create-slater
+
+SCI wavefunction container
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sparse multi-determinant wavefunctions for Selected Configuration Interaction methods.
 
 .. tab:: Python API
 
@@ -74,17 +67,17 @@ Sparse multi-determinant wavefunctions for Selected Configuration Interaction me
       :start-after: # start-cell-create-sci
       :end-before: # end-cell-create-sci
 
-CAS wavefunction container
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A multi-determinant wavefunction from Complete Active Space methods (:term:`CASSCF`/:term:`CASCI`).
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/wavefunction_container.cpp
       :language: cpp
-      :start-after: // start-cell-create-cas
-      :end-before: // end-cell-create-cas
+      :start-after: // start-cell-create-sci
+      :end-before: // end-cell-create-sci
+
+CAS wavefunction container
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A multi-determinant wavefunction from Complete Active Space methods (:term:`CASSCF`/:term:`CASCI`).
 
 .. tab:: Python API
 
@@ -92,6 +85,13 @@ A multi-determinant wavefunction from Complete Active Space methods (:term:`CASS
       :language: python
       :start-after: # start-cell-create-cas
       :end-before: # end-cell-create-cas
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/wavefunction_container.cpp
+      :language: cpp
+      :start-after: // start-cell-create-cas
+      :end-before: // end-cell-create-cas
 
 Amplitude wavefunction container
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -102,13 +102,6 @@ It is pure storage: the amplitudes are supplied by the producing algorithm and a
 
 The following example tags the amplitudes as :term:`MP2` (T1 is zero for MP2):
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/wavefunction_container.cpp
-      :language: cpp
-      :start-after: // start-cell-create-mp2
-      :end-before: // end-cell-create-mp2
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/wavefunction_container.py
@@ -116,14 +109,14 @@ The following example tags the amplitudes as :term:`MP2` (T1 is zero for MP2):
       :start-after: # start-cell-create-mp2
       :end-before: # end-cell-create-mp2
 
-The same container holds coupled cluster amplitudes when tagged as ``CCSD``:
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/wavefunction_container.cpp
       :language: cpp
-      :start-after: // start-cell-create-cc
-      :end-before: // end-cell-create-cc
+      :start-after: // start-cell-create-mp2
+      :end-before: // end-cell-create-mp2
+
+The same container holds coupled cluster amplitudes when tagged as ``CCSD``:
 
 .. tab:: Python API
 
@@ -131,6 +124,13 @@ The same container holds coupled cluster amplitudes when tagged as ``CCSD``:
       :language: python
       :start-after: # start-cell-create-cc
       :end-before: # end-cell-create-cc
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/wavefunction_container.cpp
+      :language: cpp
+      :start-after: // start-cell-create-cc
+      :end-before: // end-cell-create-cc
 
 Properties
 ~~~~~~~~~~
@@ -249,13 +249,6 @@ Accessing wavefunction data
 
 The :class:`~qdk_chemistry.data.Wavefunction` class provides methods to access coefficients, determinants, and derived properties:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/wavefunction_container.cpp
-      :language: cpp
-      :start-after: // start-cell-access-data
-      :end-before: // end-cell-access-data
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/wavefunction_container.py
@@ -263,17 +256,17 @@ The :class:`~qdk_chemistry.data.Wavefunction` class provides methods to access c
       :start-after: # start-cell-access-data
       :end-before: # end-cell-access-data
 
-Accessing cluster amplitudes
-----------------------------
-
-For :term:`MP2` and coupled cluster wavefunctions, one can access T1 and T2 cluster amplitudes.
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../../_static/examples/cpp/wavefunction_container.cpp
       :language: cpp
-      :start-after: // start-cell-access-amplitudes
-      :end-before: // end-cell-access-amplitudes
+      :start-after: // start-cell-access-data
+      :end-before: // end-cell-access-data
+
+Accessing cluster amplitudes
+----------------------------
+
+For :term:`MP2` and coupled cluster wavefunctions, one can access T1 and T2 cluster amplitudes.
 
 .. tab:: Python API
 
@@ -281,6 +274,13 @@ For :term:`MP2` and coupled cluster wavefunctions, one can access T1 and T2 clus
       :language: python
       :start-after: # start-cell-access-amplitudes
       :end-before: # end-cell-access-amplitudes
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/wavefunction_container.cpp
+      :language: cpp
+      :start-after: // start-cell-access-amplitudes
+      :end-before: // end-cell-access-amplitudes
 
 Related classes
 ---------------

--- a/docs/source/user/comprehensive/design/index.rst
+++ b/docs/source/user/comprehensive/design/index.rst
@@ -81,19 +81,19 @@ Factory pattern
 
 QDK/Chemistry's :doc:`plugin architecture <../plugins>` leverages a :doc:`factory pattern <../algorithms/factory_pattern>` for algorithm creation:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/design_principles.cpp
-      :language: cpp
-      :start-after: // start-cell-scf-create
-      :end-before: // end-cell-scf-create
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/design_principles.py
       :language: python
       :start-after: # start-cell-scf-create
       :end-before: # end-cell-scf-create
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/design_principles.cpp
+      :language: cpp
+      :start-after: // start-cell-scf-create
+      :end-before: // end-cell-scf-create
 
 This pattern allows:
 
@@ -109,19 +109,19 @@ Runtime configuration with settings
 
 Algorithm configuration is managed through instances of :doc:`Settings <../algorithms/settings>` objects, which contain a type-safe data store of configuration parameters consistent between the python and C++ APIs:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/design_principles.cpp
-      :language: cpp
-      :start-after: // start-cell-scf-settings
-      :end-before: // end-cell-scf-settings
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/design_principles.py
       :language: python
       :start-after: # start-cell-scf-settings
       :end-before: # end-cell-scf-settings
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/design_principles.cpp
+      :language: cpp
+      :start-after: // start-cell-scf-settings
+      :end-before: // end-cell-scf-settings
 
 Read more on how one can configure, discover, and extend instances of Settings objects in the
 :doc:`Settings <../algorithms/settings>` documentation.
@@ -133,19 +133,19 @@ A complete dataflow example
 
 A typical workflow in QDK/Chemistry demonstrates the data-algorithm separation:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../../_static/examples/cpp/design_principles.cpp
-      :language: cpp
-      :start-after: // start-cell-data-flow
-      :end-before: // end-cell-data-flow
-
 .. tab:: Python API
 
    .. literalinclude:: ../../../_static/examples/python/design_principles.py
       :language: python
       :start-after: # start-cell-data-flow
       :end-before: # end-cell-data-flow
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../../_static/examples/cpp/design_principles.cpp
+      :language: cpp
+      :start-after: // start-cell-data-flow
+      :end-before: // end-cell-data-flow
 
 Further reading
 ===============

--- a/docs/source/user/comprehensive/model_hamiltonians.rst
+++ b/docs/source/user/comprehensive/model_hamiltonians.rst
@@ -75,19 +75,19 @@ The Hückel (tight-binding) model describes non-interacting electrons hopping on
 where :math:`\hat{a}_i^\dagger` and :math:`\hat{a}_i` are the fermionic creation and annihilation operators for site *i*, :math:`\hat{n}_i = \sum_\sigma \hat{a}_{i,\sigma}^\dagger \hat{a}_{i,\sigma}` is the number operator, :math:`\varepsilon_i` are on-site energies, :math:`t_{ij}` are hopping integrals, :math:`w_{ij}` is the edge weight from the lattice adjacency matrix, and the sum runs over connected site pairs.
 This model produces a :doc:`Hamiltonian <data/hamiltonian>` with one-body integrals only.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../_static/examples/cpp/model_hamiltonians.cpp
-      :language: cpp
-      :start-after: // start-cell-create-huckel
-      :end-before: // end-cell-create-huckel
-
 .. tab:: Python API
 
    .. literalinclude:: ../../_static/examples/python/model_hamiltonians.py
       :language: python
       :start-after: # start-cell-create-huckel
       :end-before: # end-cell-create-huckel
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../_static/examples/cpp/model_hamiltonians.cpp
+      :language: cpp
+      :start-after: // start-cell-create-huckel
+      :end-before: // end-cell-create-huckel
 
 .. _model-hubbard:
 
@@ -103,13 +103,6 @@ The Hubbard model extends the Hückel model with on-site Coulomb repulsion:
 where :math:`U_i` is the on-site repulsion strength.
 This model produces a :doc:`Hamiltonian <data/hamiltonian>` with both one-body and two-body integrals.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../_static/examples/cpp/model_hamiltonians.cpp
-      :language: cpp
-      :start-after: // start-cell-create-hubbard
-      :end-before: // end-cell-create-hubbard
-
 .. tab:: Python API
 
    .. literalinclude:: ../../_static/examples/python/model_hamiltonians.py
@@ -117,14 +110,14 @@ This model produces a :doc:`Hamiltonian <data/hamiltonian>` with both one-body a
       :start-after: # start-cell-create-hubbard
       :end-before: # end-cell-create-hubbard
 
-The Hubbard model naturally extends to 2D lattices for studying strongly correlated materials:
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../_static/examples/cpp/model_hamiltonians.cpp
       :language: cpp
-      :start-after: // start-cell-create-hubbard-2d
-      :end-before: // end-cell-create-hubbard-2d
+      :start-after: // start-cell-create-hubbard
+      :end-before: // end-cell-create-hubbard
+
+The Hubbard model naturally extends to 2D lattices for studying strongly correlated materials:
 
 .. tab:: Python API
 
@@ -132,6 +125,13 @@ The Hubbard model naturally extends to 2D lattices for studying strongly correla
       :language: python
       :start-after: # start-cell-create-hubbard-2d
       :end-before: # end-cell-create-hubbard-2d
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../_static/examples/cpp/model_hamiltonians.cpp
+      :language: cpp
+      :start-after: // start-cell-create-hubbard-2d
+      :end-before: // end-cell-create-hubbard-2d
 
 .. _model-ppp:
 
@@ -152,19 +152,19 @@ The intersite potential :math:`V_{ij}` is typically computed using the Ohno or M
    The stored two-body integrals do **not** include the :math:`\frac{1}{2}` prefactor.
    This follows the standard quantum chemistry convention where the factor is applied at contraction time rather than stored in the integrals.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../_static/examples/cpp/model_hamiltonians.cpp
-      :language: cpp
-      :start-after: // start-cell-create-ppp
-      :end-before: // end-cell-create-ppp
-
 .. tab:: Python API
 
    .. literalinclude:: ../../_static/examples/python/model_hamiltonians.py
       :language: python
       :start-after: # start-cell-create-ppp
       :end-before: # end-cell-create-ppp
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../_static/examples/cpp/model_hamiltonians.cpp
+      :language: cpp
+      :start-after: // start-cell-create-ppp
+      :end-before: // end-cell-create-ppp
 
 .. _intersite-potentials:
 
@@ -199,19 +199,19 @@ Custom pairwise potential
 
 The ``pairwise_potential`` function accepts a user-defined callable ``func(i, j, U_ij, R_ij) -> V_ij`` for arbitrary distance-dependent potentials.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../_static/examples/cpp/model_hamiltonians.cpp
-      :language: cpp
-      :start-after: // start-cell-potentials
-      :end-before: // end-cell-potentials
-
 .. tab:: Python API
 
    .. literalinclude:: ../../_static/examples/python/model_hamiltonians.py
       :language: python
       :start-after: # start-cell-potentials
       :end-before: # end-cell-potentials
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../_static/examples/cpp/model_hamiltonians.cpp
+      :language: cpp
+      :start-after: // start-cell-potentials
+      :end-before: // end-cell-potentials
 
 Spin models
 -----------
@@ -301,19 +301,19 @@ Per-pair parameters
    Scalar ``float`` (broadcast to all pairs) or ``(n, n)`` ``numpy.ndarray`` (one value per pair).
    Used for: hopping (:math:`t`), intersite potential (:math:`V`), spin couplings (:math:`J_x, J_y, J_z`).
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../_static/examples/cpp/model_hamiltonians.cpp
-      :language: cpp
-      :start-after: // start-cell-site-dependent
-      :end-before: // end-cell-site-dependent
-
 .. tab:: Python API
 
    .. literalinclude:: ../../_static/examples/python/model_hamiltonians.py
       :language: python
       :start-after: # start-cell-site-dependent
       :end-before: # end-cell-site-dependent
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../_static/examples/cpp/model_hamiltonians.cpp
+      :language: cpp
+      :start-after: // start-cell-site-dependent
+      :end-before: // end-cell-site-dependent
 
 Using model Hamiltonians with algorithms
 -----------------------------------------
@@ -328,19 +328,19 @@ Spin model Hamiltonians produce :class:`~qdk_chemistry.data.QubitHamiltonian` ob
 
 .. rubric:: Example: exact diagonalization of the Hubbard model
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../_static/examples/cpp/model_hamiltonians.cpp
-      :language: cpp
-      :start-after: // start-cell-solve-hubbard
-      :end-before: // end-cell-solve-hubbard
-
 .. tab:: Python API
 
    .. literalinclude:: ../../_static/examples/python/model_hamiltonians.py
       :language: python
       :start-after: # start-cell-solve-hubbard
       :end-before: # end-cell-solve-hubbard
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../_static/examples/cpp/model_hamiltonians.cpp
+      :language: cpp
+      :start-after: // start-cell-solve-hubbard
+      :end-before: // end-cell-solve-hubbard
 
 .. rubric:: Example: exact diagonalization of the Ising model
 

--- a/docs/source/user/comprehensive/plugins.rst
+++ b/docs/source/user/comprehensive/plugins.rst
@@ -36,13 +36,6 @@ Using plugins
 
 To select an implementation, specify it by name:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../_static/examples/cpp/interfaces.cpp
-      :language: cpp
-      :start-after: // start-cell-scf
-      :end-before: // end-cell-scf
-
 .. tab:: Python API
 
    .. literalinclude:: ../../_static/examples/python/interfaces.py
@@ -50,16 +43,16 @@ To select an implementation, specify it by name:
       :start-after: # start-cell-scf
       :end-before: # end-cell-scf
 
-.. _listing-implementations:
-
-To list available implementations:
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../_static/examples/cpp/interfaces.cpp
       :language: cpp
-      :start-after: // start-cell-list-methods
-      :end-before: // end-cell-list-methods
+      :start-after: // start-cell-scf
+      :end-before: // end-cell-scf
+
+.. _listing-implementations:
+
+To list available implementations:
 
 .. tab:: Python API
 
@@ -67,6 +60,13 @@ To list available implementations:
       :language: python
       :start-after: # start-cell-list-methods
       :end-before: # end-cell-list-methods
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../_static/examples/cpp/interfaces.cpp
+      :language: cpp
+      :start-after: // start-cell-list-methods
+      :end-before: // end-cell-list-methods
 
 Documentation pertaining to the availability and configuration of each algorithm implementation provided within QDK/Chemistry can be found on the :doc:`algorithm <algorithms/index>` documentation pages.
 
@@ -213,19 +213,19 @@ Each algorithm type in QDK/Chemistry defines an abstract base class specifying t
 
 When an implementation requires configuration options beyond those provided by the base settings class, a derived settings class can be defined:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../_static/examples/cpp/custom_plugin.cpp
-      :language: cpp
-      :start-after: // start-cell-custom-settings
-      :end-before: // end-cell-custom-settings
-
 .. tab:: Python API
 
    .. literalinclude:: ../../_static/examples/python/custom_plugin.py
       :language: python
       :start-after: # start-cell-custom-settings
       :end-before: # end-cell-custom-settings
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../_static/examples/cpp/custom_plugin.cpp
+      :language: cpp
+      :start-after: // start-cell-custom-settings
+      :end-before: // end-cell-custom-settings
 
 .. rubric:: Implementation structure
 
@@ -236,13 +236,6 @@ The ``_run_impl()`` method is responsible for:
 2. Invoking the external computation
 3. Converting results back to QDK/Chemistry data structures
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../_static/examples/cpp/custom_plugin.cpp
-      :language: cpp
-      :start-after: // start-cell-custom-scf-solver
-      :end-before: // end-cell-custom-scf-solver
-
 .. tab:: Python API
 
    .. literalinclude:: ../../_static/examples/python/custom_plugin.py
@@ -250,17 +243,17 @@ The ``_run_impl()`` method is responsible for:
       :start-after: # start-cell-custom-scf-solver
       :end-before: # end-cell-custom-scf-solver
 
-.. rubric:: Registration
-
-Implementations are registered with the algorithm factory to enable discovery and instantiation by name.
-Registration is typically performed during module initialization:
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../_static/examples/cpp/custom_plugin.cpp
       :language: cpp
-      :start-after: // start-cell-registration
-      :end-before: // end-cell-registration
+      :start-after: // start-cell-custom-scf-solver
+      :end-before: // end-cell-custom-scf-solver
+
+.. rubric:: Registration
+
+Implementations are registered with the algorithm factory to enable discovery and instantiation by name.
+Registration is typically performed during module initialization:
 
 .. tab:: Python API
 
@@ -268,6 +261,13 @@ Registration is typically performed during module initialization:
       :language: python
       :start-after: # start-cell-registration
       :end-before: # end-cell-registration
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../_static/examples/cpp/custom_plugin.cpp
+      :language: cpp
+      :start-after: // start-cell-registration
+      :end-before: // end-cell-registration
 
 Following registration, the implementation is accessible through the standard API:
 
@@ -299,13 +299,6 @@ Configuration
 
 Define a settings class containing all configuration parameters:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../_static/examples/cpp/custom_plugin.cpp
-      :language: cpp
-      :start-after: // start-cell-geometry-settings
-      :end-before: // end-cell-geometry-settings
-
 .. tab:: Python API
 
    .. literalinclude:: ../../_static/examples/python/custom_plugin.py
@@ -313,16 +306,16 @@ Define a settings class containing all configuration parameters:
       :start-after: # start-cell-geometry-settings
       :end-before: # end-cell-geometry-settings
 
-.. rubric:: Base class definition
-
-Define an abstract base class specifying the interface for all implementations:
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../_static/examples/cpp/custom_plugin.cpp
       :language: cpp
-      :start-after: // start-cell-geometry-base-class
-      :end-before: // end-cell-geometry-base-class
+      :start-after: // start-cell-geometry-settings
+      :end-before: // end-cell-geometry-settings
+
+.. rubric:: Base class definition
+
+Define an abstract base class specifying the interface for all implementations:
 
 .. tab:: Python API
 
@@ -331,16 +324,16 @@ Define an abstract base class specifying the interface for all implementations:
       :start-after: # start-cell-geometry-base-class
       :end-before: # end-cell-geometry-base-class
 
-.. rubric:: Factory definition
-
-The factory manages implementation registration and provides instance creation:
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../_static/examples/cpp/custom_plugin.cpp
       :language: cpp
-      :start-after: // start-cell-geometry-factory
-      :end-before: // end-cell-geometry-factory
+      :start-after: // start-cell-geometry-base-class
+      :end-before: // end-cell-geometry-base-class
+
+.. rubric:: Factory definition
+
+The factory manages implementation registration and provides instance creation:
 
 .. tab:: Python API
 
@@ -349,16 +342,16 @@ The factory manages implementation registration and provides instance creation:
       :start-after: # start-cell-geometry-factory
       :end-before: # end-cell-geometry-factory
 
-.. rubric:: Concrete implementations
-
-Implement the algorithm by inheriting from the base class:
-
 .. tab:: C++ API
 
    .. literalinclude:: ../../_static/examples/cpp/custom_plugin.cpp
       :language: cpp
-      :start-after: // start-cell-geometry-implementations
-      :end-before: // end-cell-geometry-implementations
+      :start-after: // start-cell-geometry-factory
+      :end-before: // end-cell-geometry-factory
+
+.. rubric:: Concrete implementations
+
+Implement the algorithm by inheriting from the base class:
 
 .. tab:: Python API
 
@@ -366,6 +359,13 @@ Implement the algorithm by inheriting from the base class:
       :language: python
       :start-after: # start-cell-geometry-implementations
       :end-before: # end-cell-geometry-implementations
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../_static/examples/cpp/custom_plugin.cpp
+      :language: cpp
+      :start-after: // start-cell-geometry-implementations
+      :end-before: // end-cell-geometry-implementations
 
 Additional implementations follow the same pattern:
 
@@ -378,19 +378,19 @@ Additional implementations follow the same pattern:
 
 Register the factory and all implementations:
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../../_static/examples/cpp/custom_plugin.cpp
-      :language: cpp
-      :start-after: // start-cell-geometry-registration
-      :end-before: // end-cell-geometry-registration
-
 .. tab:: Python API
 
    .. literalinclude:: ../../_static/examples/python/custom_plugin.py
       :language: python
       :start-after: # start-cell-geometry-registration
       :end-before: # end-cell-geometry-registration
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../../_static/examples/cpp/custom_plugin.cpp
+      :language: cpp
+      :start-after: // start-cell-geometry-registration
+      :end-before: // end-cell-geometry-registration
 
 .. rubric:: Usage
 

--- a/docs/source/user/quickstart.rst
+++ b/docs/source/user/quickstart.rst
@@ -53,19 +53,19 @@ Internally to QDK/Chemistry, coordinates are always stored in Bohr/atomic units;
 See below for language specific examples of creating and serializing :doc:`comprehensive/data/structure` objects.
 
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../_static/examples/cpp/quickstart.cpp
-      :language: cpp
-      :start-after: // start-cell-structure
-      :end-before: // end-cell-structure
-
 .. tab:: Python API
 
    .. literalinclude:: ../_static/examples/python/quickstart.py
       :language: python
       :start-after: # start-cell-structure
       :end-before: # end-cell-structure
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../_static/examples/cpp/quickstart.cpp
+      :language: cpp
+      :start-after: // start-cell-structure
+      :end-before: // end-cell-structure
 
 Run a self-consistent field (SCF) calculation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,19 +80,19 @@ The inputs for an :term:`SCF` calculation are a :doc:`comprehensive/data/structu
 Optionally, :doc:`comprehensive/algorithms/settings` specific to the particular :doc:`comprehensive/algorithms/scf_solver` can be configured to control the execution of the :term:`SCF` algorithm (e.g. convergence tolerances, etc) by accessing the ``settings()`` method.
 The basis for the :term:`SCF` calculation can be set via a string input (specifying one of the :ref:`available_basis_sets`), a custom :doc:`comprehensive/data/basis_set` or initial :doc:`comprehensive/data/orbitals` can also be provided.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../_static/examples/cpp/quickstart.cpp
-      :language: cpp
-      :start-after: // start-cell-scf
-      :end-before: // end-cell-scf
-
 .. tab:: Python API
 
    .. literalinclude:: ../_static/examples/python/quickstart.py
       :language: python
       :start-after: # start-cell-scf
       :end-before: # end-cell-scf
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../_static/examples/cpp/quickstart.cpp
+      :language: cpp
+      :start-after: // start-cell-scf
+      :end-before: // end-cell-scf
 
 
 Select an active space
@@ -106,19 +106,19 @@ See the :doc:`comprehensive/algorithms/active_space` documentation for a list of
 
 The following are language-specific examples of how to select a so-called "valence" active space containing a subset of only those orbitals surrounding the Fermi level - in this case 6 electrons to be distributed in 6 orbitals (6e, 6o).
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../_static/examples/cpp/quickstart.cpp
-      :language: cpp
-      :start-after: // start-cell-active-space
-      :end-before: // end-cell-active-space
-
 .. tab:: Python API
 
    .. literalinclude:: ../_static/examples/python/quickstart.py
       :language: python
       :start-after: # start-cell-active-space
       :end-before: # end-cell-active-space
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../_static/examples/cpp/quickstart.cpp
+      :language: cpp
+      :start-after: // start-cell-active-space
+      :end-before: // end-cell-active-space
 
 
 Calculate the Hamiltonian
@@ -128,19 +128,19 @@ Once an active space has been selected, the electronic Hamiltonian can be comput
 QDK/Chemistry provides flexible Hamiltonian construction capabilities through the :doc:`comprehensive/algorithms/hamiltonian_constructor` algorithm.
 The Hamiltonian constructor generates the one- and two-electron integrals (or factorizations thereof) needed for subsequent quantum many-body calculations and quantum algorithms.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../_static/examples/cpp/quickstart.cpp
-      :language: cpp
-      :start-after: // start-cell-hamiltonian-constructor
-      :end-before: // end-cell-hamiltonian-constructor
-
 .. tab:: Python API
 
    .. literalinclude:: ../_static/examples/python/quickstart.py
       :language: python
       :start-after: # start-cell-hamiltonian-constructor
       :end-before: # end-cell-hamiltonian-constructor
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../_static/examples/cpp/quickstart.cpp
+      :language: cpp
+      :start-after: // start-cell-hamiltonian-constructor
+      :end-before: // end-cell-hamiltonian-constructor
 
 Compute a multi-configurational wavefunction for the active space
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -155,13 +155,6 @@ These methods also serve as a critical analysis tool, allowing users to better u
 
 In the following example, as the aforementioned (6e, 6o) active space is relatively small, we perform a :term:`CASCI` calculation to obtain the exact ground state wavefunction within the active space.
 
-.. tab:: C++ API
-
-   .. literalinclude:: ../_static/examples/cpp/quickstart.cpp
-      :language: cpp
-      :start-after: // start-cell-mc-compute
-      :end-before: // end-cell-mc-compute
-
 .. tab:: Python API
 
    .. literalinclude:: ../_static/examples/python/quickstart.py
@@ -169,18 +162,18 @@ In the following example, as the aforementioned (6e, 6o) active space is relativ
       :start-after: # start-cell-mc-compute
       :end-before: # end-cell-mc-compute
 
+.. tab:: C++ API
+
+   .. literalinclude:: ../_static/examples/cpp/quickstart.cpp
+      :language: cpp
+      :start-after: // start-cell-mc-compute
+      :end-before: // end-cell-mc-compute
+
 Select important configurations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For large active spaces, the multi-configuration :class:`~qdk_chemistry.data.Wavefunction` may contain thousands or millions of configurations, but often only a small subset contributes significantly to the overall state.
 By identifying and retaining only the dominant configurations (those with the largest amplitudes), we can create a sparse wavefunction that maintains high fidelity with respect to the original Wavefunction while dramatically reducing resource requirements for quantum state preparation.
-
-.. tab:: C++ API
-
-   .. literalinclude:: ../_static/examples/cpp/quickstart.cpp
-      :language: cpp
-      :start-after: // start-cell-wfn-select-configs
-      :end-before: // end-cell-wfn-select-configs
 
 .. tab:: Python API
 
@@ -188,6 +181,13 @@ By identifying and retaining only the dominant configurations (those with the la
       :language: python
       :start-after: # start-cell-wfn-select-configs
       :end-before: # end-cell-wfn-select-configs
+
+.. tab:: C++ API
+
+   .. literalinclude:: ../_static/examples/cpp/quickstart.cpp
+      :language: cpp
+      :start-after: // start-cell-wfn-select-configs
+      :end-before: // end-cell-wfn-select-configs
 
 Preparing a qubit representation of the Hamiltonian
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -202,18 +202,18 @@ For efficient energy estimation, the qubit Hamiltonian can be optimized in two w
 1. Filter out terms that have negligible expectation values given the sparse :class:`~qdk_chemistry.data.Wavefunction`, pre-computing their classical contributions.
 2. Group the remaining Pauli operators into commuting sets that can be measured simultaneously, significantly reducing the number of measurement circuits required on the quantum device.
 
-.. tab:: C++ API
-
-   .. code-block:: cpp
-
-      // This step is currently only available in the Python API.
-
 .. tab:: Python API
 
    .. literalinclude:: ../_static/examples/python/quickstart.py
       :language: python
       :start-after: # start-cell-qubit-hamiltonian
       :end-before: # end-cell-qubit-hamiltonian
+
+.. tab:: C++ API
+
+   .. code-block:: cpp
+
+      // This step is currently only available in the Python API.
 
 Generate the state preparation circuit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -224,18 +224,18 @@ However, when the wavefunction is very sparse, these methods can be inefficient.
 In QDK/Chemistry, we provide a specialized method for generating state preparation circuits for sparse wavefunctions based on the construction of sparse isometries over GF(2) with X gates, provided as a :doc:`comprehensive/algorithms/state_preparation` algorithm.
 See :doc:`comprehensive/algorithms/state_preparation` for more details on the other algorithms provided for state preparation in QDK/Chemistry.
 
-.. tab:: C++ API
-
-   .. code-block:: cpp
-
-      // This step is currently only available in the Python API.
-
 .. tab:: Python API
 
    .. literalinclude:: ../_static/examples/python/quickstart.py
       :language: python
       :start-after: # start-state-prep-circuit
       :end-before: # end-state-prep-circuit
+
+.. tab:: C++ API
+
+   .. code-block:: cpp
+
+      // This step is currently only available in the Python API.
 
 
 Estimate the ground state energy by sampling
@@ -248,18 +248,18 @@ The measurement outcomes are repeated many times (shots) to build up statistics 
 The energy expectation value is computed by combining the measurement statistics from each group with their corresponding Hamiltonian coefficients and the pre-computed classical contributions.
 The statistical nature of quantum measurements introduces variance in the energy estimate, which decreases as the number of shots is increased.
 
-.. tab:: C++ API
-
-   .. code-block:: cpp
-
-      // This step is currently only available in the Python API.
-
 .. tab:: Python API
 
    .. literalinclude:: ../_static/examples/python/quickstart.py
       :language: python
       :start-after: # start-cell-energy-estimation
       :end-before: # end-cell-energy-estimation
+
+.. tab:: C++ API
+
+   .. code-block:: cpp
+
+      // This step is currently only available in the Python API.
 
 Additional examples
 -------------------


### PR DESCRIPTION
Python is more accessible in general, we likely have more Python users, and we already document Python as the easiest way to use the library (e.g. pip install in the README and quickstart). So it makes sense for the default API docs selection to be Python instead of C++.

This PR accomplishes this.