### PR TITLE
Zassenhaus optimizations

### DIFF
--- a/python/src/qdk_chemistry/utils/zassenhaus_generation.py
+++ b/python/src/qdk_chemistry/utils/zassenhaus_generation.py
@@ -298,4 +298,9 @@ def zassenhaus_commutator_plan(
     valid evaluation order.
     """
     leaf_tuple = _normalize_leaves(leaves)
-    return _cached_zassenhaus_commutator_plan(leaf_tuple, max_order)
+    cached_exponents, cached_plan = _cached_zassenhaus_commutator_plan(leaf_tuple, max_order)
+
+    # Return fresh copies to prevent caller mutation from corrupting the cached objects
+    exponents_copy = {k: dict(v) for k, v in cached_exponents.items()}
+    plan_copy = dict(cached_plan)
+    return exponents_copy, plan_copy

--- a/python/src/qdk_chemistry/utils/zassenhaus_generation.py
+++ b/python/src/qdk_chemistry/utils/zassenhaus_generation.py
@@ -17,6 +17,7 @@ from collections import defaultdict
 from collections.abc import Hashable, Sequence
 from dataclasses import dataclass
 from fractions import Fraction
+import functools
 from math import factorial
 
 Term = Hashable | tuple["Term", "Term"]
@@ -265,6 +266,25 @@ def _plan_expr(
     return _clean(dict(out))
 
 
+# Cache the symbolic plan. Since the commutator plan depends purely on the number of leaves
+# and the target order (not on coefficients or time), caching avoids redundant DAG builds.
+@functools.lru_cache(maxsize=128)
+def _cached_zassenhaus_commutator_plan(
+    leaves: tuple[Hashable, ...],
+    max_order: int,
+) -> tuple[dict[int, PlanExpr], CommutatorPlan]:
+    exponents = zassenhaus_exponents(leaves, max_order=max_order)
+    plan: CommutatorPlan = {}
+    planned_exponents: dict[int, PlanExpr] = {}
+    primitive_leaves = set(leaves)
+    term_nodes: dict[Term, CommutatorNode] = {}
+
+    for order, expr in exponents.items():
+        planned_exponents[order] = _plan_expr(expr, plan, primitive_leaves, term_nodes)
+
+    return planned_exponents, plan
+
+
 def zassenhaus_commutator_plan(
     leaves: Sequence[Hashable],
     max_order: int = 5,
@@ -278,13 +298,4 @@ def zassenhaus_commutator_plan(
     valid evaluation order.
     """
     leaf_tuple = _normalize_leaves(leaves)
-    exponents = zassenhaus_exponents(leaf_tuple, max_order=max_order)
-    plan: CommutatorPlan = {}
-    planned_exponents: dict[int, PlanExpr] = {}
-    primitive_leaves = set(leaf_tuple)
-    term_nodes: dict[Term, CommutatorNode] = {}
-
-    for order, expr in exponents.items():
-        planned_exponents[order] = _plan_expr(expr, plan, primitive_leaves, term_nodes)
-
-    return planned_exponents, plan
+    return _cached_zassenhaus_commutator_plan(leaf_tuple, max_order)

--- a/python/src/qdk_chemistry/utils/zassenhaus_generation.py
+++ b/python/src/qdk_chemistry/utils/zassenhaus_generation.py
@@ -266,8 +266,9 @@ def _plan_expr(
     return _clean(dict(out))
 
 
-# Cache the symbolic plan. Since the commutator plan depends purely on the number of leaves
-# and the target order (not on coefficients or time), caching avoids redundant DAG builds.
+# Cache the symbolic plan. Since the commutator plan depends on the specific leaf labels
+# and the target order (not on coefficients or time), caching avoids redundant DAG builds
+# for calls with the same leaf identifiers and order.
 @functools.lru_cache(maxsize=128)
 def _cached_zassenhaus_commutator_plan(
     leaves: tuple[Hashable, ...],

--- a/python/src/qdk_chemistry/utils/zassenhaus_generation.py
+++ b/python/src/qdk_chemistry/utils/zassenhaus_generation.py
@@ -13,11 +13,11 @@ caching and linear-time evaluation of the commutator DAG.
 
 from __future__ import annotations
 
+import functools
 from collections import defaultdict
 from collections.abc import Hashable, Sequence
 from dataclasses import dataclass
 from fractions import Fraction
-import functools
 from math import factorial
 
 Term = Hashable | tuple["Term", "Term"]

--- a/python/tests/test_zassenhaus.py
+++ b/python/tests/test_zassenhaus.py
@@ -234,7 +234,7 @@ class TestZassenhausTimeEvolution:
             pauli_matrix = pauli_to_dense_matrix([pauli_label], np.array([1.0]))
             cos_val = np.cos(term.angle)
             sin_val = np.sin(term.angle)
-            rotation_matrix = cos_val * np.eye(pauli_matrix.shape[0]) - 1j * sin_val * pauli_matrix
+            rotation_matrix = cos_val * np.eye(pauli_matrix.shape[0], dtype=complex) - 1j * sin_val * pauli_matrix
             step_unitary = rotation_matrix @ step_unitary
 
         return np.linalg.matrix_power(step_unitary, container.step_reps)

--- a/python/tests/test_zassenhaus.py
+++ b/python/tests/test_zassenhaus.py
@@ -479,16 +479,6 @@ class TestZassenhausTimeEvolution:
     def test_zassenhaus_operator_norm_error_scaling(self):
         """Check empirical operator-norm error scaling slopes match order + 1 to within 0.1."""
         cases = [
-            (self._open_heisenberg_chain_4_site, 2),
-            (self._open_heisenberg_chain_4_site, 3),
-            (self._open_heisenberg_chain_4_site, 4),
-            (self._h2_sto3g_jordan_wigner_hamiltonian, 2),
-            (self._h2_sto3g_jordan_wigner_hamiltonian, 3),
-            (self._h2_sto3g_jordan_wigner_hamiltonian, 4),
-        ]
-        for factory, order in cases:
-            slope = self._fit_zassenhaus_error_slope(factory(), order=order)
-        cases = [
             (self._open_heisenberg_chain_4_site(), (2, 3, 4)),
             (self._h2_sto3g_jordan_wigner_hamiltonian(), (2, 3, 4)),
         ]

--- a/python/tests/test_zassenhaus.py
+++ b/python/tests/test_zassenhaus.py
@@ -13,7 +13,7 @@ import numpy as np
 import pytest
 import scipy.linalg
 
-from qdk_chemistry.algorithms import create, registry
+from qdk_chemistry.algorithms import create
 from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus import Zassenhaus
 from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus_error import (
     zassenhaus_steps_commutator,
@@ -226,7 +226,17 @@ class TestZassenhausTimeEvolution:
         builder = Zassenhaus(num_divisions=1, order=order, time=time)
         container = builder.run(hamiltonian).get_container()
 
-        step_unitary = np.eye(2**hamiltonian.num_qubits, dtype=complex)
+        identity = np.eye(2**hamiltonian.num_qubits, dtype=complex)
+        step_unitary = identity
+        for term in container.step_terms:
+            pauli_label = TestZassenhausTimeEvolution._pauli_label_from_map(
+                term.pauli_term, num_qubits=hamiltonian.num_qubits
+            )
+            pauli_matrix = pauli_to_dense_matrix([pauli_label], np.array([1.0]))
+            cos_val = np.cos(term.angle)
+            sin_val = np.sin(term.angle)
+            rotation_matrix = cos_val * identity - 1j * sin_val * pauli_matrix
+            step_unitary = rotation_matrix @ step_unitary
         for term in container.step_terms:
             pauli_label = TestZassenhausTimeEvolution._pauli_label_from_map(
                 term.pauli_term, num_qubits=hamiltonian.num_qubits
@@ -267,7 +277,7 @@ class TestZassenhausTimeEvolution:
             for pauli in ("X", "Y", "Z")
         ]
         h = QubitHamiltonian(pauli_strings=labels, coefficients=[1.0] * len(labels))
-        grouper = registry.create("term_grouper", "commuting")
+        grouper = create("term_grouper", "commuting")
         return grouper.run(h)
 
     @staticmethod
@@ -298,7 +308,7 @@ class TestZassenhausTimeEvolution:
             active_hamiltonian,
             MajoranaMapping.jordan_wigner(n_spin_orbitals),
         )
-        grouper = registry.create("term_grouper", "commuting")
+        grouper = create("term_grouper", "commuting")
         return grouper.run(h)
 
     def test_zassenhaus_builder_and_decomposition(self):
@@ -487,7 +497,14 @@ class TestZassenhausTimeEvolution:
         ]
         for factory, order in cases:
             slope = self._fit_zassenhaus_error_slope(factory(), order=order)
-            assert np.isclose(slope, order + 1, atol=0.1)
+        cases = [
+            (self._open_heisenberg_chain_4_site(), (2, 3, 4)),
+            (self._h2_sto3g_jordan_wigner_hamiltonian(), (2, 3, 4)),
+        ]
+        for hamiltonian, orders in cases:
+            for order in orders:
+                slope = self._fit_zassenhaus_error_slope(hamiltonian, order=order)
+                assert np.isclose(slope, order + 1, atol=0.1)
 
 
 class TestZassenhausPhaseEstimation:

--- a/python/tests/test_zassenhaus.py
+++ b/python/tests/test_zassenhaus.py
@@ -13,7 +13,7 @@ import numpy as np
 import pytest
 import scipy.linalg
 
-from qdk_chemistry.algorithms import create
+from qdk_chemistry.algorithms import create, registry
 from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus import Zassenhaus
 from qdk_chemistry.algorithms.hamiltonian_unitary_builder.time_evolution.zassenhaus_error import (
     zassenhaus_steps_commutator,
@@ -267,7 +267,6 @@ class TestZassenhausTimeEvolution:
             for pauli in ("X", "Y", "Z")
         ]
         h = QubitHamiltonian(pauli_strings=labels, coefficients=[1.0] * len(labels))
-        from qdk_chemistry.algorithms import registry
         grouper = registry.create("term_grouper", "commuting")
         return grouper.run(h)
 
@@ -299,7 +298,6 @@ class TestZassenhausTimeEvolution:
             active_hamiltonian,
             MajoranaMapping.jordan_wigner(n_spin_orbitals),
         )
-        from qdk_chemistry.algorithms import registry
         grouper = registry.create("term_grouper", "commuting")
         return grouper.run(h)
 

--- a/python/tests/test_zassenhaus.py
+++ b/python/tests/test_zassenhaus.py
@@ -232,7 +232,10 @@ class TestZassenhausTimeEvolution:
                 term.pauli_term, num_qubits=hamiltonian.num_qubits
             )
             pauli_matrix = pauli_to_dense_matrix([pauli_label], np.array([1.0]))
-            step_unitary = scipy.linalg.expm(-1j * term.angle * pauli_matrix) @ step_unitary
+            cos_val = np.cos(term.angle)
+            sin_val = np.sin(term.angle)
+            rotation_matrix = cos_val * np.eye(pauli_matrix.shape[0]) - 1j * sin_val * pauli_matrix
+            step_unitary = rotation_matrix @ step_unitary
 
         return np.linalg.matrix_power(step_unitary, container.step_reps)
 
@@ -263,7 +266,10 @@ class TestZassenhausTimeEvolution:
             for site in range(3)
             for pauli in ("X", "Y", "Z")
         ]
-        return QubitHamiltonian(pauli_strings=labels, coefficients=[1.0] * len(labels))
+        h = QubitHamiltonian(pauli_strings=labels, coefficients=[1.0] * len(labels))
+        from qdk_chemistry.algorithms import registry
+        grouper = registry.create("term_grouper", "commuting")
+        return grouper.run(h)
 
     @staticmethod
     def _h2_sto3g_jordan_wigner_hamiltonian() -> QubitHamiltonian:
@@ -289,10 +295,13 @@ class TestZassenhausTimeEvolution:
         constructor = create("hamiltonian_constructor")
         active_hamiltonian = constructor.run(active_orbitals)
         n_spin_orbitals = 2 * active_hamiltonian.get_orbitals().get_num_molecular_orbitals()
-        return create("qubit_mapper", "qdk").run(
+        h = create("qubit_mapper", "qdk").run(
             active_hamiltonian,
             MajoranaMapping.jordan_wigner(n_spin_orbitals),
         )
+        from qdk_chemistry.algorithms import registry
+        grouper = registry.create("term_grouper", "commuting")
+        return grouper.run(h)
 
     def test_zassenhaus_builder_and_decomposition(self):
         """Test metadata, registry creation, settings, decomposition, filtering, and evolution examples."""
@@ -468,11 +477,6 @@ class TestZassenhausTimeEvolution:
 
         assert np.allclose(u_opt, u_raw, atol=1e-12)
 
-    @pytest.mark.slow
-    @pytest.mark.skipif(
-        not _RUN_SLOW_TESTS,
-        reason="Skipping slow test. Set QDK_CHEMISTRY_RUN_SLOW_TESTS=1 to enable.",
-    )
     def test_zassenhaus_operator_norm_error_scaling(self):
         """Check empirical operator-norm error scaling slopes match order + 1 to within 0.1."""
         cases = [

--- a/python/tests/test_zassenhaus.py
+++ b/python/tests/test_zassenhaus.py
@@ -237,15 +237,6 @@ class TestZassenhausTimeEvolution:
             sin_val = np.sin(term.angle)
             rotation_matrix = cos_val * identity - 1j * sin_val * pauli_matrix
             step_unitary = rotation_matrix @ step_unitary
-        for term in container.step_terms:
-            pauli_label = TestZassenhausTimeEvolution._pauli_label_from_map(
-                term.pauli_term, num_qubits=hamiltonian.num_qubits
-            )
-            pauli_matrix = pauli_to_dense_matrix([pauli_label], np.array([1.0]))
-            cos_val = np.cos(term.angle)
-            sin_val = np.sin(term.angle)
-            rotation_matrix = cos_val * np.eye(pauli_matrix.shape[0], dtype=complex) - 1j * sin_val * pauli_matrix
-            step_unitary = rotation_matrix @ step_unitary
 
         return np.linalg.matrix_power(step_unitary, container.step_reps)
 


### PR DESCRIPTION
Closes #559.

### Proposed Optimizations
This PR contains optimizations to speed up cases like `test_zassenhaus_operator_norm_error_scaling` where we call the generator `zassenhaus_commutator_plan()` multiple times for the same plan:
* **Caching:** Added an LRU cache (`@functools.lru_cache`) to the plan generator in `zassenhaus_generation.py` to prevent redundant DAG builds.
* **Term Partitioning:** Updated the test factories to apply the default `commuting` term grouper. This reduces the number of leaves/groups to 3 and 5, shrinking the commutator tree dramatically while preserving the mathematically expected $O(t^{\rm{order} + 1})$ convergence scaling.
* **Analytical Exponentiation:** Substituted `scipy.linalg.expm` which uses Padé approximation which is unnecessary because `_zassenhaus_unitary_matrix` can perform the exact analytical Pauli exponentiation.
* **Test Promotion:** Since these optimizations reduce the test run time to under 0.5 seconds (~150x speedup locally and ~2000x expected speedup on CI), I have removed the `@pytest.mark.slow` marker so that it can be safely run by default.

Tagging @lorisercole.