### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -71,8 +71,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        # Python 3.10 temporarily disabled: stable qdk[qre] requires cirq-core>=1.6.1,
-        # which needs Python >= 3.11, so the qre extra cannot resolve on 3.10.
+        - os-name: Linux
+          runner: [self-hosted, 1ES.Pool=1es-gh-Dads_v5-pool-wus2, 1ES.ImageOverride=Ubuntu24.04Nightly, 'JobId=qdk_chemistry-linux-py3.10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}']
+          build-parallel: 32
+          uarch: x86-64-v3
+          python-version: '3.10'
+          cpp-test-threads: 2
+          python-test-threads: 2
         - os-name: Linux
           runner: [self-hosted, 1ES.Pool=1es-gh-Dads_v5-pool-wus2, 1ES.ImageOverride=Ubuntu24.04Nightly, 'JobId=qdk_chemistry-linux-py3.13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}']
           build-parallel: 32

--- a/.pipelines/pip-scripts/build-pip-wheels-windows.ps1
+++ b/.pipelines/pip-scripts/build-pip-wheels-windows.ps1
@@ -72,8 +72,8 @@ try {
 # scikit-build-core builds the full C++ library; pre-installed deps (vcpkg
 # packages + libint2/ecpint/gauxc) are found via CMAKE_PREFIX_PATH.
 Write-Host "=== python -m build --wheel ==="
-# Default to a clean release version (python/_dev_version.py) when run standalone.
-if (-not $env:QDK_CHEMISTRY_RELEASE_BUILD) { $env:QDK_CHEMISTRY_RELEASE_BUILD = '1' }
+# Default to a non-release build unless explicitly overridden (to keep +local on dev builds).
+if (-not $env:QDK_CHEMISTRY_RELEASE_BUILD) { $env:QDK_CHEMISTRY_RELEASE_BUILD = '0' }
 $prefix = "$DepsInstallDir;$SrcDir\vcpkg_installed\x64-windows-static-md"
 $buildArgs = @(
     'run', '-n', 'buildenv',

--- a/.pipelines/pip-scripts/build-pip-wheels-windows.ps1
+++ b/.pipelines/pip-scripts/build-pip-wheels-windows.ps1
@@ -72,6 +72,10 @@ try {
 # scikit-build-core builds the full C++ library; pre-installed deps (vcpkg
 # packages + libint2/ecpint/gauxc) are found via CMAKE_PREFIX_PATH.
 Write-Host "=== python -m build --wheel ==="
+# Version-provider toggle (python/_dev_version.py). The release pipeline sets this
+# (via the `releaseBuild` parameter) to emit a clean, publishable version. A false-y
+# value appends a PEP 440 +local suffix. Default to a clean build when run standalone.
+if (-not $env:QDK_CHEMISTRY_RELEASE_BUILD) { $env:QDK_CHEMISTRY_RELEASE_BUILD = '1' }
 $prefix = "$DepsInstallDir;$SrcDir\vcpkg_installed\x64-windows-static-md"
 $buildArgs = @(
     'run', '-n', 'buildenv',

--- a/.pipelines/pip-scripts/build-pip-wheels-windows.ps1
+++ b/.pipelines/pip-scripts/build-pip-wheels-windows.ps1
@@ -72,9 +72,7 @@ try {
 # scikit-build-core builds the full C++ library; pre-installed deps (vcpkg
 # packages + libint2/ecpint/gauxc) are found via CMAKE_PREFIX_PATH.
 Write-Host "=== python -m build --wheel ==="
-# Version-provider toggle (python/_dev_version.py). The release pipeline sets this
-# (via the `releaseBuild` parameter) to emit a clean, publishable version. A false-y
-# value appends a PEP 440 +local suffix. Default to a clean build when run standalone.
+# Default to a clean release version (python/_dev_version.py) when run standalone.
 if (-not $env:QDK_CHEMISTRY_RELEASE_BUILD) { $env:QDK_CHEMISTRY_RELEASE_BUILD = '1' }
 $prefix = "$DepsInstallDir;$SrcDir\vcpkg_installed\x64-windows-static-md"
 $buildArgs = @(

--- a/.pipelines/pip-scripts/build-pip-wheels.sh
+++ b/.pipelines/pip-scripts/build-pip-wheels.sh
@@ -12,6 +12,11 @@ BLIS_VERSION=${8:-2.0}
 LIBFLAME_VERSION=${9:-5.2.0}
 MAC_BUILD=${10:-OFF}
 
+# Version-provider toggle (python/_dev_version.py). The release pipeline sets this
+# (via the `releaseBuild` parameter) to emit a clean, publishable version. A false-y
+# value appends a PEP 440 +local suffix. Default to a clean build when run standalone.
+export QDK_CHEMISTRY_RELEASE_BUILD="${QDK_CHEMISTRY_RELEASE_BUILD:-1}"
+
 export CFLAGS="-fPIC -Os"
 if [ "$MAC_BUILD" == "OFF" ]; then # Build/install Linux dependencies
     export DEBIAN_FRONTEND=noninteractive

--- a/.pipelines/pip-scripts/build-pip-wheels.sh
+++ b/.pipelines/pip-scripts/build-pip-wheels.sh
@@ -12,9 +12,7 @@ BLIS_VERSION=${8:-2.0}
 LIBFLAME_VERSION=${9:-5.2.0}
 MAC_BUILD=${10:-OFF}
 
-# Version-provider toggle (python/_dev_version.py). The release pipeline sets this
-# (via the `releaseBuild` parameter) to emit a clean, publishable version. A false-y
-# value appends a PEP 440 +local suffix. Default to a clean build when run standalone.
+# Default to a clean release version (python/_dev_version.py) when run standalone.
 export QDK_CHEMISTRY_RELEASE_BUILD="${QDK_CHEMISTRY_RELEASE_BUILD:-1}"
 
 export CFLAGS="-fPIC -Os"

--- a/.pipelines/pip-scripts/build-pip-wheels.sh
+++ b/.pipelines/pip-scripts/build-pip-wheels.sh
@@ -12,8 +12,8 @@ BLIS_VERSION=${8:-2.0}
 LIBFLAME_VERSION=${9:-5.2.0}
 MAC_BUILD=${10:-OFF}
 
-# Default to a clean release version (python/_dev_version.py) when run standalone.
-export QDK_CHEMISTRY_RELEASE_BUILD="${QDK_CHEMISTRY_RELEASE_BUILD:-1}"
+# Default to a non-release build unless explicitly overridden (to keep +local on dev builds).
+export QDK_CHEMISTRY_RELEASE_BUILD="${QDK_CHEMISTRY_RELEASE_BUILD:-0}"
 
 export CFLAGS="-fPIC -Os"
 if [ "$MAC_BUILD" == "OFF" ]; then # Build/install Linux dependencies

--- a/.pipelines/python-wheels.yaml
+++ b/.pipelines/python-wheels.yaml
@@ -62,10 +62,6 @@ parameters:
   - 3.13
   - 3.14
   displayName: Python versions
-- name: publishInternalFeed
-  type: boolean
-  default: false
-  displayName: Publish to Internal Feed
 - name: publishEsrp
   type: boolean
   default: false
@@ -283,23 +279,6 @@ extends:
             - script: |
                 sudo chown -R $(id -u):$(id -g) $(System.DefaultWorkingDirectory)/python/repaired_wheelhouse
               displayName: Fix wheel directory ownership
-
-          - task: TwineAuthenticate@1
-            inputs:
-              artifactFeed: $(artifactProject)/$(artifactFeed)
-            displayName: Authenticate to internal feed
-            condition: and(succeeded(), ${{ parameters.publishInternalFeed }})
-
-          - script: |
-              cd $(Agent.BuildDirectory)/qdk-chemistry/python
-              # --break-system-packages: the Linux x86_64 host image (Ubuntu 24.04) ships a
-              # PEP 668 EXTERNALLY-MANAGED system Python, which refuses a bare `pip install`.
-              # The flag lets pip fall back to a per-user install (as it already does on the
-              # other agents) and is an accepted no-op where the marker is absent.
-              python3 -m pip install --break-system-packages twine
-              python3 -m twine upload -r $(artifactFeed) repaired_wheelhouse/*.whl --config-file $(PYPIRC_PATH)
-            displayName: Upload wheel with twine
-            condition: and(succeeded(), ${{ parameters.publishInternalFeed }})
 
           # Publishing debug symbols is not supported for macOS
           - ${{ if and( eq(target.os, 'linux'), eq(target.arch, 'x86_64') ) }}:

--- a/.pipelines/python-wheels.yaml
+++ b/.pipelines/python-wheels.yaml
@@ -70,6 +70,10 @@ parameters:
   type: string
   default: None
   displayName: PyPI Development Tag (e.g. 'dev1', 'rc1', etc.)
+- name: releaseBuild
+  type: boolean
+  default: true
+  displayName: Emit clean release version (strip +local dev suffix)
 - name: runSlowTests
   type: boolean
   default: true
@@ -79,6 +83,11 @@ variables:
 - group: QdkChemistry
 - name: ComponentDetection.MaxDetectionThreads
   value: '16'
+# Controls the version provider (python/_dev_version.py). When true, wheels get the
+# bare release version; when false, a +local suffix is appended for dev builds.
+# PyPI/ESRP reject local versions, so keep this true for any published release.
+- name: QDK_CHEMISTRY_RELEASE_BUILD
+  value: '${{ parameters.releaseBuild }}'
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:

--- a/.pipelines/python-wheels.yaml
+++ b/.pipelines/python-wheels.yaml
@@ -292,7 +292,11 @@ extends:
 
           - script: |
               cd $(Agent.BuildDirectory)/qdk-chemistry/python
-              python3 -m pip install twine
+              # --break-system-packages: the Linux x86_64 host image (Ubuntu 24.04) ships a
+              # PEP 668 EXTERNALLY-MANAGED system Python, which refuses a bare `pip install`.
+              # The flag lets pip fall back to a per-user install (as it already does on the
+              # other agents) and is an accepted no-op where the marker is absent.
+              python3 -m pip install --break-system-packages twine
               python3 -m twine upload -r $(artifactFeed) repaired_wheelhouse/*.whl --config-file $(PYPIRC_PATH)
             displayName: Upload wheel with twine
             condition: and(succeeded(), ${{ parameters.publishInternalFeed }})

--- a/.pipelines/python-wheels.yaml
+++ b/.pipelines/python-wheels.yaml
@@ -199,9 +199,7 @@ extends:
                 imageTag: linux/amd64
                 pythonVersion: $(pythonVersion)
                 runSlowTests: ${{ parameters.runSlowTests }}
-                # Python 3.10 tests temporarily disabled (qre/cirq cannot resolve on 3.10);
-                # the wheel is still built and published.
-                condition: and(succeeded(), ne(variables['pythonVersion'], '3.10'))
+                condition: succeeded()
 
           # Build - Linux ARM64
           - ${{ if and(eq(target.arch, 'aarch64'), eq(target.os, 'linux')) }}:
@@ -225,9 +223,7 @@ extends:
                 imageTag: linux/arm64/v8
                 pythonVersion: $(pythonVersion)
                 runSlowTests: ${{ parameters.runSlowTests }}
-                # Python 3.10 tests temporarily disabled (qre/cirq cannot resolve on 3.10);
-                # the wheel is still built and published.
-                condition: and(succeeded(), ne(variables['pythonVersion'], '3.10'))
+                condition: succeeded()
 
           # Build - macOS ARM64
           - ${{ if eq(target.os, 'macOS') }}:
@@ -249,9 +245,7 @@ extends:
                 pythonVersion: $(pythonVersion)
                 macBuild: ON
                 runSlowTests: ${{ parameters.runSlowTests }}
-                # Python 3.10 tests temporarily disabled (qre/cirq cannot resolve on 3.10);
-                # the wheel is still built and published.
-                condition: and(succeeded(), ne(variables['pythonVersion'], '3.10'))
+                condition: succeeded()
 
           # Build - Windows x86_64
           - ${{ if eq(target.os, 'windows') }}:
@@ -269,9 +263,7 @@ extends:
               parameters:
                 pythonVersion: $(pythonVersion)
                 runSlowTests: ${{ parameters.runSlowTests }}
-                # Python 3.10 tests temporarily disabled (qre/cirq cannot resolve on 3.10);
-                # the wheel is still built and published.
-                condition: and(succeeded(), ne(variables['pythonVersion'], '3.10'))
+                condition: succeeded()
 
           # SBoM Manifest Generator Task requires we transfer ownership of the wheel directory
           # back to the original base image user (Linux/macOS only; not needed on Windows).

--- a/.pipelines/python-wheels.yaml
+++ b/.pipelines/python-wheels.yaml
@@ -278,6 +278,9 @@ extends:
           - ${{ if ne(target.os, 'windows') }}:
             - script: |
                 sudo chown -R $(id -u):$(id -g) $(System.DefaultWorkingDirectory)/python/repaired_wheelhouse
+                if [ -d "$(System.DefaultWorkingDirectory)/python/debug_symbols" ]; then
+                  sudo chown -R $(id -u):$(id -g) $(System.DefaultWorkingDirectory)/python/debug_symbols
+                fi
               displayName: Fix wheel directory ownership
 
           # Publishing debug symbols is not supported for macOS

--- a/.pipelines/python-wheels.yaml
+++ b/.pipelines/python-wheels.yaml
@@ -70,10 +70,6 @@ parameters:
   type: string
   default: None
   displayName: PyPI Development Tag (e.g. 'dev1', 'rc1', etc.)
-- name: releaseBuild
-  type: boolean
-  default: true
-  displayName: Emit clean release version (strip +local dev suffix)
 - name: runSlowTests
   type: boolean
   default: true
@@ -83,11 +79,9 @@ variables:
 - group: QdkChemistry
 - name: ComponentDetection.MaxDetectionThreads
   value: '16'
-# Controls the version provider (python/_dev_version.py). When true, wheels get the
-# bare release version; when false, a +local suffix is appended for dev builds.
-# PyPI/ESRP reject local versions, so keep this true for any published release.
+# Emit a clean, publishable version (no +local suffix) when publishing to PyPI.
 - name: QDK_CHEMISTRY_RELEASE_BUILD
-  value: '${{ parameters.releaseBuild }}'
+  value: ${{ parameters.publishEsrp }}
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:

--- a/.pipelines/templates/build-pip-wheels.yml
+++ b/.pipelines/templates/build-pip-wheels.yml
@@ -94,6 +94,7 @@ steps:
         -e PIP_INDEX_URL \
         -e SYSTEM_ACCESSTOKEN \
         -e QDK_UARCH=${{ parameters.march }} \
+        -e QDK_CHEMISTRY_RELEASE_BUILD \
         -w /workspace/qdk-chemistry \
         ${{ parameters.dockerImage }} \
       bash .pipelines/pip-scripts/build-pip-wheels.sh ${{ parameters.march }} \
@@ -122,6 +123,7 @@ steps:
         -e PIP_INDEX_URL \
         -e SYSTEM_ACCESSTOKEN \
         -e QDK_UARCH=${{ parameters.march }} \
+        -e QDK_CHEMISTRY_RELEASE_BUILD \
         -w /workspace/qdk-chemistry \
         ${{ parameters.dockerImage }} \
       bash .pipelines/pip-scripts/build-pip-wheels.sh ${{ parameters.march }} \

--- a/python/_dev_version.py
+++ b/python/_dev_version.py
@@ -5,9 +5,20 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import os
 import re
 import subprocess
 from pathlib import Path
+
+# Env var set by the official release/wheel pipeline to force a clean, publishable
+# version. PEP 440 local versions (e.g. "2.0.0+local") are rejected by PyPI/ESRP.
+_RELEASE_BUILD_ENV = "QDK_CHEMISTRY_RELEASE_BUILD"
+_FALSEY = frozenset({"", "0", "false", "no", "off"})
+
+
+def _is_release_build() -> bool:
+    """Whether this is an official pipeline build that must emit a clean version (no +local)."""
+    return os.environ.get(_RELEASE_BUILD_ENV, "").strip().lower() not in _FALSEY
 
 
 def dynamic_metadata(field, settings):
@@ -18,6 +29,10 @@ def dynamic_metadata(field, settings):
 
     # If VERSION already carries a pre-release/dev suffix (e.g. CI set it), use as-is.
     if not re.fullmatch(r"\d+\.\d+\.\d+", version):
+        return version
+
+    # Official pipeline builds publish the bare release version; never tag it +local.
+    if _is_release_build():
         return version
 
     repo_root = version_file.resolve().parent

--- a/python/_dev_version.py
+++ b/python/_dev_version.py
@@ -10,14 +10,13 @@ import re
 import subprocess
 from pathlib import Path
 
-# Env var set by the official release/wheel pipeline to force a clean, publishable
-# version. PEP 440 local versions (e.g. "2.0.0+local") are rejected by PyPI/ESRP.
+# Set by the release pipeline to force a clean, publishable version (no +local).
 _RELEASE_BUILD_ENV = "QDK_CHEMISTRY_RELEASE_BUILD"
 _FALSEY = frozenset({"", "0", "false", "no", "off"})
 
 
 def _is_release_build() -> bool:
-    """Whether this is an official pipeline build that must emit a clean version (no +local)."""
+    """Whether to emit a clean version (no +local)."""
     return os.environ.get(_RELEASE_BUILD_ENV, "").strip().lower() not in _FALSEY
 
 
@@ -31,7 +30,7 @@ def dynamic_metadata(field, settings):
     if not re.fullmatch(r"\d+\.\d+\.\d+", version):
         return version
 
-    # Official pipeline builds publish the bare release version; never tag it +local.
+    # Release builds publish the bare version; never tag it +local.
     if _is_release_build():
         return version
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "scipy>=1.7.0",
   "matplotlib>=3.10.0",
   "ruamel-yaml>=0.18.10",
-  "qdk[jupyter]>=1.28.0",
+  "qdk[jupyter]>=1.30.0",
   "pybind11-stubgen>=2.5.1",
   "h5py>=3.0.0",
 ]
@@ -100,7 +100,7 @@ qiskit-extras = [
   "requests>=2.33.0; python_version < '3.14'"
 ]
 qre = [
-  "qdk[qre,jupyter]>=1.29.1; python_version >= '3.11'"
+  "qdk[qre,jupyter]>=1.30.0"
 ]
 test = [
   "qdk-chemistry[coverage,jupyter,networkx-extras,openfermion-extras,plugins,qiskit-extras,qre]",


### PR DESCRIPTION
## Summary
- Removes the obsolete `publishInternalFeed` pipeline parameter and its related steps (`TwineAuthenticate` and the internal feed twine upload script). This publishing path is no longer used.
- Fixes the `Publish debug symbols` step failing with `UnauthorizedAccessException` on Linux x86_64. The `debug_symbols` directory is created as root inside the manylinux build container, so `PublishSymbols@2` (running as the agent user) couldn't read it. Extends the existing ownership-fix step to also chown `python/debug_symbols` when present.
- Re-enable Python 3.10 and pin `qdk>=1.30.0`
