### PR TITLE
Fix DOT fonts in workflow figure for docs

### DIFF
--- a/docs/source/_static/diagrams/workflow.dot
+++ b/docs/source/_static/diagrams/workflow.dot
@@ -10,7 +10,7 @@ digraph QuantumWorkflow {
     bgcolor="#FAFAFA";
 
     // Default node style
-    node [shape=box, style="rounded,filled", fontname="Arial", width=3.2, height=1.0, fixedsize=true, margin=0.2];
+    node [shape=box, style="rounded,filled", fontname="Arial", width=3.2, height=1.0, margin=0.2];
 
     // Input subgraph
     subgraph cluster_0 {


### PR DESCRIPTION
This pull request makes a minor update to the workflow diagram configuration by removing the `fixedsize=true` attribute from the default node style. This change allows node sizes to adjust automatically based on their content, improving diagram readability.