### PR TITLE
Fix arm64 apt mirror redirect breaking all Linux armv8-a wheel builds

### DIFF
--- a/.pipelines/pip-scripts/build-pip-wheels.sh
+++ b/.pipelines/pip-scripts/build-pip-wheels.sh
@@ -19,11 +19,14 @@ if [ "$MAC_BUILD" == "OFF" ]; then # Build/install Linux dependencies
     export DEBIAN_FRONTEND=noninteractive
 
     # CFSClean3: redirect Ubuntu apt endpoints to the Azure-internal mirror.
+    # Note: azure.archive.ubuntu.com only carries amd64/i386. Non-x86 architectures
+    # (e.g. arm64) live under ubuntu-ports and must go to azure.ports.ubuntu.com,
+    # otherwise apt gets a 404 for binary-<arch>/Packages and exits with code 100.
     _cfs_apt_redirect() {
         sed -i \
             -e 's|https\?://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
             -e 's|https\?://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
-            -e 's|https\?://ports.ubuntu.com/ubuntu-ports|http://azure.archive.ubuntu.com/ubuntu|g' \
+            -e 's|https\?://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
             "$1"
     }
     [ -f /etc/apt/sources.list.d/ubuntu.sources ] && _cfs_apt_redirect /etc/apt/sources.list.d/ubuntu.sources

--- a/.pipelines/pip-scripts/test-pip-wheels.sh
+++ b/.pipelines/pip-scripts/test-pip-wheels.sh
@@ -17,11 +17,14 @@ export DEBIAN_FRONTEND=noninteractive
 
 if [ "$MAC_BUILD" == "OFF" ]; then
     # CFSClean3: redirect Ubuntu apt endpoints to the Azure-internal mirror.
+    # Note: azure.archive.ubuntu.com only carries amd64/i386. Non-x86 architectures
+    # (e.g. arm64) live under ubuntu-ports and must go to azure.ports.ubuntu.com,
+    # otherwise apt gets a 404 for binary-<arch>/Packages and exits with code 100.
     _cfs_apt_redirect() {
         sed -i \
             -e 's|https\?://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
             -e 's|https\?://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
-            -e 's|https\?://ports.ubuntu.com/ubuntu-ports|http://azure.archive.ubuntu.com/ubuntu|g' \
+            -e 's|https\?://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
             "$1"
     }
     [ -f /etc/apt/sources.list.d/ubuntu.sources ] && _cfs_apt_redirect /etc/apt/sources.list.d/ubuntu.sources


### PR DESCRIPTION
## Problem

The nightly `qdk-chemistry-gh-wheels` pipeline has failed on `main` every single
night since 2026-07-16. Last green `main` build was `20260715.1` (167275).

Example: [build 169937](https://dev.azure.com/ms-azurequantum/AzureQuantum/_build/results?buildId=169937)

All five **`Build wheel (Linux armv8-a)`** jobs (Py3.10–3.14) fail with
`Bash exited with code '100'`, and both `RetryHelper` attempts fail identically:

```
Err:5  http://azure.archive.ubuntu.com/ubuntu noble/multiverse arm64 Packages
  404  Not Found [IP: 52.250.76.244 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/dists/noble/multiverse/binary-arm64/Packages  404  Not Found
E: Some index files failed to download.
```

## Root cause

`#574` ("Fix CFSClean3 violations in Linux pip-wheel pipeline", fe92cc2, merged 2026-07-16)
added an apt endpoint redirect for CFSClean3 compliance. It intended to cover arm64,
but pointed `ports.ubuntu.com/ubuntu-ports` at the **wrong** Azure mirror:

```sh
-e 's|https\?://ports.ubuntu.com/ubuntu-ports|http://azure.archive.ubuntu.com/ubuntu|g'
```

`azure.archive.ubuntu.com/ubuntu` only carries **amd64/i386**. Non-x86 architectures
are served from a separate `ubuntu-ports` archive. So on the arm64 agents the
arch-independent `InRelease` files resolved fine (masking the problem), but every
`dists/*/binary-arm64/Packages` fetch 404'd, `apt-get update` exited `100`, and the
job died before any build work started.

The correct Azure mirror for ports is `azure.ports.ubuntu.com/ubuntu-ports`.

## Fix

Redirect `ports.ubuntu.com/ubuntu-ports` to `azure.ports.ubuntu.com/ubuntu-ports`
in both `build-pip-wheels.sh` and `test-pip-wheels.sh`. The amd64 redirects are
unchanged, and this stays CFSClean3-compliant (still an Azure-internal mirror,
never the public archive).

## Verification

Ran the **actual patched `_cfs_apt_redirect` function extracted from the repo scripts**
inside real `mcr.microsoft.com/mirror/docker/library/ubuntu:24.04` containers
(the same image the pipeline uses), under qemu:

| Scenario | Result |
|---|---|
| `linux/arm64/v8` + `build-pip-wheels.sh` | ✅ `apt-get update` exit 0, all 19 arm64 indices fetched, `apt-get install` works |
| `linux/arm64/v8` + `test-pip-wheels.sh` | ✅ same |
| `linux/amd64` + `build-pip-wheels.sh` | ✅ no regression, still `azure.archive.ubuntu.com` |

Before/after on the exact failing URL:

```
404  http://azure.archive.ubuntu.com/ubuntu/dists/noble/main/binary-arm64/Packages.gz   (old)
200  http://azure.ports.ubuntu.com/ubuntu-ports/dists/noble/main/binary-arm64/Packages.gz  (new)
```

All 16 suite/component combinations (`noble{,-updates,-backports,-security}` ×
`main/universe/restricted/multiverse`) return `200` on the new endpoint.
Also confirmed the rewrite is idempotent and does not touch amd64 sources.

Container output on arm64 after the fix:

```
container arch: arm64
--- rewritten sources ---
URIs: http://azure.ports.ubuntu.com/ubuntu-ports/
URIs: http://azure.ports.ubuntu.com/ubuntu-ports/
--- apt-get update ---
Get:5 http://azure.ports.ubuntu.com/ubuntu-ports noble/main arm64 Packages [1776 kB]
...
Fetched 33.3 MB in 14s (2313 kB/s)
APT_UPDATE_EXIT=0
```

## Note on the other failure in build 169937

Build 169937 additionally shows three `Test wheel (Docker linux/amd64)` jobs failing
with `Bash exited with code '125'` /
`Error waiting for container: Canceled: grpc: the client connection is closing`.

That is **unrelated infrastructure flake**, not a code defect: it aborts at random
points (mid `pip install`, mid `apt-get download`, mid `pytest`), on distinct agents,
and does not appear in builds 169697/169623/169587/169296/169073, which failed
*only* from the arm64 apt bug. Left out of scope here.
