### PR TITLE
Correct example optional dependency requirements

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -23,8 +23,8 @@ The table below summarizes which [optional extras](https://github.com/microsoft/
 
 | Example | Install command |
 |---------|----------------|
-| `qpe_stretched_n2.ipynb` | `pip install 'qdk-chemistry[jupyter,qre]'` |
-| `state_prep_energy.ipynb` | `pip install 'qdk-chemistry[jupyter]'` |
+| `qpe_stretched_n2.ipynb` | `pip install 'qdk-chemistry[jupyter,qiskit-extras,qre]'` |
+| `state_prep_energy.ipynb` | `pip install 'qdk-chemistry[jupyter,qiskit-extras]'` |
 | `time_evolve_and_measure.ipynb` | `pip install 'qdk-chemistry[jupyter]'` |
 | `estimation_ising_2d.ipynb` | `pip install 'qdk-chemistry[jupyter,qre]'` |
 | `extended_hubbard.ipynb` | `pip install 'qdk-chemistry[jupyter,qre]'` |
@@ -33,6 +33,9 @@ The table below summarizes which [optional extras](https://github.com/microsoft/
 | `interoperability/qiskit/` | `pip install 'qdk-chemistry[qiskit-extras]'` |
 | `interoperability/openFermion/` | `pip install 'qdk-chemistry[openfermion-extras]'` |
 | `interoperability/rdkit/` | `pip install rdkit` |
+
+The `qiskit-extras` extra is not supported on Python 3.14. The `qre` extra
+requires Python 3.11 or newer.
 
 To install everything needed for all examples at once:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,8 +34,7 @@ The table below summarizes which [optional extras](https://github.com/microsoft/
 | `interoperability/openFermion/` | `pip install 'qdk-chemistry[openfermion-extras]'` |
 | `interoperability/rdkit/` | `pip install rdkit` |
 
-The `qiskit-extras` extra is not supported on Python 3.14. The `qre` extra
-requires Python 3.11 or newer.
+The `qiskit-extras` extra is not supported on Python 3.14.
 
 To install everything needed for all examples at once:
 


### PR DESCRIPTION
## Summary

- add `qiskit-extras` to the two notebook install commands that require it
- retain `qre` for the stretched N2 QPE notebook
- document the Python 3.14 restriction for Qiskit extras

## Verification

- compared the README commands with both notebook prerequisite cells
- verified `qdk[qre,jupyter]==1.30.0` resolves for Python 3.10 from published package metadata
- targeted pre-commit hooks for `examples/README.md` at `3b38c5b13c541d019b01e217f8089e8b2f8263be`
- markdownlint
- `git diff --check`

Closes #585
