### PR TITLE
Allow dense_pure_state to accept a dense amplitude vector

### DIFF
--- a/python/src/qdk_chemistry/algorithms/state_preparation/dense_pure_state.py
+++ b/python/src/qdk_chemistry/algorithms/state_preparation/dense_pure_state.py
@@ -5,6 +5,8 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from collections.abc import Sequence
+
 import numpy as np
 
 from qdk_chemistry.data import Wavefunction
@@ -38,20 +40,37 @@ class DensePureStatePreparation(StatePreparation):
         """
         return "dense_pure_state"
 
-    def _run_impl(self, wavefunction: Wavefunction) -> Circuit:
-        """Prepare a quantum circuit from a Wavefunction using PreparePureStateD.
+    def _run_impl(self, wavefunction: Wavefunction | Sequence[float] | np.ndarray) -> Circuit:
+        """Prepare a quantum circuit using PreparePureStateD.
 
-        Builds a dense statevector directly from the wavefunction's
-        determinants and coefficients, normalizes it, and wraps it in a
-        Q# ``StatePreparation`` circuit.
+        Accepts either a :class:`~qdk_chemistry.data.Wavefunction`, in which case
+        a dense statevector is built from its determinants and coefficients, or a
+        dense amplitude vector of length ``2**n_qubits`` given directly as a
+        sequence or array.
+
+        The amplitude-vector form exists because ``PreparePureStateD`` itself has
+        no notion of orbitals or determinants: once a statevector is in hand, the
+        remainder of this routine is independent of where it came from. Requiring
+        a ``Wavefunction`` forces callers who already hold amplitudes -- model
+        Hamiltonians, spin systems, or externally computed guiding states -- to
+        construct orbitals that carry no meaning for their problem.
 
         Args:
-            wavefunction: The target wavefunction to prepare.
+            wavefunction: The target wavefunction, or a real amplitude vector
+                whose length is a power of two.
 
         Returns:
             Circuit: A Circuit object implementing the state preparation.
 
+        Raises:
+            ValueError: If amplitudes are complex, the vector length is not a
+                power of two, the vector has zero norm, or more than 32 qubits
+                would be required.
+
         """
+        if not isinstance(wavefunction, Wavefunction):
+            return self._circuit_from_statevector(np.asarray(wavefunction))
+
         config_set = wavefunction.get_configuration_set()
         dets = wavefunction.get_active_determinants()
         coeffs = np.asarray(wavefunction.get_coefficients())
@@ -71,14 +90,36 @@ class DensePureStatePreparation(StatePreparation):
                 idx |= b << i
             statevector[idx] += coeff
 
-        row_map = list(range(n_qubits - 1, -1, -1))
+        return self._circuit_from_statevector(statevector, n_qubits=n_qubits)
+
+    @staticmethod
+    def _circuit_from_statevector(statevector: np.ndarray, n_qubits: int | None = None) -> Circuit:
+        """Wrap a dense real statevector in a Q# ``PreparePureStateD`` circuit."""
+        statevector = np.asarray(statevector)
+        if np.iscomplexobj(statevector):
+            if not np.allclose(statevector.imag, 0.0):
+                raise ValueError("Dense state preparation requires real amplitudes (imaginary part must be zero).")
+            statevector = statevector.real
+        statevector = statevector.astype(float, copy=True)
+
+        if n_qubits is None:
+            size = statevector.size
+            if size < 2 or size & (size - 1):
+                raise ValueError(f"Amplitude vector length must be a power of two greater than one. Got {size}.")
+            n_qubits = size.bit_length() - 1
+            if n_qubits > 32:
+                raise ValueError("Dense state preparation is only supported for up to 32 qubits.")
+            norm = float(np.linalg.norm(statevector))
+            if norm == 0.0:
+                raise ValueError("Cannot prepare a state from an all-zero amplitude vector.")
+            statevector /= norm
+
         state_prep_params = QSHARP_UTILS.StatePreparation.StatePreparationParams(
-            rowMap=row_map,
+            rowMap=list(range(n_qubits - 1, -1, -1)),
             stateVector=statevector.tolist(),
             expansionOps=[],
             numQubits=n_qubits,
         )
-
         qsharp_op = QSHARP_UTILS.StatePreparation.MakeStatePreparationOp(state_prep_params)
         qsharp_factory = QsharpFactoryData(
             program=QSHARP_UTILS.StatePreparation.MakeStatePreparationCircuit,

--- a/python/src/qdk_chemistry/algorithms/state_preparation/state_preparation.py
+++ b/python/src/qdk_chemistry/algorithms/state_preparation/state_preparation.py
@@ -5,6 +5,10 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from collections.abc import Sequence
+
+import numpy as np
+
 from qdk_chemistry.algorithms.base import Algorithm, AlgorithmFactory
 from qdk_chemistry.data import Circuit, Settings, Wavefunction
 
@@ -51,11 +55,13 @@ class StatePreparation(Algorithm):
         """Return the algorithm type name as state_prep."""
         return "state_prep"
 
-    def run(self, wavefunction: Wavefunction) -> Circuit:
+    def run(self, wavefunction: Wavefunction | Sequence[float] | np.ndarray) -> Circuit:
         """Prepare a quantum circuit that encodes the given wavefunction.
 
         Args:
-            wavefunction: The target wavefunction to prepare.
+            wavefunction: The target wavefunction to prepare. Implementations may
+                additionally accept a dense amplitude vector; see
+                :class:`~qdk_chemistry.algorithms.state_preparation.dense_pure_state.DensePureStatePreparation`.
 
         Returns:
             A Circuit object containing an OpenQASM3 string of the quantum circuit that prepares the wavefunction.

--- a/python/tests/test_state_preparation.py
+++ b/python/tests/test_state_preparation.py
@@ -903,3 +903,58 @@ def test_gf2x_with_tracking_edge_case_pseudo_diagonal():
 
     # Should have some operations recorded
     assert len(elimination_results.operations) > 0, "Should have recorded some operations"
+
+
+def test_dense_pure_state_accepts_amplitude_vector(wavefunction_4e4o):
+    """A dense amplitude vector produces the same circuit as the equivalent Wavefunction."""
+    state_prep = create("state_prep", "dense_pure_state")
+
+    circuit_from_wavefunction = state_prep.run(wavefunction_4e4o)
+    statevector = np.array(circuit_from_wavefunction._qsharp_factory.parameter["stateVector"])
+
+    circuit_from_vector = state_prep.run(statevector)
+
+    params_wfn = circuit_from_wavefunction._qsharp_factory.parameter
+    params_vec = circuit_from_vector._qsharp_factory.parameter
+    assert params_vec["numQubits"] == params_wfn["numQubits"]
+    assert params_vec["rowMap"] == params_wfn["rowMap"]
+    np.testing.assert_allclose(params_vec["stateVector"], params_wfn["stateVector"], atol=1e-12)
+    assert circuit_from_vector.qasm == circuit_from_wavefunction.qasm
+
+
+def test_dense_pure_state_amplitude_vector_is_normalized():
+    """An unnormalized amplitude vector is normalized before preparation."""
+    circuit = create("state_prep", "dense_pure_state").run([3.0, 4.0])
+    np.testing.assert_allclose(circuit._qsharp_factory.parameter["stateVector"], [0.6, 0.8], atol=1e-12)
+    assert circuit._qsharp_factory.parameter["numQubits"] == 1
+
+
+def test_dense_pure_state_amplitude_vector_accepts_list_and_array():
+    """Sequences and arrays are both accepted and give the same result."""
+    state_prep = create("state_prep", "dense_pure_state")
+    from_list = state_prep.run([0.0, 1.0, 1.0, 0.0])
+    from_array = state_prep.run(np.array([0.0, 1.0, 1.0, 0.0]))
+    assert from_list.qasm == from_array.qasm
+
+
+@pytest.mark.parametrize(
+    ("amplitudes", "message"),
+    [
+        ([1.0, 2.0, 3.0], "power of two"),
+        ([1.0], "power of two"),
+        ([0.0, 0.0], "all-zero"),
+        (np.array([1.0 + 1.0j, 0.0]), "real amplitudes"),
+    ],
+)
+def test_dense_pure_state_amplitude_vector_validation(amplitudes, message):
+    """Invalid amplitude vectors are rejected with an explanatory error."""
+    with pytest.raises(ValueError, match=message):
+        create("state_prep", "dense_pure_state").run(amplitudes)
+
+
+def test_dense_pure_state_amplitude_vector_allows_zero_imaginary_part():
+    """A complex array with zero imaginary part is accepted."""
+    circuit = create("state_prep", "dense_pure_state").run(np.array([1.0 + 0.0j, 1.0 + 0.0j]))
+    np.testing.assert_allclose(
+        circuit._qsharp_factory.parameter["stateVector"], [1 / np.sqrt(2), 1 / np.sqrt(2)], atol=1e-12
+    )


### PR DESCRIPTION
## Summary

`state_prep/dense_pure_state` currently only accepts a `Wavefunction`. Its `_run_impl` calls `get_configuration_set()` / `get_active_determinants()` for one purpose: to build a dense statevector. Every line after that point (`StatePreparationParams` -> `MakeStatePreparationOp` -> `Circuit`) is already independent of chemistry, and `PreparePureStateD` itself has no notion of orbitals or determinants.

Because `ConfigurationSet.__init__` requires `Orbitals` and raises if they are `None`, a caller who already holds amplitudes has to fabricate orbitals that carry no meaning for their problem in order to reach a routine that never looks at them.

**NEEDED-BY:** preparing an externally computed guiding state — a normalized amplitude vector over a qubit register with no molecular structure — fails with `AttributeError: 'numpy.ndarray' object has no attribute 'get_configuration_set'`. The only workarounds are to fabricate a molecule, or to duplicate the ~25 neutral lines of `_run_impl` outside the library, which then silently drifts from it.

## Change

- `_run_impl` accepts `Wavefunction | Sequence[float] | np.ndarray`.
- Both paths route through a new shared `_circuit_from_statevector` helper, so they are identical by construction rather than by maintenance.
- The `Wavefunction` path is behaviourally untouched.
- Amplitude vectors are normalized; non-power-of-two lengths, zero-norm vectors, `>32` qubits, and genuinely complex amplitudes are rejected with explanatory `ValueError`s. A complex array whose imaginary part is zero is accepted.

## Validation

Run against the released `2.0.0` wheel's compiled `_core` with these Python sources overlaid, because no local C++ toolchain was available:

- `tests/test_state_preparation.py` — **34 passed** (26 pre-existing and unmodified, plus 8 new).
- `tests/test_algorithms.py` — **30 passed**, no regression.
- Equivalence is asserted directly rather than assumed: for the `wavefunction_4e4o` fixture, feeding the statevector that the `Wavefunction` path produces back through the amplitude path yields the same `numQubits`, the same `rowMap`, `stateVector` agreeing to `1e-12` (measured max abs difference `0.0`), and identical QASM.
- `ruff format --check` clean. `ruff check` on the touched files is clean; the one error it reports (`PLR0917` at `sparse_isometry.py:739`) is pre-existing and in a file this PR does not modify.

## Notes for reviewers

- I could not build the C++ extension in my environment, so CI will be the first full-matrix build of this branch.
- `_circuit_from_statevector` is a private `@staticmethod`. If you would prefer it exposed publicly (e.g. as a module-level `circuit_from_statevector`), say so and I will adjust.
- The base `StatePreparation.run` type hint was widened to match, with the docstring noting that accepting amplitudes is implementation-specific rather than required of every implementation.
