### PR TITLE
Enable Qiskit extras on Python 3.14; skip qiskit-aer on Linux ARM64 and fix examples README

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,7 +23,7 @@ Most users should start with the PyPI install.
 - Supported platforms:
   - Linux: x86_64, arm64
   - macOS: arm64 (Apple Silicon)
-  - Windows: x86_64 (native and via [WSL](https://learn.microsoft.com/windows/wsl/install)), arm64 ([WSL](https://learn.microsoft.com/windows/wsl/install))
+  - Windows: x86_64 and arm64 via [WSL](https://learn.microsoft.com/windows/wsl/install)
 
 ### Step 1: Create a virtual environment
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,7 +23,7 @@ Most users should start with the PyPI install.
 - Supported platforms:
   - Linux: x86_64, arm64
   - macOS: arm64 (Apple Silicon)
-  - Windows: x86_64 and arm64 via [WSL](https://learn.microsoft.com/windows/wsl/install)
+  - Windows: x86_64 (native and via [WSL](https://learn.microsoft.com/windows/wsl/install)), arm64 ([WSL](https://learn.microsoft.com/windows/wsl/install))
 
 ### Step 1: Create a virtual environment
 
@@ -51,7 +51,7 @@ If you prefer a minimal install (core library only, no optional backends):
 python3 -m pip install qdk-chemistry
 ```
 
-> **NOTE:** The `all` and `qiskit-extras` extras are not supported on Python 3.14 because Qiskit does not yet publish Python 3.14 wheels. See the [Optional Extras](#optional-extras) table below for details and alternative install targets.
+> **NOTE:** On Python 3.14, `qiskit-aer` is omitted from the `qiskit-extras` and `all` extras on Linux ARM64 (aarch64), because Qiskit does not yet publish a Python 3.14 wheel for that platform. All other platforms (Linux x86_64, macOS, Windows) install the full set. See the [Optional Extras](#optional-extras) table below for details.
 
 ### Step 3: Verify the installation
 

--- a/docs/source/user/comprehensive/plugins.rst
+++ b/docs/source/user/comprehensive/plugins.rst
@@ -113,7 +113,9 @@ Alternatively, you can install them directly:
 
 .. note::
 
-   The ``qiskit-extras`` extra is not currently supported on Python 3.14.
+   On Python 3.14, ``qiskit-aer`` is omitted from ``qiskit-extras`` on Linux ARM64
+   (aarch64), because Qiskit does not yet publish a Python 3.14 wheel for that
+   platform. All other platforms install the full set.
 
 **Checking what is loaded:**
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,8 +23,8 @@ The table below summarizes which [optional extras](https://github.com/microsoft/
 
 | Example | Install command |
 |---------|----------------|
-| `qpe_stretched_n2.ipynb` | `pip install 'qdk-chemistry[jupyter,qre]'` |
-| `state_prep_energy.ipynb` | `pip install 'qdk-chemistry[jupyter]'` |
+| `qpe_stretched_n2.ipynb` | `pip install 'qdk-chemistry[jupyter,qiskit-extras,qre]'` |
+| `state_prep_energy.ipynb` | `pip install 'qdk-chemistry[jupyter,qiskit-extras]'` |
 | `time_evolve_and_measure.ipynb` | `pip install 'qdk-chemistry[jupyter]'` |
 | `estimation_ising_2d.ipynb` | `pip install 'qdk-chemistry[jupyter,qre]'` |
 | `extended_hubbard.ipynb` | `pip install 'qdk-chemistry[jupyter,qre]'` |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: C++",
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Quantum Computing",
@@ -92,13 +93,13 @@ plugins = [
   "pyscf>=2.9.0,<2.12.1; sys_platform != 'win32'"
 ]
 qiskit-extras = [
-  "qiskit[qasm3-import]>=2.2.0; python_version < '3.14'",
-  "qiskit-aer; python_version < '3.14'",
-  "qiskit-ibm-runtime>=0.46.1; python_version < '3.14'",
-  "qiskit-nature; python_version < '3.14'",
-  "qiskit-qasm3-import; python_version < '3.14'",
-  "pylatexenc==2.10; python_version < '3.14'",
-  "requests>=2.33.0; python_version < '3.14'"
+  "qiskit[qasm3-import]>=2.2.0",
+  "qiskit-aer",
+  "qiskit-ibm-runtime>=0.46.1",
+  "qiskit-nature",
+  "qiskit-qasm3-import",
+  "pylatexenc==2.10",
+  "requests>=2.33.0"
 ]
 qre = [
   "qdk[qre,jupyter]>=1.30.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -94,8 +94,7 @@ plugins = [
 ]
 qiskit-extras = [
   "qiskit[qasm3-import]>=2.2.0",
-  # No cp314 manylinux aarch64 wheel yet; source build needs network-restricted Conan. Restrict to Linux ARM64 only.
-  "qiskit-aer; python_version < '3.14' or platform_machine != 'aarch64' or sys_platform != 'linux'",
+  "qiskit-aer; python_version < '3.14' or platform_machine != 'aarch64' or sys_platform != 'linux'",  # cp314 manylinux aarch64 wheel not available
   "qiskit-ibm-runtime>=0.46.1",
   "qiskit-nature",
   "qiskit-qasm3-import",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -94,7 +94,8 @@ plugins = [
 ]
 qiskit-extras = [
   "qiskit[qasm3-import]>=2.2.0",
-  "qiskit-aer; python_version < '3.14' or platform_machine != 'aarch64'",  # cp314 manylinux aarch64 wheel not available
+  # No cp314 manylinux aarch64 wheel yet; source build needs network-restricted Conan. Restrict to Linux ARM64 only.
+  "qiskit-aer; python_version < '3.14' or platform_machine != 'aarch64' or sys_platform != 'linux'",
   "qiskit-ibm-runtime>=0.46.1",
   "qiskit-nature",
   "qiskit-qasm3-import",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -94,7 +94,7 @@ plugins = [
 ]
 qiskit-extras = [
   "qiskit[qasm3-import]>=2.2.0",
-  "qiskit-aer",
+  "qiskit-aer; python_version < '3.14' or platform_machine != 'aarch64'",  # cp314 manylinux aarch64 wheel not available
   "qiskit-ibm-runtime>=0.46.1",
   "qiskit-nature",
   "qiskit-qasm3-import",

--- a/python/tests/test_phase_estimation_qubitization.py
+++ b/python/tests/test_phase_estimation_qubitization.py
@@ -13,7 +13,7 @@ from qdk_chemistry.algorithms.phase_estimation.iterative_phase_estimation import
 from qdk_chemistry.algorithms.phase_estimation.standard_phase_estimation import StandardPhaseEstimation
 from qdk_chemistry.data import AlgorithmRef, Circuit, QubitOperator
 from qdk_chemistry.data.circuit import QsharpFactoryData
-from qdk_chemistry.plugins.qiskit import QDK_CHEMISTRY_HAS_QISKIT
+from qdk_chemistry.plugins.qiskit import QDK_CHEMISTRY_HAS_QISKIT, QDK_CHEMISTRY_HAS_QISKIT_AER
 from qdk_chemistry.utils.qsharp import QSHARP_UTILS
 
 from .reference_tolerances import (
@@ -217,7 +217,9 @@ class TestQPEWithQubitization:
         )
         assert np.isclose(result.raw_energy, reference_energy, atol=0.02)
 
-    @pytest.mark.skipif(not QDK_CHEMISTRY_HAS_QISKIT, reason="Qiskit not available")
+    @pytest.mark.skipif(
+        not QDK_CHEMISTRY_HAS_QISKIT_AER or not QDK_CHEMISTRY_HAS_QISKIT, reason="Qiskit Aer not available."
+    )
     def test_standard_qpe_with_qubitization_h2(self, h2_hamiltonian):
         """Verify standard QPE with qubitization recovers H2 ground-state energy."""
         # Exact ground state from qubit Hamiltonian solver (dense diagonalization)


### PR DESCRIPTION
## Summary

- Enable the `qiskit-extras` group on Python 3.14 (previously the whole group was gated behind `python_version < '3.14'`) and add the 3.14 classifier.
- Scope `qiskit-aer` so it is skipped only on **Linux ARM64 + Python 3.14**, where no cp314 `manylinux` aarch64 wheel exists.
- Gate `test_standard_qpe_with_qubitization_h2` on `QDK_CHEMISTRY_HAS_QISKIT_AER` so it skips where Aer is absent.
- Fixes `examples/README.md` install commands to include `qiskit-extras` for the Qiskit-based notebooks (#585).

## Why

The nightly wheels pipeline failed on the Linux ARM64 / Python 3.14 job: with no cp314 aarch64 wheel, pip built `qiskit-aer` from source, which needs Conan to reach `center.conan.io` — blocked by the pipeline's network isolation.

```toml
"qiskit-aer; python_version < '3.14' or platform_machine != 'aarch64'",
```

This excludes `qiskit-aer` only when `python_version >= 3.14` **and** `platform_machine == 'aarch64'` (Linux ARM64). macOS arm64 (`arm64`), Linux x86_64, and Windows all have cp314 wheels and report a different `platform_machine`, so they are unaffected.

## Testing impact

Aer-dependent tests gate on `QDK_CHEMISTRY_HAS_QISKIT_AER` (from `importlib.util.find_spec`), so they skip cleanly where the package is absent.

## Follow-up

Drop the `platform_machine` clause once upstream ships a cp314 manylinux aarch64 `qiskit-aer` wheel.