### PR TITLE
Give tensor loaders distinct serialization names

### DIFF
--- a/cpp/include/qdk/chemistry/data/symmetry/symmetry_blocked_tensor.hpp
+++ b/cpp/include/qdk/chemistry/data/symmetry/symmetry_blocked_tensor.hpp
@@ -157,11 +157,12 @@ class SymmetryBlockedTensor
   // ---- DataClass interface ------------------------------------------------
 
   /**
-   * @brief @ref DataClass type identifier.
-   * @return The stable string @c "symmetry_blocked_tensor".
+   * @brief @ref DataClass type identifier for this specialization.
+   * @return A stable identifier of the form @c symmetry_blocked_tensor_r2c.
    */
   std::string get_data_type_name() const override {
-    return "symmetry_blocked_tensor";
+    return "symmetry_blocked_tensor_r" + std::to_string(Rank) +
+           (utils::is_complex_scalar_v<Scalar> ? "c" : "r");
   }
 
   /**

--- a/python/tests/test_symmetry_blocked_tensor.py
+++ b/python/tests/test_symmetry_blocked_tensor.py
@@ -31,6 +31,36 @@ def unrestricted_spin():
     return syms, alpha, beta
 
 
+@pytest.mark.parametrize(
+    ("tensor_type", "rank", "is_complex"),
+    [
+        (sym.SymmetryBlockedTensorRank1, 1, False),
+        (sym.SymmetryBlockedTensorRank1Complex, 1, True),
+        (sym.SymmetryBlockedTensorRank2, 2, False),
+        (sym.SymmetryBlockedTensorRank2Complex, 2, True),
+        (sym.SymmetryBlockedTensorRank3, 3, False),
+        (sym.SymmetryBlockedTensorRank3Complex, 3, True),
+        (sym.SymmetryBlockedTensorRank4, 4, False),
+        (sym.SymmetryBlockedTensorRank4Complex, 4, True),
+    ],
+)
+def test_tensor_specializations_have_distinct_loader_names(
+    unrestricted_spin,
+    tensor_type,
+    rank,
+    is_complex,
+):
+    """Each serialized tensor name identifies one concrete loader."""
+    syms, alpha, beta = unrestricted_spin
+    extents = [{alpha: 1, beta: 1}] * rank
+    labels = (alpha,) * rank
+    scalar = 1.0 + 1.0j if is_complex else 1.0
+    block = np.full((1,) if rank in (1, 4) else (1, 1), scalar)
+    tensor = tensor_type([syms] * rank, extents, [(labels, block)])
+
+    assert tensor.get_data_type_name() == f"symmetry_blocked_tensor_r{rank}{'c' if is_complex else 'r'}"
+
+
 class TestSymmetryBlockedTensorRank2:
     """Tests for the rank-2 (matrix) symmetry-blocked tensor."""
 


### PR DESCRIPTION
- Give each symmetry-blocked tensor specialization a distinct serialization type name.
- Encode tensor rank and scalar type in the name, for example `symmetry_blocked_tensor_r2c`.
- Add coverage for all eight real and complex tensor specializations.

Previously, every specialization reported `symmetry_blocked_tensor`, so serialization could not select the exact loader type.
