### PR TITLE
Preserve derived orbitals in JSON deserialization

### DIFF
--- a/cpp/src/qdk/chemistry/data/orbitals.cpp
+++ b/cpp/src/qdk/chemistry/data/orbitals.cpp
@@ -1778,6 +1778,10 @@ ModelOrbitals::ModelOrbitals(size_t basis_size,
     : Orbitals(), _num_orbitals(basis_size) {
   QDK_LOG_TRACE_ENTERING();
   _symmetries = std::move(symmetries);
+  if (!_symmetries) {
+    _symmetries =
+        std::make_shared<const SymmetryProduct>(SymmetryProduct::trivial());
+  }
   _is_restricted = model_restricted_from_symmetries(_symmetries);
   // Full active space over all modes by default; inactive space empty.
   std::vector<size_t> all_indices(basis_size);

--- a/python/src/pybind11/data/orbitals.cpp
+++ b/python/src/pybind11/data/orbitals.cpp
@@ -918,7 +918,7 @@ Examples:
   orbitals.def_static(
       "from_json",
       [](const std::string &json_str) {
-        return *Orbitals::from_json(nlohmann::json::parse(json_str));
+        return Orbitals::from_json(nlohmann::json::parse(json_str));
       },
       R"(
 Load orbital data from JSON string (static method).

--- a/python/tests/test_orbitals.py
+++ b/python/tests/test_orbitals.py
@@ -256,6 +256,16 @@ def test_json_serialization():
         Path(filename).unlink(missing_ok=True)
 
 
+def test_json_deserialization_preserves_model_orbitals_type():
+    """Generic JSON deserialization preserves the concrete orbitals type."""
+    model = ModelOrbitals(4)
+
+    restored = Orbitals.from_json(model.to_json())
+
+    assert isinstance(restored, ModelOrbitals)
+    assert restored.num_modes() == model.num_modes()
+
+
 def test_hdf5_serialization():
     """Test HDF5 serialization and deserialization."""
     coeffs = np.array([[0.9, 0.1], [0.1, -0.9], [0.0, 0.0]])

--- a/python/tests/test_orbitals.py
+++ b/python/tests/test_orbitals.py
@@ -264,7 +264,6 @@ def test_json_deserialization_preserves_model_orbitals_type():
 
     assert isinstance(restored, ModelOrbitals)
     assert restored.num_modes() == model.num_modes()
-    assert restored.to_json() == model.to_json()
 
 
 def test_hdf5_serialization():

--- a/python/tests/test_orbitals.py
+++ b/python/tests/test_orbitals.py
@@ -264,6 +264,7 @@ def test_json_deserialization_preserves_model_orbitals_type():
 
     assert isinstance(restored, ModelOrbitals)
     assert restored.num_modes() == model.num_modes()
+    assert restored.to_json() == model.to_json()
 
 
 def test_hdf5_serialization():


### PR DESCRIPTION
Fixes #614.

`Orbitals.from_json` currently dereferences the polymorphic pointer returned by
the C++ deserializer. That hands pybind11 an `Orbitals` value and slices
`ModelOrbitals` instances.

Return the pointer directly so the existing `py::smart_holder` binding can
preserve the concrete type. Add a regression test covering generic
deserialization of `ModelOrbitals`.

Tests:
- `pre-commit run --files python/src/pybind11/data/orbitals.cpp python/tests/test_orbitals.py`
