### PR TITLE
Remove check-up-to-date job from build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -37,33 +37,6 @@ permissions:
   statuses: write
 
 jobs:
-  check-up-to-date:
-    name: Check if branch is up to date with main
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        submodules: recursive
-
-    - name: Check if branch is up to date with main (Pull Request)
-      run: |
-        # Ensure origin/main is present
-        git fetch --no-tags --prune origin +refs/heads/main:refs/remotes/origin/main
-
-        # Check if the current commit is ahead of main
-        # Kills pipeline if branch is not up to date with main
-        # For pull requests, we use github.event.pull_request.sha to get the commit SHA,
-        # as GitHub treats the current commit as one that would be produced by merging into main
-        if ! git merge-base --is-ancestor origin/main "${{ github.event.pull_request.head.sha }}"; then
-          echo "This branch is not up to date with main. Please merge the latest changes from main into your branch to continue."
-          exit 1
-        fi
-
-        echo "Branch is up to date, starting Build and Test workflow."
-
   coverage:
     name: ${{ matrix.os-name }} Build, Test, and Coverage Analysis
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
Removes the check-up-to-date job from the workflow.

The job does not stop pipelines, it turns pipelines into the failed state while not blocking and the PRs being fine to merge via merge queue.

This job is outdated and can be removed or should be made blocking as the documentation suggests.