### PR TITLE
Fix BLIS/libFLAME symbol collision in Linux wheel builds

### DIFF
--- a/cpp/src/qdk/chemistry/algorithms/microsoft/localization/gauge_fixing.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/localization/gauge_fixing.cpp
@@ -377,8 +377,6 @@ std::shared_ptr<data::Wavefunction> GaugeFixingLocalizer::_run_impl(
             const double cosine = std::cos(angle);
             const double sine = std::sin(angle);
             Eigen::MatrixXd candidate = active_rotation;
-            // Use the header-only template: the wheel's BLIS and legacy
-            // libFLAME archives both export the out-of-line rotation symbols.
             blas::rot<double, double>(num_active, candidate.col(left).data(), 1,
                                       candidate.col(right).data(), 1, cosine,
                                       sine);

--- a/cpp/src/qdk/chemistry/algorithms/microsoft/localization/gauge_fixing.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/microsoft/localization/gauge_fixing.cpp
@@ -377,8 +377,11 @@ std::shared_ptr<data::Wavefunction> GaugeFixingLocalizer::_run_impl(
             const double cosine = std::cos(angle);
             const double sine = std::sin(angle);
             Eigen::MatrixXd candidate = active_rotation;
-            blas::rot(num_active, candidate.col(left).data(), 1,
-                      candidate.col(right).data(), 1, cosine, sine);
+            // Use the header-only template: the wheel's BLIS and legacy
+            // libFLAME archives both export the out-of-line rotation symbols.
+            blas::rot<double, double>(num_active, candidate.col(left).data(), 1,
+                                      candidate.col(right).data(), 1, cosine,
+                                      sine);
             return coefficient_norm(candidate);
           };
 
@@ -412,8 +415,9 @@ std::shared_ptr<data::Wavefunction> GaugeFixingLocalizer::_run_impl(
             current_norm = plane_norm(canonical_angle);
             const double cosine = std::cos(canonical_angle);
             const double sine = std::sin(canonical_angle);
-            blas::rot(num_active, active_rotation.col(left).data(), 1,
-                      active_rotation.col(right).data(), 1, cosine, sine);
+            blas::rot<double, double>(
+                num_active, active_rotation.col(left).data(), 1,
+                active_rotation.col(right).data(), 1, cosine, sine);
           }
         }
       }


### PR DESCRIPTION
Fixes #661 

## Summary

Use explicit template arguments for `blas::rot` so BLAS++ selects its header-only implementation instead of the compiled wrapper.

The compiled wrapper references `drot_`, causing the linker to extract BLIS's `bla_rot.o`. That object also defines `crot_` and `zrot_`, which conflict with the same symbols provided by libFLAME.

Using `blas::rot<double, double>(...)` preserves the numerical operation while avoiding the external wrapper and conflicting member.

## Validation

I used the following minimal example to reproduce the static-library link conflict between BLIS and libFLAME:

```bash
cat > rot.cpp <<'CPP'
#include <blas.hh>
#include <cstdint>

extern "C" void crot_();
extern "C" void zrot_();

int main() {
  double x[]{1, 0}, y[]{0, 1};
#ifdef FIXED
  blas::rot<double, double>(std::int64_t{2}, x, 1, y, 1, 0.8, 0.6);
#else
  blas::rot(std::int64_t{2}, x, 1, y, 1, 0.8, 0.6);
#endif
  crot_();
  zrot_();
}
CPP

cat > flame.c <<'C'
void crot_(void) {}
void zrot_(void) {}
C

cat > blis.c <<'C'
void srot_(void) {}
void drot_(void) {}
void csrot_(void) {}
void zdrot_(void) {}
void crot_(void) {}
void zrot_(void) {}
C

gcc -c flame.c && ar rcs libflame.a flame.o
gcc -c blis.c -o bla_rot.o && ar rcs libblis.a bla_rot.o
g++ -std=c++20 -I/usr/local/include -c rot.cpp -o old.o
g++ -std=c++20 -I/usr/local/include -DFIXED -c rot.cpp -o fixed.o
```
The original call reproduced the link failure:
```bash
g++ old.o /usr/local/lib/libblaspp.a libflame.a libblis.a -fopenmp -lm -o old
```
```
/usr/bin/ld: libblis.a(bla_rot.o): multiple definition of `crot_';
libflame.a(flame.o): first defined here
/usr/bin/ld: libblis.a(bla_rot.o): multiple definition of `zrot_';
libflame.a(flame.o): first defined here
collect2: error: ld returned 1 exit status
```
The explicit-template version linked successfully with the same libraries and link order:
```bash
g++ fixed.o /usr/local/lib/libblaspp.a libflame.a libblis.a -fopenmp -lm -o fixed
```