### PR TITLE
Update molecular QPE tutorial to current sparse-isometry API

### DIFF
--- a/docs/source/_static/examples/python/tutorial_prepare_trial_state.py
+++ b/docs/source/_static/examples/python/tutorial_prepare_trial_state.py
@@ -325,7 +325,7 @@ def run_trial_state_workflow(
 
         ################################################################################
         # start-cell-preparation-circuit
-        state_preparation = create("state_prep", "sparse_isometry_gf2x")
+        state_preparation = create("state_prep", "sparse_isometry")
         circuit = state_preparation.run(trial_wavefunction)
         num_compute_qubits, num_logical_gates, logical_gate_counts = circuit_statistics(
             circuit

--- a/docs/source/_static/examples/python/tutorial_qpe_setup.py
+++ b/docs/source/_static/examples/python/tutorial_qpe_setup.py
@@ -58,7 +58,7 @@ required_implementations = (
     create("hamiltonian_constructor", "qdk"),
     create("multi_configuration_calculator", "macis_cas"),
     create("qubit_mapper", "qdk"),
-    create("state_prep", "sparse_isometry_gf2x"),
+    create("state_prep", "sparse_isometry"),
     create("phase_estimation", "qdk_iterative"),
     create("circuit_executor", "qdk_full_state_simulator"),
 )

--- a/docs/source/tutorials/ground_state_molecular_energies_with_qpe/05_preparing_the_trial_state.rst
+++ b/docs/source/tutorials/ground_state_molecular_energies_with_qpe/05_preparing_the_trial_state.rst
@@ -191,7 +191,7 @@ Compare the gate types and circuit structure before revealing the answer below.
 
 To measure the generated logical-circuit cost, the script traverses the decomposed :ref:`Q# circuit representation <tutorial-qsharp>`, counts displayed gate records that have no nested child operations, and identifies controlled X gates as CNOT gates.
 The script creates the QDK/Chemistry sparse-isometry implementation and inspects the generated Q# logical circuit.
-The factory key :ref:`sparse_isometry_gf2x <sparse-isometry-gf2x>` is the implementation's current API identifier using a helper function to count gates:
+The factory key :ref:`sparse_isometry <sparse-isometry>` selects the current implementation:
 
 .. literalinclude:: ../../_static/examples/python/tutorial_prepare_trial_state.py
    :language: python

--- a/docs/source/user/comprehensive/algorithms/state_preparation.rst
+++ b/docs/source/user/comprehensive/algorithms/state_preparation.rst
@@ -75,6 +75,7 @@ You can discover available implementations programmatically:
       :start-after: # start-cell-list-implementations
       :end-before: # end-cell-list-implementations
 
+.. _sparse-isometry:
 .. _sparse-isometry-gf2x:
 
 Sparse Isometry


### PR DESCRIPTION
## Summary

- replace the deprecated `sparse_isometry_gf2x` tutorial factory key with `sparse_isometry`
- update the tutorial setup check and Chapter 5 API link
- add the canonical documentation anchor while retaining the legacy anchor for existing links

## Stack

This PR is stacked on #667 and should be reviewed relative to `tutorial/notebook-script-cleanup`. Merge it only after #667.

## Validation

Local builds and test suites were intentionally not run; CI/CD provides validation for this focused API migration.

Closes #669
