### PR TITLE
Use analytic gradients by default for nuclear derivatives

### DIFF
--- a/cpp/include/qdk/chemistry/algorithms/geometry_optimization.hpp
+++ b/cpp/include/qdk/chemistry/algorithms/geometry_optimization.hpp
@@ -48,8 +48,7 @@ class GeometryOptimizerSettings : public data::Settings {
    */
   GeometryOptimizerSettings() {
     set_default("derivative_calculator",
-                data::AlgorithmRef("nuclear_derivative_calculator",
-                                   "qdk_finite_difference"),
+                data::AlgorithmRef("nuclear_derivative_calculator", "qdk"),
                 "Nuclear derivative calculator used to evaluate energies and "
                 "gradients during optimization.");
     set_default("max_iterations", static_cast<int64_t>(300),

--- a/cpp/include/qdk/chemistry/algorithms/nuclear_derivative.hpp
+++ b/cpp/include/qdk/chemistry/algorithms/nuclear_derivative.hpp
@@ -51,10 +51,12 @@ class NuclearDerivativeSettings : public data::Settings {
   NuclearDerivativeSettings() {
     set_default(
         "energy_calculator", data::AlgorithmRef("scf_solver", "qdk"),
-        "Algorithm used for each energy evaluation. Use an scf_solver for "
-        "direct SCF finite differences, a multi_configuration_scf solver for "
-        "MCSCF energies, or a multi_configuration_calculator such as CASCI or "
-        "ASCI for Hamiltonian-based multi-reference energies.");
+        "Electronic-structure algorithm used by the derivative calculator. "
+        "The qdk implementation requires scf_solver/qdk and uses its analytic "
+        "gradients. The qdk_finite_difference implementation also accepts a "
+        "multi_configuration_scf solver or a multi_configuration_calculator "
+        "such as CASCI or ASCI for numeric derivatives of multi-reference "
+        "energies.");
     allow_algorithm_ref_type_change("energy_calculator");
     set_default(
         "orbital_solver", data::AlgorithmRef("scf_solver", "qdk"),
@@ -195,9 +197,7 @@ struct NuclearDerivativeCalculatorFactory
   /**
    * @brief Return the default nuclear derivative implementation name.
    */
-  static std::string default_algorithm_name() {
-    return "qdk_finite_difference";
-  }
+  static std::string default_algorithm_name() { return "qdk"; }
 };
 
 }  // namespace qdk::chemistry::algorithms

--- a/cpp/src/qdk/chemistry/algorithms/qdk_nuclear_derivative.cpp
+++ b/cpp/src/qdk/chemistry/algorithms/qdk_nuclear_derivative.cpp
@@ -4,10 +4,12 @@
 
 #include "qdk_nuclear_derivative.hpp"
 
+#include <Eigen/Dense>
 #include <memory>
 #include <optional>
 #include <qdk/chemistry/algorithms/scf.hpp>
 #include <qdk/chemistry/data/nuclear_gradients.hpp>
+#include <qdk/chemistry/data/nuclear_hessian.hpp>
 #include <qdk/chemistry/utils/logger.hpp>
 #include <stdexcept>
 
@@ -26,12 +28,6 @@ NuclearDerivativeResult QdkNuclearDerivativeCalculator::_run_impl(
   }
   if (!structure) {
     throw std::invalid_argument("Structure must not be null");
-  }
-  if (_settings->get<bool>("compute_hessian")) {
-    throw std::invalid_argument(
-        "The QDK analytic nuclear derivative calculator does not currently "
-        "provide Hessians. Use the finite_difference implementation for "
-        "numeric Hessians.");
   }
 
   const auto ref = _settings->get<data::AlgorithmRef>("energy_calculator");
@@ -54,18 +50,47 @@ NuclearDerivativeResult QdkNuclearDerivativeCalculator::_run_impl(
     solver.settings().update(*ref.get_settings());
   }
 
-  auto scf_result =
-      solver.run_with_analytic_gradient(structure, charge, spin_multiplicity,
-                                        detail::seed_to_scf_input(seed, true));
-  auto nuclear_gradient = scf_result.nuclear_gradient;
-  if (!nuclear_gradient.has_value()) {
-    throw std::runtime_error(
-        "Internal SCF did not return the requested analytic nuclear gradient");
-  }
-  auto gradients = std::make_shared<data::NuclearGradients>(
-      detail::copy_structure(structure), *nuclear_gradient);
+  auto evaluate = [&](const std::shared_ptr<data::Structure>& current_structure,
+                      bool allow_orbital_guess) {
+    auto result = solver.run_with_analytic_gradient(
+        current_structure, charge, spin_multiplicity,
+        detail::seed_to_scf_input(seed, allow_orbital_guess));
+    if (!result.nuclear_gradient.has_value()) {
+      throw std::runtime_error(
+          "Internal SCF did not return the requested analytic nuclear "
+          "gradient");
+    }
+    return result;
+  };
 
-  return {scf_result.energy, gradients, std::nullopt, scf_result.wavefunction};
+  auto scf_result = evaluate(structure, true);
+  auto gradients = std::make_shared<data::NuclearGradients>(
+      detail::copy_structure(structure), *scf_result.nuclear_gradient);
+
+  std::optional<std::shared_ptr<data::NuclearHessian>> hessian;
+  if (_settings->get<bool>("compute_hessian")) {
+    const auto dimension =
+        static_cast<Eigen::Index>(3 * structure->get_num_atoms());
+    const double step = _settings->get<double>("finite_difference_step");
+    Eigen::MatrixXd hessian_matrix =
+        Eigen::MatrixXd::Zero(dimension, dimension);
+    for (Eigen::Index coordinate = 0; coordinate < dimension; ++coordinate) {
+      auto plus_structure =
+          detail::displace_structure(structure, coordinate, step);
+      auto minus_structure =
+          detail::displace_structure(structure, coordinate, -step);
+      auto plus = evaluate(plus_structure, false);
+      auto minus = evaluate(minus_structure, false);
+      hessian_matrix.col(coordinate) =
+          (*plus.nuclear_gradient - *minus.nuclear_gradient) / (2.0 * step);
+    }
+    hessian_matrix =
+        (0.5 * (hessian_matrix + hessian_matrix.transpose())).eval();
+    hessian = std::make_shared<data::NuclearHessian>(
+        detail::copy_structure(structure), hessian_matrix);
+  }
+
+  return {scf_result.energy, gradients, hessian, scf_result.wavefunction};
 }
 
 std::unique_ptr<NuclearDerivativeCalculator>

--- a/cpp/src/qdk/chemistry/algorithms/qdk_nuclear_derivative.hpp
+++ b/cpp/src/qdk/chemistry/algorithms/qdk_nuclear_derivative.hpp
@@ -11,8 +11,23 @@
 
 namespace qdk::chemistry::algorithms {
 
+class QdkNuclearDerivativeSettings : public NuclearDerivativeSettings {
+ public:
+  QdkNuclearDerivativeSettings() : NuclearDerivativeSettings() {
+    set_default(
+        "finite_difference_step", 1.0e-3,
+        "Central nuclear displacement step in Bohr used to compute Hessians "
+        "by finite differences of analytic gradients.",
+        data::BoundConstraint<double>{1.0e-8, 1.0});
+  }
+};
+
 class QdkNuclearDerivativeCalculator : public NuclearDerivativeCalculator {
  public:
+  QdkNuclearDerivativeCalculator() {
+    _settings = std::make_unique<QdkNuclearDerivativeSettings>();
+  }
+
   std::string name() const final { return "qdk"; }
 
   std::vector<std::string> aliases() const final {

--- a/cpp/tests/test_nuclear_derivative.cpp
+++ b/cpp/tests/test_nuclear_derivative.cpp
@@ -6,6 +6,7 @@
 
 #include <cmath>
 #include <memory>
+#include <qdk/chemistry/algorithms/geometry_optimization.hpp>
 #include <qdk/chemistry/algorithms/localization.hpp>
 #include <qdk/chemistry/algorithms/mc.hpp>
 #include <qdk/chemistry/algorithms/nuclear_derivative.hpp>
@@ -185,8 +186,20 @@ TEST(NuclearDerivativeSettingsTest, SettingsHaveUserFacingDescriptions) {
 }
 
 TEST(NuclearDerivativeSettingsTest,
+     GeometryOptimizationDefaultsToAnalyticGradients) {
+  GeometryOptimizerSettings settings;
+  const auto derivative_calculator =
+      settings.get<AlgorithmRef>("derivative_calculator");
+
+  EXPECT_EQ(derivative_calculator.get_algorithm_type(),
+            "nuclear_derivative_calculator");
+  EXPECT_EQ(derivative_calculator.get_algorithm_name(), "qdk");
+}
+
+TEST(NuclearDerivativeSettingsTest,
      FiniteDifferenceSettingsHaveUserFacingDescriptions) {
-  auto calculator = NuclearDerivativeCalculatorFactory::create();
+  auto calculator =
+      NuclearDerivativeCalculatorFactory::create("qdk_finite_difference");
   for (const auto& key :
        {"reuse_seed_active_space", "finite_difference_step"}) {
     EXPECT_TRUE(calculator->settings().has_description(key)) << key;
@@ -194,15 +207,16 @@ TEST(NuclearDerivativeSettingsTest,
   }
 }
 
-TEST(NuclearDerivativeSettingsTest,
-     ImplementationSettingsBelongToFiniteDifferenceOnly) {
-  auto finite_difference = NuclearDerivativeCalculatorFactory::create();
+TEST(NuclearDerivativeSettingsTest, ImplementationSpecificSettingsAreScoped) {
+  auto finite_difference =
+      NuclearDerivativeCalculatorFactory::create("qdk_finite_difference");
   auto analytic = NuclearDerivativeCalculatorFactory::create("qdk");
 
   EXPECT_TRUE(finite_difference->settings().has("reuse_seed_active_space"));
   EXPECT_TRUE(finite_difference->settings().has("finite_difference_step"));
   EXPECT_FALSE(analytic->settings().has("reuse_seed_active_space"));
-  EXPECT_FALSE(analytic->settings().has("finite_difference_step"));
+  EXPECT_TRUE(analytic->settings().has("finite_difference_step"));
+  EXPECT_TRUE(analytic->settings().has_description("finite_difference_step"));
 }
 
 TEST(NuclearDerivativeDataTest, GradientsReferenceStructureAndRoundTripJson) {
@@ -248,7 +262,8 @@ TEST(NuclearDerivativeDataTest, HessianReferencesStructureAndRoundTripsJson) {
 }
 
 TEST(NuclearDerivativeCalculatorTest, FiniteDifferenceRunsRealScfForWater) {
-  auto calculator = NuclearDerivativeCalculatorFactory::create();
+  auto calculator =
+      NuclearDerivativeCalculatorFactory::create("qdk_finite_difference");
   calculator->settings().set("compute_hessian", true);
   calculator->settings().set("finite_difference_step", 1.0e-3);
 
@@ -276,6 +291,31 @@ TEST(NuclearDerivativeCalculatorTest, FiniteDifferenceRunsRealScfForWater) {
   EXPECT_TRUE((*hessian)->get_matrix().isApprox(
       (*hessian)->get_matrix().transpose(), 1.0e-8));
 
+  ASSERT_TRUE(wavefunction.has_value());
+  EXPECT_NE(*wavefunction, nullptr);
+}
+
+TEST(NuclearDerivativeCalculatorTest,
+     QdkAnalyticBuildsHessianFromAnalyticGradients) {
+  auto calculator = NuclearDerivativeCalculatorFactory::create();
+  EXPECT_EQ(calculator->name(), "qdk");
+  calculator->settings().set("compute_hessian", true);
+  calculator->settings().set("finite_difference_step", 1.0e-3);
+
+  auto structure = testing::create_lih_structure();
+  auto [energy, gradients, hessian, wavefunction] =
+      calculator->run(structure, 0, 1, std::string("sto-3g"), 0);
+
+  EXPECT_TRUE(std::isfinite(energy));
+  ASSERT_NE(gradients, nullptr);
+  EXPECT_TRUE(gradients->get_values().allFinite());
+  ASSERT_TRUE(hessian.has_value());
+  ASSERT_NE(*hessian, nullptr);
+  const auto& matrix = (*hessian)->get_matrix();
+  EXPECT_EQ(matrix.rows(), 6);
+  EXPECT_EQ(matrix.cols(), 6);
+  EXPECT_TRUE(matrix.allFinite());
+  EXPECT_TRUE(matrix.isApprox(matrix.transpose(), 1.0e-12));
   ASSERT_TRUE(wavefunction.has_value());
   EXPECT_NE(*wavefunction, nullptr);
 }
@@ -358,7 +398,8 @@ TEST(NuclearDerivativeCalculatorTest,
       testing::with_active_space(wavefunction->get_orbitals(),
                                  std::vector<size_t>{0}, std::vector<size_t>{});
 
-  auto calculator = NuclearDerivativeCalculatorFactory::create();
+  auto calculator =
+      NuclearDerivativeCalculatorFactory::create("qdk_finite_difference");
   calculator->settings().set(
       "energy_calculator",
       AlgorithmRef("multi_configuration_calculator",
@@ -407,7 +448,8 @@ TEST(NuclearDerivativeCalculatorTest,
       testing::with_active_space(wavefunction->get_orbitals(),
                                  std::vector<size_t>{0}, std::vector<size_t>{});
 
-  auto calculator = NuclearDerivativeCalculatorFactory::create();
+  auto calculator =
+      NuclearDerivativeCalculatorFactory::create("qdk_finite_difference");
   calculator->settings().set(
       "energy_calculator",
       AlgorithmRef("multi_configuration_calculator",

--- a/python/src/pybind11/algorithms/nuclear_derivative.cpp
+++ b/python/src/pybind11/algorithms/nuclear_derivative.cpp
@@ -80,6 +80,18 @@ Args:
 Returns:
     tuple: ``(energy, gradients, hessian, wavefunction)``.
 )");
+  calculator.def(
+      "hash",
+      [](const NuclearDerivativeCalculator& self,
+         std::shared_ptr<Structure> structure, int charge,
+         int spin_multiplicity, NuclearDerivativeSeedType seed,
+         unsigned int n_inactive_orbitals) {
+        return self.hash(structure, charge, spin_multiplicity, seed,
+                         n_inactive_orbitals);
+      },
+      py::arg("structure"), py::arg("charge"), py::arg("spin_multiplicity"),
+      py::arg("seed_or_basis"), py::arg("n_inactive_orbitals") = 0,
+      R"(Compute a deterministic content hash for a derivative run.)");
   calculator.def("settings", &NuclearDerivativeCalculator::settings,
                  py::return_value_policy::reference_internal,
                  R"(Return the calculator settings.)");
@@ -96,6 +108,8 @@ Returns:
       R"(Internal settings replacement hook for Python subclasses.)");
   calculator.def("name", &NuclearDerivativeCalculator::name,
                  R"(Return the implementation name.)");
+  calculator.def("aliases", &NuclearDerivativeCalculator::aliases,
+                 R"(Return all registered names for the implementation.)");
   calculator.def("type_name", &NuclearDerivativeCalculator::type_name,
                  R"(Return the algorithm type name.)");
   calculator.def("__repr__", [](const NuclearDerivativeCalculator& self) {
@@ -118,7 +132,7 @@ Returns:
   py::class_<QdkNuclearDerivativeCalculator, NuclearDerivativeCalculator,
              py::smart_holder>(
       m, "QdkNuclearDerivativeCalculator",
-      R"(QDK nuclear derivative calculator using analytic internal SCF gradients.)")
+      R"(QDK nuclear derivative calculator using analytic internal SCF gradients and gradient-difference Hessians.)")
       .def(py::init<>(),
-           R"(Create a QDK analytic nuclear derivative calculator.)");
+           R"(Create a QDK analytic-gradient nuclear derivative calculator.)");
 }

--- a/python/tests/test_geometric_plugin.py
+++ b/python/tests/test_geometric_plugin.py
@@ -55,7 +55,7 @@ def test_geometric_optimizer_settings():
     assert isinstance(settings, algorithms.GeometryOptimizerSettings)
     derivative_ref = settings.get("derivative_calculator")
     assert derivative_ref.algorithm_type == "nuclear_derivative_calculator"
-    assert derivative_ref.algorithm_name == "qdk_finite_difference"
+    assert derivative_ref.algorithm_name == "qdk"
 
     assert settings.get("transition_state") is False
     assert settings.get("optimizer") == "tric"

--- a/python/tests/test_nuclear_derivative.py
+++ b/python/tests/test_nuclear_derivative.py
@@ -58,8 +58,8 @@ def test_nuclear_derivative_factory_registered():
     """Create the default nuclear derivative calculator from the factory."""
     calculator = algorithms.create("nuclear_derivative_calculator")
 
-    assert isinstance(calculator, algorithms.NuclearDerivativeCalculator)
-    assert calculator.name() == "qdk_finite_difference"
+    assert isinstance(calculator, algorithms.QdkNuclearDerivativeCalculator)
+    assert calculator.name() == "qdk"
 
 
 def test_qdk_nuclear_derivative_factory_registered():
@@ -68,6 +68,14 @@ def test_qdk_nuclear_derivative_factory_registered():
 
     assert isinstance(calculator, algorithms.QdkNuclearDerivativeCalculator)
     assert calculator.name() == "qdk"
+
+
+def test_geometry_optimizer_factory_registered():
+    """The geometry optimizer algorithm type is registered in the core registry."""
+    assert algorithms.show_default("geometry_optimizer") == "geometric"
+    available = algorithms.available("geometry_optimizer")
+    assert isinstance(available, list)
+    assert not available or "geometric" in available
 
 
 def test_nuclear_derivative_data_roundtrip_json_file(tmp_path):

--- a/python/tests/ui/test_mcp_tools.py
+++ b/python/tests/ui/test_mcp_tools.py
@@ -225,7 +225,7 @@ def test_list_algorithms_filters_by_type():
     assert result["status"] == "ok"
     algorithm_types = result["result"]["algorithm_types"]
     assert list(algorithm_types) == ["nuclear_derivative_calculator"]
-    assert algorithm_types["nuclear_derivative_calculator"]["default"] == "qdk_finite_difference"
+    assert algorithm_types["nuclear_derivative_calculator"]["default"] == "qdk"
     assert "qdk" in algorithm_types["nuclear_derivative_calculator"]["implementations"]
 
 
@@ -264,12 +264,14 @@ def test_describe_algorithm_falls_back_when_default_is_unavailable(monkeypatch):
 
 
 def test_describe_algorithm_returns_settings_schema():
-    result = srv.describe_algorithm(algorithm_type="nuclear_derivative_calculator", algorithm_name="qdk")
+    result = srv.describe_algorithm(
+        algorithm_type="nuclear_derivative_calculator", algorithm_name="qdk_finite_difference"
+    )
 
     assert result["status"] == "ok"
     description = result["result"]
-    assert description["name"] == "qdk"
-    assert description["aliases"] == ["analytical_gradient", "qdk"]
+    assert description["name"] == "qdk_finite_difference"
+    assert description["aliases"] == ["numeric", "qdk_finite_difference"]
     assert description["is_default"] is False
     assert description["default_settings"]["compute_hessian"] is False
     settings = {setting["name"]: setting for setting in description["settings"]}
@@ -282,8 +284,8 @@ def test_describe_algorithm_reports_nuclear_derivative_default_aliases():
 
     assert result["status"] == "ok"
     description = result["result"]
-    assert description["name"] == "qdk_finite_difference"
-    assert description["aliases"] == ["numeric", "qdk_finite_difference"]
+    assert description["name"] == "qdk"
+    assert description["aliases"] == ["analytical_gradient", "qdk"]
     assert description["is_default"] is True
 
 


### PR DESCRIPTION
- Make the QDK analytic nuclear derivative calculator the default.
- Use analytic SCF gradients for nuclear-gradient calculations.
- Compute nuclear Hessians using central finite differences of analytic gradients.
- Update geometry optimization to use the analytic derivative calculator by default.
- Expose derivative calculator hashing and aliases through Python bindings.
- Update C++ and Python tests for the new behavior.