### PR TITLE
Add reference for sparse isometry state preparation

### DIFF
--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -128,6 +128,14 @@
     doi={10.22331/q-2021-06-21-412},
     url={http://arxiv.org/abs/2006.00016}
 }
+@article{Chen2026,
+    title={{Clifford}-efficient sparse state preparation for molecular wavefunctions},
+    author={Yingrong Chen and Nathan A. Baker and Rushi Gong and Conrad S. N. Johnston and Brad Lackey and Hongbin Liu and Sasha Schmidt and Yuan Su and David B. Williams-Young and Yinuo Yang},
+    journal={arXiv},
+    year={2026},
+    doi={10.48550/arXiv.2608.20593},
+    url={https://arxiv.org/abs/2608.20593}
+}
 @article{Lehtola2018,
     title={Recent developments in {Libxc} — A comprehensive library of functionals for density functional theory},
     author={Susi Lehtola and Conrad Steigemann and Micael J. T. Oliveira and Miguel A. L. Marques},

--- a/docs/source/user/comprehensive/algorithms/state_preparation.rst
+++ b/docs/source/user/comprehensive/algorithms/state_preparation.rst
@@ -82,7 +82,7 @@ Sparse Isometry
 
 .. rubric:: Factory name: ``"sparse_isometry"``
 
-This method is an optimized approach that leverages sparsity in the target wavefunction. It is a modification of the original sparse isometry work in :cite:`Malvetti2021`, and is native to QDK/Chemistry. By working only with the non-zero amplitudes, it substantially reduces circuit depth and gate count compared with dense methods, and is especially efficient for wavefunctions with sparse amplitude structure.
+This method is an optimized approach that leverages sparsity in the target wavefunction. It is a modification of the original sparse isometry work in :cite:`Malvetti2021`, and is native to QDK/Chemistry, described in :cite:`Chen2026`. By working only with the non-zero amplitudes, it substantially reduces circuit depth and gate count compared with dense methods, and is especially efficient for wavefunctions with sparse amplitude structure.
 
 .. rubric:: How it works
 

--- a/python/src/qdk_chemistry/algorithms/state_preparation/sparse_isometry.py
+++ b/python/src/qdk_chemistry/algorithms/state_preparation/sparse_isometry.py
@@ -209,6 +209,7 @@ class SparseIsometryStatePreparation(StatePreparation):
     Key References:
 
         * Sparse isometry: Malvetti, Iten, and Colbeck (arXiv:2006.00016) :cite:`Malvetti2021`
+        * GF(2) affine compression and binary encoding: Chen et al. (arXiv:2608.20593) :cite:`Chen2026`
 
     """
 


### PR DESCRIPTION
## Summary

Adds the reference for the sparse state preparation algorithm implemented in QDK/Chemistry: [*Clifford-efficient sparse state preparation for molecular wavefunctions*](https://arxiv.org/abs/2608.20593) (arXiv:2608.20593).

## Changes

- `docs/source/references.bib` — new `Chen2026` entry, following the existing arXiv-preprint style (DOI + arXiv URL)
- `docs/source/user/comprehensive/algorithms/state_preparation.rst` — cite `Chen2026` in the Sparse Isometry section
- `python/src/qdk_chemistry/algorithms/state_preparation/sparse_isometry.py` — add the paper to the "Key References" list in the `SparseIsometryStatePreparation` docstring

Documentation only; no behavior changes.