### PR TITLE
Add QCE 2026 tutorial landing page to the published docs site

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_stages: [pre-commit, pre-push]
 # Define the list of directories to lint
 # You can extend this list to include more directories over time
 files: &linted_files .*
-exclude: \.(xyz|fcidump|wfn|qasm)$
+exclude: \.(xyz|fcidump|wfn|qasm|ics)$
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/docs/source/_extra/qce26-tutorial/.gitattributes
+++ b/docs/source/_extra/qce26-tutorial/.gitattributes
@@ -1,0 +1,3 @@
+# RFC 5545 requires CRLF line endings in iCalendar files.
+# Treat .ics as binary so git never normalises them.
+*.ics -text

--- a/docs/source/_extra/qce26-tutorial/both-sessions.ics
+++ b/docs/source/_extra/qce26-tutorial/both-sessions.ics
@@ -1,0 +1,73 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Microsoft Quantum Development Kit//QCE 2026 Tutorial//EN
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+X-WR-CALNAME:Microsoft QDK Tutorials - QCE 2026
+X-WR-TIMEZONE:America/Toronto
+BEGIN:VTIMEZONE
+TZID:America/Toronto
+BEGIN:DAYLIGHT
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+TZNAME:EDT
+DTSTART:19700308T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+TZNAME:EST
+DTSTART:19701101T020000
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:qdk-qce2026-tutorial-session1@microsoft.com
+DTSTAMP:20260811T000000Z
+DTSTART;TZID=America/Toronto:20260916T100000
+DTEND;TZID=America/Toronto:20260916T113000
+SUMMARY:QDK Tutorial (Session 1): From Molecules to Logical Qubits
+DESCRIPTION:Session 1 of the Microsoft Quantum Development Kit tutorial at 
+ IEEE Quantum Week (QCE 2026).\n\nFrom Molecules to Logical Qubits: A Pract
+ ical Tutorial on the Microsoft Quantum Development Kit (QDK)\n\nFull detai
+ ls: https://qce.quantum.ieee.org/2026/qce26-schedule/tutorial-schedule/#12
+ 97-1
+LOCATION:Room 715B\, Metro Toronto Convention Centre\, 255 Front St W\, Tor
+ onto\, ON\, Canada
+URL:https://qce.quantum.ieee.org/2026/qce26-schedule/tutorial-schedule/#129
+ 7-1
+STATUS:CONFIRMED
+TRANSP:OPAQUE
+SEQUENCE:0
+BEGIN:VALARM
+TRIGGER:-PT30M
+ACTION:DISPLAY
+DESCRIPTION:QDK Tutorial Session 1 starts in 30 minutes - Room 715B
+END:VALARM
+END:VEVENT
+BEGIN:VEVENT
+UID:qdk-qce2026-tutorial-session2@microsoft.com
+DTSTAMP:20260811T000000Z
+DTSTART;TZID=America/Toronto:20260916T130000
+DTEND;TZID=America/Toronto:20260916T143000
+SUMMARY:QDK Tutorial (Session 2): From Molecules to Logical Qubits
+DESCRIPTION:Session 2 of the Microsoft Quantum Development Kit tutorial at 
+ IEEE Quantum Week (QCE 2026).\n\nFrom Molecules to Logical Qubits: A Pract
+ ical Tutorial on the Microsoft Quantum Development Kit (QDK)\n\nFull detai
+ ls: https://qce.quantum.ieee.org/2026/qce26-schedule/tutorial-schedule/#12
+ 97-1
+LOCATION:Room 715B\, Metro Toronto Convention Centre\, 255 Front St W\, Tor
+ onto\, ON\, Canada
+URL:https://qce.quantum.ieee.org/2026/qce26-schedule/tutorial-schedule/#129
+ 7-1
+STATUS:CONFIRMED
+TRANSP:OPAQUE
+SEQUENCE:0
+BEGIN:VALARM
+TRIGGER:-PT30M
+ACTION:DISPLAY
+DESCRIPTION:QDK Tutorial Session 2 starts in 30 minutes - Room 715B
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/docs/source/_extra/qce26-tutorial/index.html
+++ b/docs/source/_extra/qce26-tutorial/index.html
@@ -1,0 +1,822 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>The Microsoft Quantum Development Kit &middot; QCE26 Tutorial</title>
+<meta name="description" content="From Molecules to Logical Qubits: A Practical Tutorial on the Microsoft Quantum Development Kit (QDK). Two 90-minute sessions at IEEE Quantum Week (QCE 2026), Toronto. Add your preferred session to your calendar.">
+<meta name="theme-color" content="#0a1020">
+<meta property="og:title" content="The Microsoft Quantum Development Kit · QCE26 Tutorial">
+<meta property="og:description" content="Two 90-minute sessions · Wednesday, September 16, 2026 · Room 715B · Metro Toronto Convention Centre">
+<meta property="og:type" content="website">
+<link rel="icon" href="data:image/svg+xml,&lt;svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 32 32%22&gt;&lt;rect width=%2213%22 height=%2213%22 x=%222%22 y=%222%22 fill=%22%23f25022%22/&gt;&lt;rect width=%2213%22 height=%2213%22 x=%2217%22 y=%222%22 fill=%22%237fba00%22/&gt;&lt;rect width=%2213%22 height=%2213%22 x=%222%22 y=%2217%22 fill=%22%2300a4ef%22/&gt;&lt;rect width=%2213%22 height=%2213%22 x=%2217%22 y=%2217%22 fill=%22%23ffb900%22/&gt;&lt;/svg&gt;">
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+
+  :root {
+    /* Palette sampled from the QCE 2026 flyer */
+    --navy-950: #0a1020;
+    --navy-900: #0f1733;
+    --navy-800: #192451;
+    --purple:   #413d78;
+    --blue-900: #0a2a5d;
+    --blue-800: #023c6a;
+    --blue-600: #0e5293;
+    --blue-500: #145192;
+    --ms-blue:  #0077d4;
+    --cyan:     #15ddf3;
+
+    --white: #ffffff;
+    --row:   #edf2f9;
+    --ink:   #0a2a5d;
+    --ink-2: #33405c;
+    --ink-3: #5a6b88;
+    --line:  rgba(10, 42, 93, .12);
+
+    --on-dark:     #eaf0fb;
+    --on-dark-dim: #9fb0d0;
+    --dark-line:   rgba(255, 255, 255, .14);
+
+    --font-display: "Segoe UI Variable Display", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+    --font-body: "Segoe UI Variable Text", "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", Arial, sans-serif;
+    --font-mono: "Cascadia Code", "Consolas", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+    --radius: 18px;
+    --header-h: 62px;
+  }
+
+  html {
+    -webkit-text-size-adjust: 100%;
+    scroll-behavior: smooth;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    html { scroll-behavior: auto; }
+    * { transition: none !important; animation: none !important; }
+  }
+
+  body {
+    margin: 0;
+    min-height: 100dvh;
+    font-family: var(--font-body);
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--on-dark);
+    background:
+      radial-gradient(900px 620px at 8% 4%, rgba(65, 61, 120, .55), transparent 62%),
+      radial-gradient(760px 540px at 96% 12%, rgba(14, 82, 147, .45), transparent 60%),
+      radial-gradient(820px 620px at 50% 108%, rgba(65, 61, 120, .60), transparent 64%),
+      var(--navy-950);
+    background-attachment: fixed;
+  }
+
+  .container {
+    width: 100%;
+    max-width: 1080px;
+    margin-inline: auto;
+    padding-inline: clamp(18px, 4vw, 32px);
+  }
+
+  .sr-only {
+    position: absolute; width: 1px; height: 1px;
+    padding: 0; margin: -1px; overflow: hidden;
+    clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+  }
+  .skip-link {
+    position: absolute; left: 12px; top: -60px; z-index: 100;
+    padding: 10px 16px; border-radius: 10px;
+    background: var(--cyan); color: var(--navy-950);
+    font-weight: 700; text-decoration: none;
+    transition: top .15s ease;
+  }
+  .skip-link:focus { top: 12px; }
+
+  :where(a, button):focus-visible {
+    outline: 2px solid var(--cyan);
+    outline-offset: 3px;
+    border-radius: 6px;
+  }
+
+  /* ---------------- Header ---------------- */
+
+  .site-header {
+    position: sticky; top: 0; z-index: 50;
+    background: rgba(10, 16, 32, .82);
+    -webkit-backdrop-filter: saturate(160%) blur(14px);
+    backdrop-filter: saturate(160%) blur(14px);
+    border-bottom: 1px solid var(--dark-line);
+  }
+  .header-inner {
+    min-height: var(--header-h);
+    display: flex; align-items: center; gap: 16px;
+    flex-wrap: wrap;
+  }
+  .brand {
+    display: inline-flex; align-items: center; gap: 10px;
+    margin-right: auto;
+    color: var(--white); text-decoration: none;
+    font-family: var(--font-display);
+    font-weight: 700; font-size: 15px; letter-spacing: .01em;
+  }
+  .brand-mark {
+    display: grid; grid-template-columns: 9px 9px; gap: 2.5px;
+    flex-shrink: 0;
+  }
+  .brand-mark i { display: block; width: 9px; height: 9px; }
+  .brand-mark i:nth-child(1) { background: #f25022; }
+  .brand-mark i:nth-child(2) { background: #7fba00; }
+  .brand-mark i:nth-child(3) { background: #00a4ef; }
+  .brand-mark i:nth-child(4) { background: #ffb900; }
+  .brand-text small {
+    display: block; font-size: 11px; font-weight: 500;
+    letter-spacing: .14em; text-transform: uppercase;
+    color: var(--cyan);
+  }
+
+  .nav-toggle {
+    display: none;
+    align-items: center; gap: 8px;
+    padding: 8px 14px; border-radius: 10px;
+    background: rgba(255, 255, 255, .07);
+    border: 1px solid var(--dark-line);
+    color: var(--on-dark);
+    font: inherit; font-size: 14px; font-weight: 600;
+    cursor: pointer;
+  }
+
+  .site-nav { display: flex; align-items: center; gap: 6px; }
+  .site-nav a {
+    padding: 8px 12px; border-radius: 9px;
+    color: var(--on-dark-dim); text-decoration: none;
+    font-size: 14.5px; font-weight: 600;
+    transition: color .15s ease, background .15s ease;
+  }
+  .site-nav a:hover { color: var(--white); background: rgba(255, 255, 255, .07); }
+  .site-nav .nav-cta {
+    color: var(--navy-950);
+    background: var(--cyan);
+    margin-left: 6px;
+  }
+  .site-nav .nav-cta:hover { background: #6ce9f8; color: var(--navy-950); }
+
+  @media (max-width: 760px) {
+    .nav-toggle { display: inline-flex; }
+    .site-nav {
+      display: none;
+      flex-basis: 100%;
+      flex-direction: column; align-items: stretch; gap: 2px;
+      padding-bottom: 12px;
+    }
+    .site-nav.is-open { display: flex; }
+    .site-nav a { padding: 12px 14px; }
+    .site-nav .nav-cta { margin-left: 0; margin-top: 6px; text-align: center; }
+  }
+
+  /* ---------------- Hero ---------------- */
+
+  .hero {
+    position: relative; isolation: isolate; overflow: hidden;
+    background:
+      radial-gradient(720px 420px at 88% -10%, rgba(21, 221, 243, .30), transparent 62%),
+      radial-gradient(640px 460px at 68% 30%, rgba(120, 190, 240, .22), transparent 60%),
+      linear-gradient(135deg, var(--blue-800) 0%, var(--blue-600) 58%, var(--blue-500) 100%);
+    border-bottom: 1px solid rgba(255, 255, 255, .10);
+  }
+  /* Faint Q# code watermark, echoing the flyer artwork */
+  .hero-code {
+    position: absolute; inset: -8% -6% auto auto; z-index: -2;
+    width: 78%;
+    margin: 0; padding: 0;
+    font-family: var(--font-mono);
+    font-size: clamp(14px, 1.75vw, 24px);
+    line-height: 2.05; white-space: pre;
+    color: rgba(255, 255, 255, .14);
+    transform: rotate(-9deg);
+    -webkit-user-select: none; user-select: none;
+    pointer-events: none;
+    -webkit-mask-image: linear-gradient(100deg, transparent 8%, #000 44%, #000 80%, transparent 100%);
+    mask-image: linear-gradient(100deg, transparent 8%, #000 44%, #000 80%, transparent 100%);
+  }
+  @media (max-width: 860px) { .hero-code { width: 130%; inset: -4% -30% auto auto; } }
+  /* Soft translucent ribbon, echoing the flyer artwork */
+  .hero-ribbon {
+    position: absolute; z-index: -1; pointer-events: none;
+    top: -34%; right: -14%; width: min(72%, 720px); aspect-ratio: 1.35;
+    background:
+      radial-gradient(closest-side, rgba(21, 221, 243, .34), transparent 72%),
+      radial-gradient(closest-side at 62% 58%, rgba(255, 255, 255, .22), transparent 70%);
+    border-radius: 50% 50% 46% 54% / 58% 42% 58% 42%;
+    filter: blur(6px);
+  }
+
+  .hero-grid {
+    position: relative;
+    display: grid; gap: clamp(26px, 4vw, 48px);
+    grid-template-columns: minmax(0, 1.15fr) minmax(0, .85fr);
+    align-items: start;
+    padding-block: clamp(48px, 8vw, 86px) clamp(30px, 4vw, 44px);
+  }
+  @media (max-width: 860px) { .hero-grid { grid-template-columns: 1fr; } }
+
+  .eyebrow {
+    display: inline-flex; align-items: center; gap: 10px;
+    margin: 0 0 18px;
+    font-size: 12px; font-weight: 700;
+    letter-spacing: .16em; text-transform: uppercase;
+    color: var(--cyan);
+  }
+  .eyebrow::before {
+    content: ""; width: 26px; height: 2px; border-radius: 2px;
+    background: linear-gradient(90deg, var(--cyan), rgba(21, 221, 243, 0));
+    flex-shrink: 0;
+  }
+
+  .hero h1 {
+    margin: 0 0 18px;
+    font-family: var(--font-display);
+    font-weight: 800; font-stretch: 87.5%;
+    font-size: clamp(30px, 5.2vw, 54px);
+    line-height: .98; letter-spacing: -.02em;
+    text-transform: uppercase;
+    color: var(--white);
+  }
+  /* One word per line so the Q / D / K initials always stack into "QDK" */
+  .hero h1 .hl-line { display: block; }
+  .hero h1 .hl-key { color: var(--cyan); }
+  .hero-sub {
+    margin: 0 0 26px; max-width: 44ch;
+    font-size: clamp(16px, 1.7vw, 19px); line-height: 1.5;
+    color: rgba(255, 255, 255, .88);
+  }
+
+  .hero-panel {
+    padding: 22px 24px;
+    background: rgba(6, 19, 40, .58);
+    border: 1px solid rgba(255, 255, 255, .24);
+    /* impeccable-disable side-tab -- deliberate: reproduces the cyan left edge
+       on the white panel of the printed QCE 2026 flyer this page pairs with. */
+    border-left: 4px solid var(--cyan);
+    border-radius: 14px;
+    box-shadow: 0 14px 34px rgba(2, 7, 20, .34);
+    -webkit-backdrop-filter: blur(6px); backdrop-filter: blur(6px);
+  }
+  .panel-label {
+    display: block; margin-bottom: 8px;
+    font-size: 11.5px; font-weight: 700;
+    letter-spacing: .16em; text-transform: uppercase;
+    color: var(--cyan);
+  }
+  .panel-title {
+    margin: 0 0 14px;
+    font-family: var(--font-display);
+    font-size: 25px; font-weight: 700; line-height: 1.15;
+    color: var(--white);
+  }
+  .panel-line { display: block; height: 1px; background: rgba(255, 255, 255, .18); margin-bottom: 14px; }
+  .panel-note { margin: 0; font-size: 14.5px; line-height: 1.55; color: rgba(255, 255, 255, .82); }
+  .panel-note strong { color: var(--white); font-weight: 700; }
+
+  .hero-actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 26px; }
+
+  .button {
+    display: inline-flex; align-items: center; justify-content: center; gap: 9px;
+    min-height: 48px; padding: 12px 22px;
+    border-radius: 11px; border: 1px solid transparent;
+    font-family: inherit; font-size: 15.5px; font-weight: 700;
+    text-decoration: none; cursor: pointer;
+    transition: transform .12s ease, filter .12s ease, background .15s ease;
+  }
+  .button svg { width: 19px; height: 19px; flex-shrink: 0; fill: none; stroke: currentColor; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+  .button:active { transform: scale(.985); }
+  .button--primary { background: var(--cyan); color: var(--navy-950); }
+  .button--primary:hover { filter: brightness(1.07); }
+  .button--onblue { background: rgba(255, 255, 255, .10); color: var(--white); border-color: rgba(255, 255, 255, .28); }
+  .button--onblue:hover { background: rgba(255, 255, 255, .18); }
+  .button--ms { background: var(--ms-blue); color: var(--white); }
+  .button--ms:hover { filter: brightness(1.08); }
+  .button--ghost { background: var(--white); color: var(--ink); border-color: var(--line); }
+  .button--ghost:hover { background: var(--row); }
+
+  /* Three flyer highlights across the bottom of the hero */
+  .highlights {
+    position: relative;
+    display: grid; gap: 14px;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    padding-bottom: clamp(44px, 6vw, 68px);
+  }
+  @media (max-width: 860px) { .highlights { grid-template-columns: 1fr; } }
+  .highlight {
+    padding: 22px;
+    background: var(--white);
+    border: 1px solid rgba(10, 42, 93, .1);
+    border-radius: 14px;
+    box-shadow: 0 16px 38px rgba(2, 7, 20, .28);
+  }
+  .highlight h3 {
+    margin: 0 0 8px;
+    font-family: var(--font-display);
+    font-size: 17px; font-weight: 700; line-height: 1.3;
+    color: var(--blue-900);
+  }
+  .highlight p { margin: 0; font-size: 14.5px; line-height: 1.55; color: var(--ink-2); }
+
+  /* ---------------- Sections ---------------- */
+
+  .section { padding-block: clamp(46px, 7vw, 82px); scroll-margin-top: calc(var(--header-h) + 12px); }
+
+  .section-head { margin-bottom: clamp(24px, 3.4vw, 38px); max-width: 62ch; }
+  .section-head h2 {
+    margin: 0 0 12px;
+    font-family: var(--font-display);
+    font-weight: 800; font-stretch: 87.5%;
+    font-size: clamp(28px, 4.4vw, 42px);
+    line-height: 1.06; letter-spacing: -.015em;
+    text-transform: uppercase;
+    color: var(--white);
+    text-wrap: balance;
+  }
+  .section-lead { margin: 0; font-size: 16.5px; line-height: 1.62; color: var(--on-dark-dim); }
+  .section-lead strong { color: var(--white); font-weight: 600; }
+
+  /* The white card, mirroring the flyer's cyan-edged panel */
+  .panel-card {
+    background: var(--white);
+    color: var(--ink-2);
+    border-radius: var(--radius);
+    /* impeccable-disable side-tab -- deliberate: reproduces the cyan left edge
+       on the white panel of the printed QCE 2026 flyer this page pairs with. */
+    border-left: 5px solid var(--cyan);
+    box-shadow: 0 24px 60px rgba(3, 8, 24, .42);
+    overflow: hidden;
+  }
+
+  /* ---------------- Sessions ---------------- */
+
+  .session-grid {
+    display: grid; gap: 16px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    padding: clamp(20px, 3vw, 28px);
+  }
+  @media (max-width: 760px) { .session-grid { grid-template-columns: 1fr; } }
+
+  .session {
+    display: flex; flex-direction: column;
+    padding: 22px;
+    background: var(--row);
+    border: 1px solid var(--line);
+    border-radius: 14px;
+  }
+  .session-head { display: flex; align-items: center; gap: 10px; margin-bottom: 14px; flex-wrap: wrap; }
+  .session-badge {
+    padding: 6px 13px; border-radius: 7px;
+    background: var(--blue-900); color: var(--white);
+    font-family: var(--font-display);
+    font-size: 12px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase;
+  }
+  .session-part { font-size: 13px; font-weight: 600; letter-spacing: .06em; text-transform: uppercase; color: var(--ink-3); }
+  .session-time {
+    margin: 0 0 6px;
+    font-family: var(--font-display);
+    font-size: clamp(23px, 3vw, 28px); font-weight: 700;
+    line-height: 1.1; letter-spacing: -.01em;
+    color: var(--ink);
+  }
+  .session-time span { font-size: .6em; font-weight: 700; color: var(--ink-3); margin-left: 5px; }
+  .session-meta { margin: 0 0 18px; font-size: 14.5px; color: var(--ink-3); }
+  .session-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: auto; }
+  .session-actions .button { flex: 1 1 168px; }
+
+  .session-foot {
+    padding: 0 clamp(20px, 3vw, 28px) clamp(22px, 3vw, 28px);
+    margin-top: -6px;
+    text-align: center;
+  }
+  .text-link {
+    display: inline-flex; align-items: center; gap: 6px;
+    color: var(--ms-blue); font-size: 14.5px; font-weight: 600;
+    text-decoration: none; border-bottom: 1px solid rgba(0, 119, 212, .35); padding-bottom: 2px;
+  }
+  .text-link:hover { border-bottom-color: var(--ms-blue); }
+
+  /* ---------------- Agenda ---------------- */
+
+  .agenda {
+    padding: clamp(22px, 3vw, 30px) clamp(20px, 3vw, 28px);
+    border-top: 1px solid var(--line);
+    background: linear-gradient(180deg, #f7f9fd, var(--white));
+  }
+  .agenda-head {
+    display: flex; align-items: baseline; justify-content: space-between;
+    gap: 14px; flex-wrap: wrap; margin-bottom: 18px;
+  }
+  .agenda-head h3 {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 20px; font-weight: 700; letter-spacing: -.01em;
+    color: var(--ink);
+  }
+  .agenda-head p { margin: 0; font-size: 13.5px; color: var(--ink-3); }
+  .agenda-grid { display: grid; gap: 12px; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  @media (max-width: 760px) { .agenda-grid { grid-template-columns: 1fr; } }
+
+  /* Each session gets its own labelled row of blocks, split by the midday break */
+  .agenda-session {
+    margin: 0 0 10px;
+    display: flex; align-items: center; gap: 9px;
+    font-family: var(--font-display);
+    font-size: 12.5px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase;
+    color: var(--blue-900);
+  }
+  .agenda-session::before {
+    content: ""; flex-shrink: 0;
+    width: 9px; height: 9px;
+    background: var(--ms-blue);
+  }
+  .agenda-session + .agenda-grid { margin-bottom: 0; }
+  .agenda-break {
+    display: flex; align-items: center; gap: 14px;
+    margin: 20px 0;
+    font-size: 12.5px; font-weight: 600; letter-spacing: .06em; text-transform: uppercase;
+    color: var(--ink-3);
+  }
+  .agenda-break::before, .agenda-break::after {
+    content: ""; flex: 1 1 auto; height: 1px; background: var(--line);
+  }
+  .agenda-card {
+    padding: 18px;
+    background: var(--white);
+    border: 1px solid var(--line);
+    border-top: 3px solid var(--ms-blue);
+    border-radius: 12px;
+  }
+  .card-number {
+    display: block; margin-bottom: 9px;
+    font-family: var(--font-mono);
+    font-size: 11.5px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase;
+    color: var(--ms-blue);
+  }
+  .agenda-card h4 {
+    margin: 0 0 5px;
+    font-family: var(--font-display);
+    font-size: 17px; font-weight: 700; color: var(--ink);
+  }
+  .agenda-card p { margin: 0; font-size: 14.5px; color: var(--ink-3); }
+
+  /* ---------------- Audience ---------------- */
+
+  .info-body { max-width: 74ch; }
+  .info-body > p:first-child { margin-top: 0; font-size: 16.5px; line-height: 1.62; color: var(--on-dark-dim); }
+  .info-body > p:first-child strong { color: var(--white); font-weight: 700; }
+
+  /* Plain labelled rows - hairline rules instead of nested boxes, so the
+     section reads as one continuous column rather than boxes within a box. */
+  .req-list { list-style: none; margin: 24px 0 0; padding: 0; display: grid; gap: 20px; }
+  .req-list li { padding-top: 20px; border-top: 1px solid var(--dark-line); }
+  .req-list strong {
+    display: block; margin-bottom: 6px;
+    font-family: var(--font-display);
+    font-size: 12.5px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase;
+    color: var(--cyan);
+  }
+  .req-list span { display: block; font-size: 15.5px; line-height: 1.58; color: var(--on-dark-dim); }
+
+  /* ---------------- Resources ---------------- */
+
+  .resource-grid { display: grid; gap: 14px; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  @media (max-width: 860px) { .resource-grid { grid-template-columns: 1fr; } }
+  .resource {
+    display: flex; flex-direction: column; gap: 8px;
+    padding: 26px 24px;
+    background: rgba(25, 36, 81, .58);
+    border: 1px solid var(--dark-line);
+    border-radius: 14px;
+    color: inherit; text-decoration: none;
+    transition: background .15s ease, border-color .15s ease, transform .15s ease;
+  }
+  .resource:hover { background: rgba(25, 36, 81, .92); border-color: rgba(21, 221, 243, .5); transform: translateY(-2px); }
+  .resource h3 {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 18px; font-weight: 700; line-height: 1.25;
+    color: var(--cyan);
+  }
+  .resource p {
+    margin: 0;
+    font-size: 14.5px; line-height: 1.5; color: var(--white);
+    overflow-wrap: anywhere;
+  }
+
+  /* ---------------- Footer ---------------- */
+
+  .site-footer {
+    background: linear-gradient(120deg, var(--navy-800), var(--purple) 130%);
+    border-top: 1px solid var(--dark-line);
+  }
+  .footer-inner { padding-block: clamp(28px, 4vw, 40px); }
+  .footer-title {
+    margin: 0 0 6px;
+    font-family: var(--font-display);
+    font-size: 12.5px; font-weight: 700; letter-spacing: .16em; text-transform: uppercase;
+    color: var(--cyan);
+  }
+  .footer-inner p { margin: 0 0 4px; font-size: 14.5px; line-height: 1.6; color: var(--on-dark-dim); }
+  .footer-inner p.strong { color: var(--white); font-weight: 600; font-size: 15.5px; }
+
+  .footer-social { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 18px; }
+  .social {
+    display: inline-flex; align-items: center; gap: 8px;
+    min-height: 44px; padding: 10px 16px;
+    background: rgba(25, 36, 81, .58);
+    border: 1px solid var(--dark-line);
+    border-radius: 11px;
+    font-size: 14.5px; font-weight: 600;
+    color: var(--on-dark); text-decoration: none;
+    transition: background .15s ease, border-color .15s ease, color .15s ease;
+  }
+  .social:hover, .social:focus-visible { background: rgba(25, 36, 81, .92); border-color: rgba(21, 221, 243, .5); color: var(--white); }
+  .social svg { width: 18px; height: 18px; flex-shrink: 0; fill: currentColor; }
+</style>
+</head>
+<body id="top">
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="site-header">
+  <div class="container header-inner">
+    <a class="brand" href="#top" aria-label="QDK QCE26 Tutorial — home">
+      <span class="brand-mark" aria-hidden="true"><i></i><i></i><i></i><i></i></span>
+      <span class="brand-text">Microsoft QDK<small>QCE26 Tutorial</small></span>
+    </a>
+
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-navigation">
+      <span class="sr-only">Toggle navigation</span>
+      <span aria-hidden="true">Menu</span>
+    </button>
+
+    <nav id="site-navigation" class="site-nav" aria-label="Primary navigation">
+      <a href="#sessions">Sessions</a>
+      <a href="#audience">Audience</a>
+      <a href="#resources">Resources</a>
+      <a class="nav-cta" href="#sessions">Add to calendar</a>
+    </nav>
+  </div>
+</header>
+
+<main id="main">
+
+  <section class="hero" aria-labelledby="page-heading">
+    <pre class="hero-code" aria-hidden="true">use (q1, q2) = (Qubit(), Qubit());
+H(q1);
+CNOT(q1, q2);
+let resultQ1 = M(q1);
+let resultQ2 = M(q2);
+// Count the number of 'Ones' returned
+mutable count = 0;
+if resultQ1 == One {
+    set count += 1;
+}
+ResetAll([q1, q2]);
+return count;</pre>
+    <span class="hero-ribbon" aria-hidden="true"></span>
+
+    <div class="container">
+      <div class="hero-grid">
+        <div class="hero-copy">
+          <p class="eyebrow">IEEE Quantum Week 2026 &middot; QCE26 Tutorial</p>
+          <h1 id="page-heading">
+            <span class="hl-line">The</span>
+            <span class="hl-line">Microsoft</span>
+            <span class="hl-line"><span class="hl-key">Q</span>uantum</span>
+            <span class="hl-line"><span class="hl-key">D</span>evelopment</span>
+            <span class="hl-line"><span class="hl-key">K</span>it</span>
+          </h1>
+          <p class="hero-sub">From Molecules to Logical Qubits: A Practical Tutorial on the Microsoft Quantum Development Kit (QDK)</p>
+        </div>
+
+        <div class="hero-side">
+          <div class="hero-panel">
+            <span class="panel-label">Tutorial format</span>
+            <p class="panel-title">Two 90-minute sessions</p>
+            <span class="panel-line" aria-hidden="true"></span>
+            <p class="panel-note"><strong>Wednesday, September 16, 2026</strong><br>Room 715B &middot; Metro Toronto Convention Centre, Toronto</p>
+          </div>
+          <div class="hero-actions">
+            <a class="button button--primary" href="#sessions">
+              Add to calendar
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 2v3M17 2v3M3.5 9h17M5 5.5h14a1.5 1.5 0 0 1 1.5 1.5v12A1.5 1.5 0 0 1 19 20.5H5A1.5 1.5 0 0 1 3.5 19V7A1.5 1.5 0 0 1 5 5.5Z"/><path d="M12 12.5v5M9.5 15h5"/></svg>
+            </a>
+            <a class="button button--onblue" href="#audience">Who it&rsquo;s for <span aria-hidden="true">&rarr;</span></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="highlights">
+        <article class="highlight">
+          <h3>Modern Quantum Development, Built for Today</h3>
+          <p>Advanced simulation, multi-language workflows, and productivity tools.</p>
+        </article>
+        <article class="highlight">
+          <h3>Build End-to-End Quantum Applications with QDK</h3>
+          <p>Build quantum solutions with QDK for chemistry and analytics.</p>
+        </article>
+        <article class="highlight">
+          <h3>AI-Powered at Every Step</h3>
+          <p>Copilot-powered assistance from learning and coding to execution and experimentation.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section id="sessions" class="section" aria-labelledby="sessions-heading">
+    <div class="container">
+      <div class="section-head">
+        <p class="eyebrow">01 / Sessions &amp; agenda</p>
+        <h2 id="sessions-heading">What&rsquo;s covered, and when</h2>
+        <p class="section-lead">Two <strong>complementary</strong> 90-minute sessions run on Wednesday, September 16.</p>
+      </div>
+
+      <div class="panel-card">
+        <div class="session-grid">
+          <article class="session">
+            <div class="session-head">
+              <span class="session-badge">Session 1</span>
+              <span class="session-part">Morning</span>
+            </div>
+            <p class="session-time">10:00 &ndash; 11:30 AM <span>EDT</span></p>
+            <p class="session-meta">Wednesday, September 16, 2026 &middot; Room 715B</p>
+            <div class="session-actions">
+              <a class="button button--ms" href="session1.ics">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 2v3M17 2v3M3.5 9h17M5 5.5h14a1.5 1.5 0 0 1 1.5 1.5v12A1.5 1.5 0 0 1 19 20.5H5A1.5 1.5 0 0 1 3.5 19V7A1.5 1.5 0 0 1 5 5.5Z"/><path d="M12 12.5v5M9.5 15h5"/></svg>
+                Add to calendar
+              </a>
+              <a class="button button--ghost" href="https://calendar.google.com/calendar/render?action=TEMPLATE&amp;text=QDK%20Tutorial%20%28Session%201%29:%20From%20Molecules%20to%20Logical%20Qubits&amp;dates=20260916T140000Z/20260916T153000Z&amp;details=Session%201%20of%20the%20Microsoft%20Quantum%20Development%20Kit%20tutorial%20at%20IEEE%20Quantum%20Week%20%28QCE%202026%29.%0A%0AFrom%20Molecules%20to%20Logical%20Qubits:%20A%20Practical%20Tutorial%20on%20the%20Microsoft%20Quantum%20Development%20Kit%20%28QDK%29%0A%0AFull%20details:%20https://qce.quantum.ieee.org/2026/qce26-schedule/tutorial-schedule/%231297-1&amp;location=Room%20715B%2C%20Metro%20Toronto%20Convention%20Centre%2C%20255%20Front%20St%20W%2C%20Toronto%2C%20ON%2C%20Canada&amp;ctz=America/Toronto" target="_blank" rel="noopener">Google Calendar</a>
+            </div>
+          </article>
+
+          <article class="session">
+            <div class="session-head">
+              <span class="session-badge">Session 2</span>
+              <span class="session-part">Afternoon</span>
+            </div>
+            <p class="session-time">1:00 &ndash; 2:30 PM <span>EDT</span></p>
+            <p class="session-meta">Wednesday, September 16, 2026 &middot; Room 715B</p>
+            <div class="session-actions">
+              <a class="button button--ms" href="session2.ics">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 2v3M17 2v3M3.5 9h17M5 5.5h14a1.5 1.5 0 0 1 1.5 1.5v12A1.5 1.5 0 0 1 19 20.5H5A1.5 1.5 0 0 1 3.5 19V7A1.5 1.5 0 0 1 5 5.5Z"/><path d="M12 12.5v5M9.5 15h5"/></svg>
+                Add to calendar
+              </a>
+              <a class="button button--ghost" href="https://calendar.google.com/calendar/render?action=TEMPLATE&amp;text=QDK%20Tutorial%20%28Session%202%29:%20From%20Molecules%20to%20Logical%20Qubits&amp;dates=20260916T170000Z/20260916T183000Z&amp;details=Session%202%20of%20the%20Microsoft%20Quantum%20Development%20Kit%20tutorial%20at%20IEEE%20Quantum%20Week%20%28QCE%202026%29.%0A%0AFrom%20Molecules%20to%20Logical%20Qubits:%20A%20Practical%20Tutorial%20on%20the%20Microsoft%20Quantum%20Development%20Kit%20%28QDK%29%0A%0AFull%20details:%20https://qce.quantum.ieee.org/2026/qce26-schedule/tutorial-schedule/%231297-1&amp;location=Room%20715B%2C%20Metro%20Toronto%20Convention%20Centre%2C%20255%20Front%20St%20W%2C%20Toronto%2C%20ON%2C%20Canada&amp;ctz=America/Toronto" target="_blank" rel="noopener">Google Calendar</a>
+            </div>
+          </article>
+        </div>
+
+        <p class="session-foot"><a class="text-link" href="both-sessions.ics">Attending both? Add the full day in one go</a></p>
+
+        <div class="agenda">
+          <div class="agenda-head">
+            <h3>Tutorial agenda</h3>
+            <p>Two 90-minute sessions &middot; complementary material in each</p>
+          </div>
+
+          <p class="agenda-session">Session 1 &middot; 10:00 &ndash; 11:30 AM</p>
+          <div class="agenda-grid">
+            <article class="agenda-card">
+              <span class="card-number">1.1 / 00&ndash;30 min</span>
+              <h4>Installing the QDK &amp; AI Support</h4>
+              <p>Set up QDK in VS Code and enhance your experience with Copilot-powered assistance.</p>
+            </article>
+            <article class="agenda-card">
+              <span class="card-number">1.2 / 30&ndash;60 min</span>
+              <h4>Core QDK Features</h4>
+              <p>Build quantum programs across languages, run them on simulators, and estimate resources.</p>
+            </article>
+            <article class="agenda-card">
+              <span class="card-number">1.3 / 60&ndash;90 min</span>
+              <h4>QDK Learning Experience</h4>
+              <p>Guided exercises and samples that take you from setup to your first working program.</p>
+            </article>
+          </div>
+
+          <p class="agenda-break">Break &middot; 11:30 AM &ndash; 1:00 PM</p>
+
+          <p class="agenda-session">Session 2 &middot; 1:00 &ndash; 2:30 PM</p>
+          <div class="agenda-grid">
+            <article class="agenda-card">
+              <span class="card-number">2.1 / 00&ndash;30 min</span>
+              <h4>QDK for Chemistry</h4>
+              <p>End-to-end workflow for mapping chemistry to quantum computing.</p>
+            </article>
+            <article class="agenda-card">
+              <span class="card-number">2.2 / 30&ndash;60 min</span>
+              <h4>QDK for Analytics</h4>
+              <p>Quantum algorithms, data-science tools, and validation workflows for large-scale data analysis.</p>
+            </article>
+            <article class="agenda-card">
+              <span class="card-number">2.3 / 60&ndash;90 min</span>
+              <h4>Chemistry Learning Experience</h4>
+              <p>Guided exercises and samples.</p>
+            </article>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="audience" class="section" aria-labelledby="audience-heading">
+    <div class="container">
+      <div class="section-head">
+        <p class="eyebrow">02 / Information</p>
+        <h2 id="audience-heading">Target audience</h2>
+      </div>
+
+      <div class="info-body">
+        <p>The tutorial is aimed at <strong>software developers</strong>, <strong>computational scientists</strong>, <strong>graduate students</strong>, and <strong>industry practitioners</strong>.</p>
+        <ul class="req-list">
+          <li>
+            <strong>Expected background</strong>
+            <span>Working knowledge of Python and a basic familiarity with introductory quantum computing concepts.</span>
+          </li>
+          <li>
+            <strong>Prerequisites for hands-on participation</strong>
+            <span>A laptop with VS Code, the Microsoft QDK extension, and a working Python 3.10+ environment.</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section id="resources" class="section" aria-labelledby="resources-heading">
+    <div class="container">
+      <div class="section-head">
+        <p class="eyebrow">03 / Resources</p>
+        <h2 id="resources-heading">Explore the QDK</h2>
+      </div>
+
+      <div class="resource-grid">
+        <a class="resource" href="https://quantum.microsoft.com/" target="_blank" rel="noopener">
+          <h3>Learn More</h3>
+          <p>Learn more on quantum.microsoft.com</p>
+        </a>
+
+        <a class="resource" href="https://github.com/microsoft/qdk" target="_blank" rel="noopener">
+          <h3>QDK on GitHub</h3>
+          <p>microsoft/qdk</p>
+        </a>
+
+        <a class="resource" href="https://github.com/microsoft/qdk-chemistry" target="_blank" rel="noopener">
+          <h3>QDK for Chemistry on GitHub</h3>
+          <p>microsoft/qdk-chemistry</p>
+        </a>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<footer class="site-footer">
+  <div class="container footer-inner">
+    <p class="footer-title">IEEE Quantum Week &middot; QCE 2026</p>
+    <p class="strong">From Molecules to Logical Qubits: A Practical Tutorial on the Microsoft Quantum Development Kit (QDK)</p>
+    <p>Wednesday, September 16, 2026 &middot; Room 715B &middot; Metro Toronto Convention Centre, 255 Front St W, Toronto, ON</p>
+    <p>All times shown in Eastern Daylight Time (EDT), local to Toronto.</p>
+
+    <div class="footer-social">
+      <a class="social" href="https://www.youtube.com/playlist?list=PLlrxD0HtieHj3mBWaxRbKBGil8Snm6LK2" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.6 12 3.6 12 3.6s-7.5 0-9.4.5A3 3 0 0 0 .5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 0 0 2.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 0 0 2.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8ZM9.6 15.6V8.4l6.2 3.6-6.2 3.6Z"/></svg>
+        YouTube
+      </a>
+      <a class="social" href="https://www.instagram.com/quantumirl/" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.2c3.2 0 3.6 0 4.9.1 1.2.1 1.8.2 2.2.4.6.2 1 .5 1.4.9.4.4.7.8.9 1.4.2.4.4 1 .4 2.2.1 1.3.1 1.7.1 4.9s0 3.6-.1 4.9c-.1 1.2-.2 1.8-.4 2.2-.2.6-.5 1-.9 1.4-.4.4-.8.7-1.4.9-.4.2-1 .4-2.2.4-1.3.1-1.7.1-4.9.1s-3.6 0-4.9-.1c-1.2-.1-1.8-.2-2.2-.4-.6-.2-1-.5-1.4-.9-.4-.4-.7-.8-.9-1.4-.2-.4-.4-1-.4-2.2C2.2 15.6 2.2 15.2 2.2 12s0-3.6.1-4.9c.1-1.2.2-1.8.4-2.2.2-.6.5-1 .9-1.4.4-.4.8-.7 1.4-.9.4-.2 1-.4 2.2-.4C8.4 2.2 8.8 2.2 12 2.2Zm0 3.1A6.7 6.7 0 1 0 18.7 12 6.7 6.7 0 0 0 12 5.3Zm0 11A4.3 4.3 0 1 1 16.3 12 4.3 4.3 0 0 1 12 16.3ZM18.9 4a1.6 1.6 0 1 0 1.6 1.6A1.6 1.6 0 0 0 18.9 4Z"/></svg>
+        Instagram
+      </a>
+    </div>
+  </div>
+</footer>
+
+<script>
+  (function () {
+    var toggle = document.querySelector('.nav-toggle');
+    var nav = document.getElementById('site-navigation');
+    if (!toggle || !nav) return;
+
+    function close() {
+      nav.classList.remove('is-open');
+      toggle.setAttribute('aria-expanded', 'false');
+    }
+
+    toggle.addEventListener('click', function () {
+      var open = nav.classList.toggle('is-open');
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+
+    nav.addEventListener('click', function (e) {
+      if (e.target.tagName === 'A') close();
+    });
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') close();
+    });
+  })();
+</script>
+
+</body>
+</html>

--- a/docs/source/_extra/qce26-tutorial/session1.ics
+++ b/docs/source/_extra/qce26-tutorial/session1.ics
@@ -1,0 +1,49 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Microsoft Quantum Development Kit//QCE 2026 Tutorial//EN
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+X-WR-CALNAME:Microsoft QDK Tutorials - QCE 2026
+X-WR-TIMEZONE:America/Toronto
+BEGIN:VTIMEZONE
+TZID:America/Toronto
+BEGIN:DAYLIGHT
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+TZNAME:EDT
+DTSTART:19700308T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+TZNAME:EST
+DTSTART:19701101T020000
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:qdk-qce2026-tutorial-session1@microsoft.com
+DTSTAMP:20260811T000000Z
+DTSTART;TZID=America/Toronto:20260916T100000
+DTEND;TZID=America/Toronto:20260916T113000
+SUMMARY:QDK Tutorial (Session 1): From Molecules to Logical Qubits
+DESCRIPTION:Session 1 of the Microsoft Quantum Development Kit tutorial at 
+ IEEE Quantum Week (QCE 2026).\n\nFrom Molecules to Logical Qubits: A Pract
+ ical Tutorial on the Microsoft Quantum Development Kit (QDK)\n\nFull detai
+ ls: https://qce.quantum.ieee.org/2026/qce26-schedule/tutorial-schedule/#12
+ 97-1
+LOCATION:Room 715B\, Metro Toronto Convention Centre\, 255 Front St W\, Tor
+ onto\, ON\, Canada
+URL:https://qce.quantum.ieee.org/2026/qce26-schedule/tutorial-schedule/#129
+ 7-1
+STATUS:CONFIRMED
+TRANSP:OPAQUE
+SEQUENCE:0
+BEGIN:VALARM
+TRIGGER:-PT30M
+ACTION:DISPLAY
+DESCRIPTION:QDK Tutorial Session 1 starts in 30 minutes - Room 715B
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/docs/source/_extra/qce26-tutorial/session2.ics
+++ b/docs/source/_extra/qce26-tutorial/session2.ics
@@ -1,0 +1,49 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Microsoft Quantum Development Kit//QCE 2026 Tutorial//EN
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+X-WR-CALNAME:Microsoft QDK Tutorials - QCE 2026
+X-WR-TIMEZONE:America/Toronto
+BEGIN:VTIMEZONE
+TZID:America/Toronto
+BEGIN:DAYLIGHT
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+TZNAME:EDT
+DTSTART:19700308T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+TZNAME:EST
+DTSTART:19701101T020000
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:qdk-qce2026-tutorial-session2@microsoft.com
+DTSTAMP:20260811T000000Z
+DTSTART;TZID=America/Toronto:20260916T130000
+DTEND;TZID=America/Toronto:20260916T143000
+SUMMARY:QDK Tutorial (Session 2): From Molecules to Logical Qubits
+DESCRIPTION:Session 2 of the Microsoft Quantum Development Kit tutorial at 
+ IEEE Quantum Week (QCE 2026).\n\nFrom Molecules to Logical Qubits: A Pract
+ ical Tutorial on the Microsoft Quantum Development Kit (QDK)\n\nFull detai
+ ls: https://qce.quantum.ieee.org/2026/qce26-schedule/tutorial-schedule/#12
+ 97-1
+LOCATION:Room 715B\, Metro Toronto Convention Centre\, 255 Front St W\, Tor
+ onto\, ON\, Canada
+URL:https://qce.quantum.ieee.org/2026/qce26-schedule/tutorial-schedule/#129
+ 7-1
+STATUS:CONFIRMED
+TRANSP:OPAQUE
+SEQUENCE:0
+BEGIN:VALARM
+TRIGGER:-PT30M
+ACTION:DISPLAY
+DESCRIPTION:QDK Tutorial Session 2 starts in 30 minutes - Room 715B
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -158,6 +158,7 @@ breathe_default_members = (
 html_theme = "sphinx_rtd_theme"  # Use the ReadTheDocs theme for styling
 templates_path = ["_templates"]  # Path to custom HTML templates
 html_static_path: list[str] = ["_static"]  # Path to static files (CSS, JS, images)
+html_extra_path: list[str] = ["_extra"]  # Files copied verbatim into the output root
 html_css_files = [  # Include custom CSS file for additional styling
     "custom.css",
 ]


### PR DESCRIPTION
## Summary

Adds the companion landing page for our QCE 2026 / IEEE Quantum Week tutorial to the published `qdk-chemistry` docs site.

**Tutorial:** *From Molecules to Logical Qubits: A Practical Tutorial on the Microsoft Quantum Development Kit (QDK)*
**When:** Wednesday 16 September 2026
**Where:** Room 715B, Metro Toronto Convention Centre

The page lists the two 90-minute sessions, the agenda, the target audience, and offers `.ics` downloads plus Google Calendar links so attendees can add either session (or both) to their calendar.

It is currently hosted on a personal GitHub Pages repo. We'd like it to live under an official Microsoft repo instead, which is what this PR does.

**Resulting URL:** `https://microsoft.github.io/qdk-chemistry/qce26-tutorial/`

## Why `html_extra_path` and not a commit to `gh-pages`

GitHub Pages for this repo serves from the `gh-pages` branch (`/docs` folder), but that branch is **100% generated Sphinx output** — its commits are titled "Update docs" / "Update docs to 2.0.0" and its tree is build artifacts. Anything committed there by hand would be destroyed by the next docs publish.

So the page has to enter the site *as part of the Sphinx build*, from source on `main`. Sphinx's [`html_extra_path`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_extra_path) is exactly the right mechanism: it copies files verbatim into the root of the HTML output with **no template or reST processing**, so the page is published byte-for-byte as authored.

That's a one-line addition to `docs/source/conf.py`, right next to the existing `html_static_path`:

```python
html_extra_path: list[str] = ["_extra"]  # Files copied verbatim into the output root
```

Everything under `docs/source/_extra/` is then mirrored into the output root, so `_extra/qce26-tutorial/index.html` becomes `/qce26-tutorial/`.

## Why this PR touches `.pre-commit-config.yaml`

This is the non-obvious bit, so flagging it up front — reviewers will otherwise wonder why a lint config is being changed in a docs PR.

RFC 5545 **requires CRLF line endings** in iCalendar files, and Outlook rejects `.ics` files that violate it. Our `.pre-commit-config.yaml` sets `files: &linted_files .*` and enables `mixed-line-ending` with `args: [--fix=lf]`, which would physically rewrite the `.ics` files to LF and break the "Add to calendar" buttons. `trailing-whitespace` and `end-of-file-fixer` also match `.*` and are similarly risky for these files.

Hence the one-token change on line 6:

```diff
-exclude: \.(xyz|fcidump|wfn|qasm)$
+exclude: \.(xyz|fcidump|wfn|qasm|ics)$
```

This follows the existing precedent in that line, which already exempts other byte-sensitive data formats (`.xyz`, `.fcidump`, `.wfn`, `.qasm`).

There is also a scoped `docs/source/_extra/qce26-tutorial/.gitattributes` with `*.ics -text`. **Both defences are needed and they solve different problems:** `.gitattributes` stops *git's own* CRLF normalisation on checkin/checkout (the repo root sets `* text=auto eol=lf`), whereas pre-commit rewrites the file on disk *before git ever sees it*. Neither one alone is sufficient.

Only `.ics` is exempted — `index.html` is still fully linted and normalised like any other file in the repo.

## Changes

7 files: 5 added, 2 modified.

| File | Change |
|---|---|
| `docs/source/_extra/qce26-tutorial/index.html` | added (822 lines) |
| `docs/source/_extra/qce26-tutorial/session1.ics` | added (49 lines) |
| `docs/source/_extra/qce26-tutorial/session2.ics` | added (49 lines) |
| `docs/source/_extra/qce26-tutorial/both-sessions.ics` | added (73 lines) |
| `docs/source/_extra/qce26-tutorial/.gitattributes` | added (3 lines) |
| `docs/source/conf.py` | +1 line |
| `.pre-commit-config.yaml` | 1 line changed |

No existing file is reordered or reformatted, and there is zero functional change to the landing page itself.

## The page is fully self-contained

Verified: no `<base>` tag, no absolute `href="/…"` / `src="/…"` paths, no protocol-relative URLs, and no external CSS/JS/font loads (the favicon is an inline `data:` SVG and all CSS/JS is inline). The only outbound URLs are ordinary navigation links (Google Calendar, github.com, quantum.microsoft.com). The `.ics` links are relative (`session1.ics`, etc.).

That's what makes it safe to serve from a subpath like `/qce26-tutorial/`.

## Verification performed

A full `make all` docs build needs Doxygen, Graphviz and the compiled `qdk-chemistry` package, so instead:

- **`html_extra_path` really does copy verbatim** — built a throwaway minimal Sphinx project (Sphinx 9.1.0) in a temp dir with its own tiny `conf.py`, containing copies of all four files. All four landed at `<output>/qce26-tutorial/` **byte-identical** (sha256 match), with CRLF intact in the `.ics` files.
- **CRLF survives the commit** — read the committed blobs back out of git: `session1.ics` 49 CRLF / 0 bare LF, `session2.ics` 49 / 0, `both-sessions.ics` 73 / 0, and sha256 of each blob matches the source file exactly.
- **`conf.py` still parses** — `ast.parse` OK.
- **`.pre-commit-config.yaml` still parses** — `yaml.safe_load` OK, new `exclude` regex compiles, and simulating pre-commit's `files`-AND-NOT-`exclude` filter confirms the three `.ics` paths are skipped while `index.html`, `conf.py` and the config itself remain linted.

## :warning: Notes for reviewers

- **The page will not appear until the docs are published to `gh-pages` again.** That branch is produced by a separate publish step rather than by CI on merge, so merging this PR alone will not make the URL live. Could a maintainer confirm how and when that publish runs, and whether anything else is needed to trigger it?
- **Please confirm the final URL before merge.** A QR code on a printed flyer currently points at the old personal URL; it will be regenerated to point at the new one once this lands, so we want to be sure `https://microsoft.github.io/qdk-chemistry/qce26-tutorial/` is the path we're committing to.
