### PR TITLE
Add bounded CLI and MCP fuzz testing

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -1,0 +1,111 @@
+name: Extended Fuzz Tests
+
+on:
+  schedule:
+  - cron: 0 6 * * 1
+  workflow_dispatch:
+    inputs:
+      examples:
+        description: Hypothesis examples per property
+        required: false
+        default: 5000
+        type: number
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Python CLI and MCP fuzz tests
+    runs-on: [self-hosted, 1ES.Pool=1es-gh-Dads_v5-pool-wus2, 1ES.ImageOverride=Ubuntu24.04Nightly, 'JobId=qdk-chemistry-fuzz-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}']
+    env:
+      CMAKE_BUILD_PARALLEL_LEVEL: 2
+      CPP_DEPS_PREFIX: ${{ github.workspace }}/cpp_deps_install
+      QDK_CHEMISTRY_FUZZ_EXAMPLES: ${{ inputs.examples || 5000 }}
+      QSHARP_PYTHON_TELEMETRY: 'false'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        submodules: recursive
+
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      with:
+        python-version: '3.13'
+        cache: pip
+        cache-dependency-path: python/pyproject.toml
+
+    - name: Install system packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          build-essential \
+          ninja-build \
+          cmake \
+          libeigen3-dev \
+          libboost-all-dev \
+          libhdf5-dev \
+          libopenblas-dev \
+          libgfortran5 \
+          pkg-config
+
+    - name: Restore C++ dependency cache
+      id: cache-cpp-deps
+      uses: actions/cache/restore@55cc8345863c7cc4e66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ env.CPP_DEPS_PREFIX }}
+        key: fuzz-cpp-deps-${{ runner.os }}-${{ hashFiles('cpp/manifest/qdk-chemistry/cgmanifest.json', 'external/macis/manifest/cgmanifest.json', '.devcontainer/scripts/install_cpp_dependencies.sh') }}
+
+    - name: Install C++ dependencies
+      if: steps.cache-cpp-deps.outputs.cache-hit != 'true'
+      env:
+        INSTALL_PREFIX: ${{ env.CPP_DEPS_PREFIX }}
+        BUILD_DIR: ${{ github.workspace }}/cpp_deps_build
+      run: |
+        bash .devcontainer/scripts/install_cpp_dependencies.sh \
+          cpp/manifest/qdk-chemistry/cgmanifest.json \
+          external/macis/manifest/cgmanifest.json
+
+    - name: Save C++ dependency cache
+      if: steps.cache-cpp-deps.outputs.cache-hit != 'true'
+      uses: actions/cache/save@55cc8345863c7cc4e66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ env.CPP_DEPS_PREFIX }}
+        key: ${{ steps.cache-cpp-deps.outputs.cache-primary-key }}
+
+    - name: Restore Hypothesis corpus
+      uses: actions/cache/restore@55cc8345863c7cc4e66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .hypothesis
+        key: hypothesis-${{ github.ref_name }}-${{ github.run_id }}
+        restore-keys: |
+          hypothesis-${{ github.ref_name }}-
+          hypothesis-main-
+
+    - name: Install QDK Chemistry and fuzz dependencies
+      env:
+        CMAKE_PREFIX_PATH: ${{ env.CPP_DEPS_PREFIX }}
+      run: python -m pip install './python[fuzz,mcp]'
+
+    - name: Run extended fuzz tests
+      run: python -m pytest python/tests/fuzz -q
+
+    - name: Save Hypothesis corpus cache
+      if: always()
+      uses: actions/cache/save@55cc8345863c7cc4e66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .hypothesis
+        key: hypothesis-${{ github.ref_name }}-${{ github.run_id }}
+
+    - name: Upload Hypothesis corpus
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: hypothesis-corpus-${{ github.run_id }}
+        path: .hypothesis
+        if-no-files-found: ignore

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -92,6 +92,11 @@ docs = [
   "sphinxcontrib-bibtex",
   "sphinx_copybutton"
 ]
+fuzz = [
+  "hypothesis>=6",
+  "hypothesis-jsonschema>=0.23",
+  "pytest"
+]
 jupyter = [
   "ipykernel>=6.0",
   "pandas>=2.0.0",
@@ -126,6 +131,7 @@ qre = [
 ]
 test = [
   "qdk-chemistry[coverage,discovery,jupyter,networkx-extras,openfermion-extras,plugins,qiskit-extras,qre]",
+  "qdk-chemistry[fuzz]",
   "qdk-chemistry[mcp]; sys_platform != 'win32' or platform_machine != 'ARM64'",
   "nbclient",
   "nbformat",

--- a/python/src/qdk_chemistry/ui/cli.py
+++ b/python/src/qdk_chemistry/ui/cli.py
@@ -187,9 +187,16 @@ def _parse_set_overrides(set_args: list[str] | None) -> dict:
 
         # Build nested dict from dotted path
         parts = key.split(".")
+        if any(not part for part in parts):
+            raise argparse.ArgumentTypeError(f"Invalid --set key path: '{key}'. Path components must be non-empty")
         target = overrides
         for part in parts[:-1]:
-            target = target.setdefault(part, {})
+            nested = target.setdefault(part, {})
+            if not isinstance(nested, dict):
+                raise argparse.ArgumentTypeError(
+                    f"Invalid --set key path: '{key}'. '{part}' already contains a non-object value"
+                )
+            target = nested
         target[parts[-1]] = parsed_value
     return overrides
 

--- a/python/tests/fuzz/conftest.py
+++ b/python/tests/fuzz/conftest.py
@@ -1,0 +1,17 @@
+"""Configuration for bounded property-based fuzz tests."""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import os
+
+from hypothesis import settings
+
+settings.register_profile(
+    "qdk-fuzz",
+    deadline=None,
+    max_examples=int(os.environ.get("QDK_CHEMISTRY_FUZZ_EXAMPLES", "100")),
+)
+settings.load_profile("qdk-fuzz")

--- a/python/tests/fuzz/test_cli_fuzz.py
+++ b/python/tests/fuzz/test_cli_fuzz.py
@@ -1,0 +1,93 @@
+"""Property-based tests for untrusted CLI input."""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import argparse
+import copy
+import json
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from qdk_chemistry.ui.cli import _deep_merge, _parse_set_overrides, create_parser, parse_json_arg
+
+_JSON_SCALARS = st.none() | st.booleans() | st.integers() | st.floats(allow_nan=False, allow_infinity=False) | st.text()
+_JSON_VALUES = st.recursive(
+    _JSON_SCALARS,
+    lambda children: st.lists(children, max_size=5) | st.dictionaries(st.text(max_size=20), children, max_size=5),
+    max_leaves=20,
+)
+_ARGV_TOKEN = st.text(max_size=80)
+
+
+@given(st.lists(_ARGV_TOKEN, max_size=20))
+def test_cli_parser_rejects_or_parses_arbitrary_argv(argv: list[str]) -> None:
+    """Arbitrary argument vectors only parse or produce an argparse exit."""
+    parser = create_parser()
+    exit_code = None
+
+    try:
+        parser.parse_args(argv)
+    except SystemExit as error:
+        exit_code = error.code
+
+    assert exit_code is None or isinstance(exit_code, int)
+
+
+@given(_JSON_VALUES)
+def test_json_argument_parser_round_trips_json_values(value: object) -> None:
+    """Every bounded JSON value survives CLI JSON parsing."""
+    encoded = json.dumps(value)
+
+    assert parse_json_arg(encoded) == value
+
+
+@given(st.text(max_size=200))
+def test_json_argument_parser_reports_invalid_text(value: str) -> None:
+    """Text that is not JSON produces the documented argparse error."""
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError:
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_json_arg(value)
+    else:
+        assert json.dumps(parse_json_arg(value), sort_keys=True) == json.dumps(decoded, sort_keys=True)
+
+
+@given(
+    st.lists(
+        st.tuples(st.lists(st.text(max_size=12), min_size=1, max_size=8), _JSON_VALUES).map(
+            lambda item: f"{'.'.join(item[0])}={json.dumps(item[1])}"
+        ),
+        max_size=12,
+    )
+)
+def test_set_overrides_handle_bounded_json_values(overrides: list[str]) -> None:
+    """Dotted overrides produce a dictionary or a documented parse error."""
+    original = list(overrides)
+
+    try:
+        result = _parse_set_overrides(overrides)
+    except argparse.ArgumentTypeError:
+        result = None
+
+    assert result is None or isinstance(result, dict)
+    assert overrides == original
+
+
+@given(
+    st.dictionaries(st.text(max_size=20), _JSON_VALUES, max_size=8),
+    st.dictionaries(st.text(max_size=20), _JSON_VALUES, max_size=8),
+)
+def test_deep_merge_is_deterministic(base: dict, overrides: dict) -> None:
+    """Merging bounded JSON mappings is deterministic and leaves overrides unchanged."""
+    first_base = copy.deepcopy(base)
+    second_base = copy.deepcopy(base)
+    original_overrides = copy.deepcopy(overrides)
+
+    assert _deep_merge(first_base, overrides) == _deep_merge(second_base, overrides)
+    assert overrides == original_overrides

--- a/python/tests/fuzz/test_mcp_schema_fuzz.py
+++ b/python/tests/fuzz/test_mcp_schema_fuzz.py
@@ -1,0 +1,83 @@
+"""Property-based tests for MCP tool schema validation and dispatch."""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import asyncio
+from typing import Any
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from hypothesis_jsonschema import from_schema
+
+pytest.importorskip("mcp", reason="MCP support is not installed")
+
+from mcp.client import Client
+from mcp.server.mcpserver import MCPServer
+
+_SERVER = MCPServer("qdk-chemistry-fuzz-test")
+
+
+@_SERVER.tool()
+def echo_tool(
+    name: str,
+    count: int,
+    enabled: bool = False,
+    labels: list[str] | None = None,
+    settings: dict[str, float] | None = None,
+) -> dict[str, Any]:
+    """Return schema-validated arguments without performing domain work."""
+    return {
+        "name": name,
+        "count": count,
+        "enabled": enabled,
+        "labels": labels,
+        "settings": settings,
+    }
+
+
+async def _tool_schema() -> dict[str, Any]:
+    """Return the input schema published for the harmless echo tool."""
+    tools = await _SERVER.list_tools()
+    return next(tool.input_schema for tool in tools if tool.name == "echo_tool")
+
+
+_SCHEMA = asyncio.run(_tool_schema())
+_JSON_VALUES = st.recursive(
+    st.none() | st.booleans() | st.integers() | st.floats(allow_nan=False, allow_infinity=False) | st.text(),
+    lambda children: st.lists(children, max_size=5) | st.dictionaries(st.text(max_size=20), children, max_size=5),
+    max_leaves=20,
+)
+
+
+async def _call_echo(arguments: dict[str, Any]):
+    """Call the echo tool through the public in-process MCP client."""
+    async with Client(_SERVER) as client:
+        return await client.call_tool("echo_tool", arguments)
+
+
+@given(from_schema(_SCHEMA))
+def test_schema_generated_tool_calls_round_trip(arguments: dict[str, Any]) -> None:
+    """Every input generated from the published schema reaches the tool body."""
+    result = asyncio.run(_call_echo(arguments))
+
+    assert result.is_error is False
+    assert result.structured_content == {
+        "name": arguments["name"],
+        "count": arguments["count"],
+        "enabled": arguments.get("enabled", False),
+        "labels": arguments.get("labels"),
+        "settings": arguments.get("settings"),
+    }
+
+
+@given(st.dictionaries(st.text(max_size=20), _JSON_VALUES, max_size=10))
+def test_arbitrary_tool_arguments_return_an_mcp_result(arguments: dict[str, Any]) -> None:
+    """Arbitrary JSON objects are either schema-valid or reported as tool errors."""
+    result = asyncio.run(_call_echo(arguments))
+
+    assert isinstance(result.is_error, bool)
+    assert result.content or result.structured_content is not None

--- a/python/tests/fuzz/test_mcp_tools_fuzz.py
+++ b/python/tests/fuzz/test_mcp_tools_fuzz.py
@@ -1,0 +1,90 @@
+"""Property-based tests for filesystem-facing MCP tools."""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from qdk_chemistry.ui import tools
+from qdk_chemistry.ui.config import config
+
+_PATH_TEXT = st.text(
+    alphabet=st.characters(categories=("L", "N")) | st.sampled_from("./\\:_- \x00"),
+    max_size=80,
+)
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    """Return whether a resolved path is contained by a resolved root."""
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+@given(project_name=_PATH_TEXT)
+def test_create_project_never_writes_outside_workspace(project_name: str) -> None:
+    """Arbitrary project names cannot create directories outside the workspace."""
+    original_projects_dir = config.projects_dir
+    attempted_paths: list[Path] = []
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        workspace = Path(temporary_directory)
+        projects_dir = workspace / "projects"
+        projects_dir.mkdir()
+        config.projects_dir = projects_dir
+
+        def record_mkdir(path: Path, *_args, **_kwargs) -> None:
+            attempted_paths.append(path)
+
+        try:
+            with patch.object(Path, "mkdir", record_mkdir):
+                result = tools.create_project(project_name=project_name)
+        finally:
+            config.projects_dir = original_projects_dir
+
+        assert result["status"] in {"ok", "error"}
+        assert all(_is_within(path, projects_dir) for path in attempted_paths)
+
+
+@given(filename=_PATH_TEXT)
+def test_create_structure_never_writes_outside_workspace(filename: str) -> None:
+    """Arbitrary output paths remain contained or return a structured error."""
+    original_projects_dir = config.projects_dir
+    attempted_paths: list[Path] = []
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        workspace = Path(temporary_directory)
+        projects_dir = workspace / "projects"
+        (projects_dir / "safe").mkdir(parents=True)
+        config.projects_dir = projects_dir
+        structure = MagicMock()
+        structure.to_json_file.side_effect = lambda path: attempted_paths.append(Path(path))
+        structure.to_hdf5_file.side_effect = lambda path: attempted_paths.append(Path(path))
+        try:
+            with patch.object(tools.data, "Structure", return_value=structure):
+                result = tools.create_structure(
+                    project_name="safe",
+                    coordinates_json="[[0.0, 0.0, 0.0]]",
+                    symbols=["H"],
+                    filename_to_save=filename,
+                )
+        finally:
+            config.projects_dir = original_projects_dir
+
+        assert result["status"] in {"ok", "exists", "error"}
+        assert all(_is_within(path, projects_dir) for path in attempted_paths)
+
+
+@given(coordinates_json=st.text(max_size=300), to_unit=st.text(max_size=40))
+def test_convert_coordinates_always_returns_a_structured_result(coordinates_json: str, to_unit: str) -> None:
+    """Arbitrary coordinate text is converted or rejected without escaping the envelope."""
+    result = tools.convert_coordinates(coordinates_json=coordinates_json, to_unit=to_unit)
+
+    assert result["status"] in {"ok", "error"}

--- a/python/tests/fuzz/test_mcp_transport_fuzz.py
+++ b/python/tests/fuzz/test_mcp_transport_fuzz.py
@@ -1,0 +1,54 @@
+"""Malformed-input recovery tests for the MCP stdio transport."""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+from qdk_chemistry.ui._mcp import MCP_AVAILABLE
+
+pytestmark = pytest.mark.skipif(not MCP_AVAILABLE, reason="MCP support is not installed")
+
+
+def test_stdio_recovers_from_malformed_messages() -> None:
+    """Malformed records do not prevent a subsequent valid MCP request."""
+    malformed_corpus = [
+        b"not-json\n",
+        b"\xff\xfe\n",
+        b'{"jsonrpc":"2.0"\n',
+        b"{}\n",
+        b"[]\n",
+        b"null\n",
+        b'"string"\n',
+        (b"[" * 80) + (b"]" * 80) + b"\n",
+        b'{"jsonrpc":"2.0","id":99,"method":"unknown/method"}\n',
+    ]
+    initialize = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "qdk-chemistry-fuzz-test", "version": "1"},
+        },
+    }
+    process = subprocess.run(
+        [sys.executable, "-m", "qdk_chemistry.ui.mcp"],
+        input=b"".join(malformed_corpus) + json.dumps(initialize).encode() + b"\n",
+        capture_output=True,
+        timeout=10,
+        check=False,
+        env=os.environ.copy(),
+    )
+    assert process.returncode == 0, process.stderr.decode(errors="replace")
+    responses = [json.loads(line) for line in process.stdout.splitlines()]
+    assert any(response.get("id") == 99 and "error" in response for response in responses)
+    assert any(response.get("id") == 1 and "result" in response for response in responses)

--- a/python/tests/ui/test_cli.py
+++ b/python/tests/ui/test_cli.py
@@ -173,6 +173,19 @@ def test_parse_set_overrides():
     assert _parse_set_overrides([]) == {}
 
 
+@pytest.mark.parametrize("override", ["=null", ".=null", "a..b=null"])
+def test_parse_set_overrides_rejects_empty_path_components(override):
+    """Reject dotted key paths with empty components."""
+    with pytest.raises(argparse.ArgumentTypeError, match="Path components must be non-empty"):
+        _parse_set_overrides([override])
+
+
+def test_parse_set_overrides_rejects_scalar_prefix_conflicts():
+    """Reject a nested override beneath an existing scalar value."""
+    with pytest.raises(argparse.ArgumentTypeError, match="already contains a non-object value"):
+        _parse_set_overrides(["settings=null", "settings.max_iterations=50"])
+
+
 def test_deep_merge():
     """Test recursive dict merging."""
     base = {"a": {"b": 1, "c": 2}, "d": 3}


### PR DESCRIPTION
## Summary

- Add bounded Hypothesis coverage for CLI parsing, JSON, and dotted overrides.
- Fuzz filesystem-facing MCP tools with direct containment assertions.
- Generate valid MCP calls from published schemas and exercise in-process dispatch.
- Verify stdio recovery from malformed JSON, invalid UTF-8, truncation, and nested payloads.
- Add a weekly/manual 5,000-example campaign with a persisted Hypothesis corpus.
- Reject malformed or scalar-conflicting `--set` paths discovered by fuzzing.

## CI behavior

Regular CI runs 100 examples per property through the existing `test` extra.

The extended workflow runs every Monday at 06:00 UTC or manually with a configurable example count. It uses two build jobs and saves minimized Hypothesis examples.
