### PR TITLE
Fix the qubit mapper and FCIDUMP export for 2-body tensors without 8-fold symmetry

### DIFF
--- a/cpp/include/qdk/chemistry/data/hamiltonian.hpp
+++ b/cpp/include/qdk/chemistry/data/hamiltonian.hpp
@@ -296,6 +296,8 @@ class HamiltonianContainer {
    * @param nbeta Number of beta electrons
    * @throws std::runtime_error if I/O error occurs, the Hamiltonian is
    * unrestricted, or its two-body integrals lack 8-fold permutation symmetry
+   * @throws std::invalid_argument if the active space has differing alpha and
+   * beta sizes
    */
   virtual void to_fcidump_file(const std::string& filename, size_t nalpha,
                                size_t nbeta) const;
@@ -634,6 +636,8 @@ class Hamiltonian : public DataClass,
    * @param nbeta Number of beta electrons
    * @throws std::runtime_error if I/O error occurs, the Hamiltonian is
    * unrestricted, or its two-body integrals lack 8-fold permutation symmetry
+   * @throws std::invalid_argument if the active space has differing alpha and
+   * beta sizes
    */
   void to_fcidump_file(const std::string& filename, size_t nalpha,
                        size_t nbeta) const;

--- a/cpp/include/qdk/chemistry/data/hamiltonian.hpp
+++ b/cpp/include/qdk/chemistry/data/hamiltonian.hpp
@@ -294,8 +294,8 @@ class HamiltonianContainer {
    * @param filename Path to FCIDUMP file to create/overwrite
    * @param nalpha Number of alpha electrons
    * @param nbeta Number of beta electrons
-   * @throws std::runtime_error if I/O error occurs or Hamiltonian is
-   * unrestricted
+   * @throws std::runtime_error if I/O error occurs, the Hamiltonian is
+   * unrestricted, or its two-body integrals lack 8-fold permutation symmetry
    */
   virtual void to_fcidump_file(const std::string& filename, size_t nalpha,
                                size_t nbeta) const;
@@ -632,7 +632,8 @@ class Hamiltonian : public DataClass,
    * @param filename Path to FCIDUMP file to create/overwrite
    * @param nalpha Number of alpha electrons
    * @param nbeta Number of beta electrons
-   * @throws std::runtime_error if I/O error occurs
+   * @throws std::runtime_error if I/O error occurs, the Hamiltonian is
+   * unrestricted, or its two-body integrals lack 8-fold permutation symmetry
    */
   void to_fcidump_file(const std::string& filename, size_t nalpha,
                        size_t nbeta) const;

--- a/cpp/include/qdk/chemistry/data/hamiltonian_containers/sparse.hpp
+++ b/cpp/include/qdk/chemistry/data/hamiltonian_containers/sparse.hpp
@@ -207,8 +207,10 @@ class SparseHamiltonianContainer : public HamiltonianContainer {
    * @param filename Path to FCIDUMP file to create/overwrite
    * @param nalpha Number of alpha electrons
    * @param nbeta Number of beta electrons
-   * @throws std::runtime_error if the Hamiltonian is unrestricted or the file
-   *         cannot be opened
+   * @throws std::runtime_error if the Hamiltonian is unrestricted, its stored
+   *         two-body records leave a permutation class partially stored or
+   *         carry disagreeing values within one (FCIDUMP readers reconstruct
+   *         all 8 permutations), or the file cannot be opened
    */
   void to_fcidump_file(const std::string& filename, size_t nalpha,
                        size_t nbeta) const override;

--- a/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
+++ b/cpp/include/qdk/chemistry/data/majorana_mapping.hpp
@@ -353,14 +353,23 @@ struct MajoranaMapResult {
  * @param eri_aabb Flattened two-body integrals (aa|bb), chemist notation.
  * @param eri_bbbb Flattened two-body integrals (bb|bb), chemist notation.
  * @param n_spatial Number of spatial orbitals.
- * @param spin_symmetric If true, use the spin-summed fast path. This assumes
- *        identical integrals across all spin channels (h_alpha == h_beta,
- *        eri_aaaa == eri_bbbb == eri_aabb), as produced by restricted orbitals.
- *        For unrestricted orbital sets, pass false — the engine handles each
- *        spin channel independently.
+ * @param spin_symmetric Declare that the input is spin-restricted and request
+ *        the spin-summed fast path. The caller must guarantee identical
+ *        integrals across all spin channels (h_alpha == h_beta and
+ *        eri_aaaa == eri_bbbb == eri_aabb); this equality is not validated.
+ *        The fast path additionally requires 8-fold ERI permutation symmetry,
+ *        which the engine does validate; tensors carrying only the 4-fold
+ *        subgroup (pq|rs) = (qp|sr) = (rs|pq) automatically use the general
+ *        spin-channel path, which reproduces them exactly. For unrestricted
+ *        inputs, pass false.
  * @param threshold Pauli terms with |coeff| < threshold are dropped.
  * @param integral_threshold Integrals with |value| < this are skipped.
  * @return MajoranaMapResult with Pauli words and coefficients.
+ * @throws std::invalid_argument If spin_symmetric is true and the two-body
+ *         integrals either define a non-Hermitian operator, or are Hermitian
+ *         but not stored with (pq|rs) = (rs|pq). The latter swap leaves the
+ *         operator unchanged, so such tensors need only be replaced by their
+ *         bra-ket average before mapping.
  */
 MajoranaMapResult majorana_map_hamiltonian(
     const MajoranaMapping& mapping, double core_energy, const double* h1_alpha,
@@ -382,10 +391,20 @@ MajoranaMapResult majorana_map_hamiltonian(
  *
  * @param mapping The Majorana-to-Pauli encoding.
  * @param hamiltonian The fermionic Hamiltonian.
- * @param spin_symmetric Use the spin-summed restricted fast path when true.
+ * @param spin_symmetric Declare that the Hamiltonian is spin-restricted and
+ *        request the spin-summed fast path. The caller is responsible for the
+ *        spin-restriction guarantee. The fast path also requires 8-fold ERI
+ *        permutation symmetry, and each container enforces it differently:
+ *        dense tensors carrying only the 4-fold subgroup fall back to the
+ *        general spin-channel path, Cholesky containers require pair-symmetric
+ *        three-center factors, and sparse containers require each permutation
+ *        class to be stored once or in full.
  * @param threshold Pauli terms with |coeff| < threshold are dropped.
  * @param integral_threshold Integrals with |value| < this are skipped.
  * @return MajoranaMapResult with Pauli words and coefficients.
+ * @throws std::invalid_argument If the container's two-body integrals cannot
+ *         be reproduced by any evaluation path (see the per-container entry
+ *         points below).
  */
 MajoranaMapResult majorana_map_hamiltonian(const MajoranaMapping& mapping,
                                            const Hamiltonian& hamiltonian,
@@ -417,9 +436,17 @@ MajoranaMapResult majorana_map_hamiltonian(const MajoranaMapping& mapping,
  * @param n_spatial Number of spatial orbitals.
  * @param naux Number of auxiliary (Cholesky) vectors.
  * @param spin_symmetric If true, use the spin-summed restricted fast path.
+ *        That path needs 8-fold ERI symmetry, and the reconstruction
+ *        sum_Q L^Q_pq L^Q_rs only carries it when every factor is symmetric in
+ *        its orbital pair, so @p three_center_aa is validated for that.
  * @param threshold Pauli terms with |coeff| < threshold are dropped.
  * @param integral_threshold Integrals with |value| < this are skipped.
  * @return MajoranaMapResult with Pauli words and coefficients.
+ * @throws std::invalid_argument If spin_symmetric is true and the alpha
+ *         three-center factors are not pair-symmetric.  Establishing the
+ *         weaker symmetry the general path needs would require materializing
+ *         the dense tensor this entry point exists to avoid, so such inputs
+ *         must be mapped from dense storage.
  */
 MajoranaMapResult majorana_map_hamiltonian_cholesky(
     const MajoranaMapping& mapping, double core_energy, const double* h1_alpha,
@@ -452,6 +479,14 @@ MajoranaMapResult majorana_map_hamiltonian_cholesky(
  * floating-point equality); conflicting duplicates are rejected rather
  * than resolved in encounter order.
  *
+ * Because one representative is expanded over its whole permutation class,
+ * each class must be stored either exactly once (unambiguously a
+ * representative) or in full.  A partially stored class is ambiguous — the
+ * expansion would overwrite the zeros implied at its missing positions — and
+ * members that disagree cannot be represented at all.  Both are rejected
+ * rather than silently symmetrized, so a tensor with genuinely reduced
+ * permutation symmetry must be mapped from dense storage instead.
+ *
  * @param mapping The Majorana-to-Pauli encoding.
  * @param core_energy Core (nuclear repulsion + frozen core) energy.
  * @param h1_alpha One-body integrals, alpha spin (row-major).
@@ -468,8 +503,9 @@ MajoranaMapResult majorana_map_hamiltonian_cholesky(
  * @param integral_threshold Integrals with |value| < this are skipped.
  * @return MajoranaMapResult with Pauli words and coefficients.
  * @throws std::invalid_argument If spin_symmetric is false, any two-body
- *         index is outside [0, n_spatial), or duplicate entries for the
- *         same position carry conflicting values.
+ *         index is outside [0, n_spatial), duplicate entries for the same
+ *         position carry conflicting values, or a permutation class is
+ *         stored partially or with disagreeing values.
  */
 MajoranaMapResult majorana_map_hamiltonian_sparse(
     const MajoranaMapping& mapping, double core_energy, const double* h1_alpha,

--- a/cpp/src/qdk/chemistry/data/hamiltonian.cpp
+++ b/cpp/src/qdk/chemistry/data/hamiltonian.cpp
@@ -22,6 +22,7 @@
 #include "hdf5_error_handling.hpp"
 #include "hdf5_serialization.hpp"
 #include "json_serialization.hpp"
+#include "two_body_symmetry.hpp"
 
 namespace qdk::chemistry::data {
 
@@ -317,11 +318,6 @@ void HamiltonianContainer::to_fcidump_file(const std::string& filename,
         "FCIDUMP format is not supported for unrestricted Hamiltonians.");
   }
 
-  std::ofstream file(filename);
-  if (!file.is_open()) {
-    throw std::runtime_error("Cannot open file for writing: " + filename);
-  }
-
   size_t num_molecular_orbitals;
   if (has_orbitals()) {
     if (_orbitals->has_active_space()) {
@@ -351,6 +347,24 @@ void HamiltonianContainer::to_fcidump_file(const std::string& filename,
       num_molecular_orbitals2 * num_molecular_orbitals;
   const double print_thresh = std::numeric_limits<double>::epsilon();
 
+  // Ordinary FCIDUMP readers reconstruct the eight permutations of every
+  // two-electron record, so reduced-symmetry tensors cannot be represented
+  // losslessly by this format.
+  auto [eri_aaaa, eri_aabb, eri_bbbb] = get_two_body_integrals();
+  if (detail::classify_two_body_symmetry(eri_aaaa.data(),
+                                         num_molecular_orbitals,
+                                         detail::two_body_symmetry_tolerance) !=
+      detail::TwoBodySymmetry::EightFold) {
+    throw std::runtime_error(
+        "FCIDUMP export requires 8-fold two-body permutation symmetry; "
+        "reduced-symmetry tensors cannot be represented losslessly.");
+  }
+
+  std::ofstream file(filename);
+  if (!file.is_open()) {
+    throw std::runtime_error("Cannot open file for writing: " + filename);
+  }
+
   // C1 symmetry
   std::string orb_string;
   for (size_t i = 0; i < num_molecular_orbitals - 1; ++i) {
@@ -378,9 +392,6 @@ void HamiltonianContainer::to_fcidump_file(const std::string& filename,
     file << std::setw(4) << k << " ";
     file << std::setw(4) << l;
   };
-
-  // Get the two-electron integrals via the virtual accessor
-  auto [eri_aaaa, eri_aabb, eri_bbbb] = get_two_body_integrals();
 
   auto write_eri = [&](size_t i, size_t j, size_t k, size_t l) {
     auto eri =

--- a/cpp/src/qdk/chemistry/data/hamiltonian_containers/sparse.cpp
+++ b/cpp/src/qdk/chemistry/data/hamiltonian_containers/sparse.cpp
@@ -16,6 +16,7 @@
 
 #include "../hdf5_serialization.hpp"
 #include "../json_serialization.hpp"
+#include "../two_body_symmetry.hpp"
 
 namespace qdk::chemistry::data {
 
@@ -518,6 +519,19 @@ void SparseHamiltonianContainer::to_fcidump_file(const std::string& filename,
   if (is_unrestricted()) {
     throw std::runtime_error(
         "FCIDUMP format is not supported for unrestricted Hamiltonians.");
+  }
+
+  // Ordinary FCIDUMP readers reconstruct the eight permutations of every
+  // two-electron record, so a permutation class that is only partially stored
+  // or whose stored records disagree cannot be represented by this format.
+  if (has_two_body_integrals() &&
+      !detail::sparse_entries_have_eightfold_symmetry(
+          _two_body_sparse->block(
+              {axes::alpha(), axes::alpha(), axes::alpha(), axes::alpha()}),
+          detail::two_body_symmetry_tolerance)) {
+    throw std::runtime_error(
+        "FCIDUMP export requires 8-fold two-body permutation symmetry; "
+        "reduced-symmetry tensors cannot be represented losslessly.");
   }
 
   std::ofstream file(filename);

--- a/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
+++ b/cpp/src/qdk/chemistry/data/majorana_map_engine.cpp
@@ -16,12 +16,15 @@
 #include <qdk/chemistry/data/majorana_mapping.hpp>
 #include <qdk/chemistry/data/pauli_operator.hpp>
 #include <qdk/chemistry/utils/hash_context.hpp>
+#include <qdk/chemistry/utils/logger.hpp>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
+#include "two_body_symmetry.hpp"
 
 namespace qdk::chemistry::data {
 namespace detail {
@@ -184,11 +187,10 @@ class PackedAccumulator {
 // The spin_symmetric flag selects one of two evaluation strategies:
 //
 //   spin_symmetric = true   (restricted orbitals)
-//     All spin channels share the same integrals (h_alpha == h_beta,
-//     eri_aaaa == eri_bbbb == eri_aabb).  The engine precomputes
-//     spin-summed E_pq = E^α_pq + E^β_pq and exploits 8-fold ERI
-//     symmetry, roughly halving the two-body work.  The δ_{qr}
-//     two-body contraction is folded into the one-body integrals.
+//     The caller guarantees that all spin channels share the same integrals
+//     (h_alpha == h_beta, eri_aaaa == eri_bbbb == eri_aabb).  The spin-summed
+//     fast path additionally requires 8-fold ERI symmetry, so callers must
+//     classify the tensor before selecting it.
 //
 //   spin_symmetric = false  (unrestricted orbitals)
 //     Each spin channel (αα, ββ, αβ, βα) is handled independently
@@ -196,7 +198,9 @@ class PackedAccumulator {
 //     where h^α ≠ h^β and the ERI channels differ — even though the
 //     underlying Hamiltonian is still spin-free.  The αβ and βα
 //     cross-spin channels are related by Coulomb symmetry (pq|rs) =
-//     (rs|pq) and are handled in a single merged loop.
+//     (rs|pq) and are handled in a single merged loop.  That merge, plus the
+//     (pq|rs) = (qp|sr) fold, makes this path exact on the 4-fold subgroup
+//     and no wider: it silently symmetrizes anything outside it.
 
 // ─── ERI providers ─────────────────────────────────────────────────
 //
@@ -928,8 +932,33 @@ MajoranaMapResult majorana_map_hamiltonian(
     const double* eri_bbbb, std::size_t n_spatial, bool spin_symmetric,
     double threshold, double integral_threshold) {
   detail::DenseEriProvider provider{eri_aaaa, eri_aabb, eri_bbbb, n_spatial};
+  bool use_spin_symmetric = spin_symmetric;
+  if (spin_symmetric) {
+    const auto symmetry = detail::classify_two_body_symmetry(
+        eri_aaaa, n_spatial, detail::two_body_symmetry_tolerance);
+    if (symmetry == detail::TwoBodySymmetry::NonHermitian) {
+      throw std::invalid_argument(
+          "majorana_map_hamiltonian: (pq|rs) + (rs|pq) != (qp|sr) + (sr|qp), "
+          "so the two-body integrals define a non-Hermitian operator, which "
+          "this engine cannot map.");
+    }
+    if (symmetry == detail::TwoBodySymmetry::NotBraKetSymmetric) {
+      throw std::invalid_argument(
+          "majorana_map_hamiltonian: the two-body integrals are Hermitian but "
+          "not stored with (pq|rs) = (rs|pq). That swap leaves the operator "
+          "unchanged, so replace the tensor by its bra-ket average "
+          "((pq|rs) + (rs|pq)) / 2 before mapping.");
+    }
+    use_spin_symmetric = symmetry == detail::TwoBodySymmetry::EightFold;
+    if (!use_spin_symmetric) {
+      QDK_LOGGER().debug(
+          "Two-body integrals carry only 4-fold permutation symmetry; using "
+          "the general spin-channel path instead of the spin-summed fast "
+          "path.");
+    }
+  }
   return detail::run_with_provider(mapping, core_energy, h1_alpha, h1_beta,
-                                   provider, n_spatial, spin_symmetric,
+                                   provider, n_spatial, use_spin_symmetric,
                                    threshold, integral_threshold);
 }
 
@@ -938,6 +967,18 @@ MajoranaMapResult majorana_map_hamiltonian_cholesky(
     const double* h1_beta, const double* three_center_aa,
     const double* three_center_bb, std::size_t n_spatial, std::size_t naux,
     bool spin_symmetric, double threshold, double integral_threshold) {
+  // Verifying the weaker 4-fold symmetry the general path needs would mean
+  // materializing the dense tensor, which is exactly what this entry point
+  // exists to avoid, so reject instead of falling back.
+  if (spin_symmetric && !detail::cholesky_factors_are_pair_symmetric(
+                            three_center_aa, n_spatial, naux,
+                            detail::two_body_symmetry_tolerance)) {
+    throw std::invalid_argument(
+        "majorana_map_hamiltonian_cholesky: the three-center factors are not "
+        "symmetric in their orbital pair, so the reconstructed integrals lack "
+        "8-fold permutation symmetry; map such Hamiltonians from dense "
+        "storage instead.");
+  }
   detail::CholeskyEriProvider provider{three_center_aa, three_center_bb,
                                        n_spatial, naux};
   return detail::run_with_provider(mapping, core_energy, h1_alpha, h1_beta,
@@ -970,34 +1011,16 @@ MajoranaMapResult majorana_map_hamiltonian_sparse(
   //
   // The engine's symmetric two-body loop reads only canonical positions
   // (p<=q, r<=s, (p,q)<=(r,s) lexicographically), so every stored entry
-  // is reduced to its canonical representative here.  This makes the
-  // result independent of which symmetry-related permutation(s) a
-  // container chose to store — unique representatives, partially
-  // redundant storage (e.g. both (ii|jj) and (jj|ii) as the PPP builder
-  // emits), or a fully expanded tensor all map to the same operator.
-  //
-  // When several stored permutations fall into the same symmetry class,
-  // the value at the exact canonical position wins (this is the position
-  // a dense materialization of the container would expose to the
-  // engine's symmetric loop); among non-canonical partners, the smallest
-  // flattened position wins, so the outcome never depends on input order.
-  using Key4 = std::array<std::size_t, 4>;
-  auto canonical = [](Key4 k) {
-    if (k[0] > k[1]) std::swap(k[0], k[1]);
-    if (k[2] > k[3]) std::swap(k[2], k[3]);
-    if (k[0] > k[2] || (k[0] == k[2] && k[1] > k[3])) {
-      std::swap(k[0], k[2]);
-      std::swap(k[1], k[3]);
-    }
-    return k;
-  };
+  // is reduced to its canonical representative here and then expanded
+  // over its whole permutation class.  See the header for which storage
+  // layouts that expansion can reproduce.
+  using Key4 = detail::TwoBodyKey;
 
-  std::map<Key4, double> canon;
-  struct Partner {
-    std::uint64_t position;
-    double value;
-  };
-  std::map<Key4, Partner> partners;
+  // Iterating in key order sees the canonical member of a class first when it
+  // was stored, and otherwise the smallest stored position, so the chosen
+  // representative never depends on the caller's entry order.
+  std::map<Key4, double> stored;
+  double scale = 0.0;
   for (std::size_t e = 0; e < num_entries; ++e) {
     // Validate before the int -> size_t cast: a negative index would wrap
     // to a huge value and read out of bounds downstream (e.g. in sym_map).
@@ -1014,7 +1037,6 @@ MajoranaMapResult majorana_map_hamiltonian_sparse(
                  static_cast<std::size_t>(two_body_indices[4 * e + 1]),
                  static_cast<std::size_t>(two_body_indices[4 * e + 2]),
                  static_cast<std::size_t>(two_body_indices[4 * e + 3])};
-    const Key4 c = canonical(k);
     const double v = two_body_values[e];
     // Duplicate entries for the same position are tolerated only when they
     // agree exactly (bitwise): duplicates can only originate from a caller
@@ -1022,39 +1044,60 @@ MajoranaMapResult majorana_map_hamiltonian_sparse(
     // contract.  A tolerance would silently keep one of two genuinely
     // different values — and which one would depend on input order, the
     // very non-determinism this path is designed to exclude.
-    auto reject_conflict = [&](double existing) {
-      if (existing != v) {
-        throw std::invalid_argument(
-            "majorana_map_hamiltonian_sparse: conflicting duplicate values "
-            "for two-body entry (" +
-            std::to_string(k[0]) + ", " + std::to_string(k[1]) + ", " +
-            std::to_string(k[2]) + ", " + std::to_string(k[3]) + ").");
-      }
-    };
-    if (k == c) {
-      auto [it, inserted] = canon.try_emplace(c, v);
-      if (!inserted) reject_conflict(it->second);
-    } else {
-      const std::uint64_t position = provider.key(k[0], k[1], k[2], k[3]);
-      auto [it, inserted] = partners.try_emplace(c, Partner{position, v});
-      if (!inserted) {
-        if (position == it->second.position) {
-          reject_conflict(it->second.value);
-        } else if (position < it->second.position) {
-          it->second = {position, v};
-        }
-      }
+    auto [it, inserted] = stored.try_emplace(k, v);
+    if (!inserted && it->second != v) {
+      throw std::invalid_argument(
+          "majorana_map_hamiltonian_sparse: conflicting duplicate values "
+          "for two-body entry (" +
+          std::to_string(k[0]) + ", " + std::to_string(k[1]) + ", " +
+          std::to_string(k[2]) + ", " + std::to_string(k[3]) + ").");
     }
+    scale = std::max(scale, std::abs(v));
   }
-  for (const auto& [c, partner] : partners) {
-    canon.emplace(c, partner.value);  // no-op if the canonical position won
+
+  const double tolerance = detail::two_body_symmetry_tolerance * scale;
+  struct SymmetryClass {
+    double value;
+    std::size_t stored_positions;
+  };
+  std::map<Key4, SymmetryClass> classes;
+  for (const auto& [k, v] : stored) {
+    const Key4 c = detail::eightfold_canonical(k);
+    auto [it, inserted] = classes.try_emplace(c, SymmetryClass{v, 1});
+    if (inserted) continue;
+    if (std::abs(it->second.value - v) > tolerance) {
+      throw std::invalid_argument(
+          "majorana_map_hamiltonian_sparse: two-body entry (" +
+          std::to_string(k[0]) + ", " + std::to_string(k[1]) + ", " +
+          std::to_string(k[2]) + ", " + std::to_string(k[3]) +
+          ") breaks 8-fold permutation symmetry; the sparse path keeps one "
+          "representative per permutation class, so reduced-symmetry tensors "
+          "must use dense storage.");
+    }
+    ++it->second.stored_positions;
+  }
+  for (const auto& [c, symmetry_class] : classes) {
+    const std::size_t members = detail::eightfold_class_size(c);
+    if (symmetry_class.stored_positions != 1 &&
+        symmetry_class.stored_positions != members) {
+      throw std::invalid_argument(
+          "majorana_map_hamiltonian_sparse: the permutation class of (" +
+          std::to_string(c[0]) + ", " + std::to_string(c[1]) + ", " +
+          std::to_string(c[2]) + ", " + std::to_string(c[3]) + ") has " +
+          std::to_string(members) + " members but only " +
+          std::to_string(symmetry_class.stored_positions) +
+          " are stored; the sparse path symmetry-expands one representative, "
+          "which would overwrite the zeros implied at the missing positions. "
+          "Store one representative or the whole class, or use dense storage "
+          "for a reduced-symmetry tensor.");
+    }
   }
 
   // Canonical entries in lexicographic (std::map) order, so the two-body
   // accumulation order is deterministic for any input ordering.
-  provider.entries_.reserve(canon.size());
-  for (const auto& [c, v] : canon) {
-    provider.entries_.push_back({c[0], c[1], c[2], c[3], v});
+  provider.entries_.reserve(classes.size());
+  for (const auto& [c, symmetry_class] : classes) {
+    provider.entries_.push_back({c[0], c[1], c[2], c[3], symmetry_class.value});
   }
 
   // Symmetry-expand into the position -> value map (all 8 index
@@ -1064,8 +1107,9 @@ MajoranaMapResult majorana_map_hamiltonian_sparse(
   // position; within one class, repeated indices (p==q and/or r==s) make
   // some permutations coincide, which is benign because every write of a
   // class carries the same value.
-  provider.map_.reserve(canon.size() * 8);
-  for (const auto& [c, v] : canon) {
+  provider.map_.reserve(classes.size() * 8);
+  for (const auto& [c, symmetry_class] : classes) {
+    const double v = symmetry_class.value;
     const std::size_t pq[2][2] = {{c[0], c[1]}, {c[1], c[0]}};
     const std::size_t rs[2][2] = {{c[2], c[3]}, {c[3], c[2]}};
     for (auto& a : pq) {

--- a/cpp/src/qdk/chemistry/data/two_body_symmetry.hpp
+++ b/cpp/src/qdk/chemistry/data/two_body_symmetry.hpp
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for
+// license information.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <map>
+#include <utility>
+
+namespace qdk::chemistry::data::detail {
+
+/// Relative to the largest integral in the tensor.  A four-index
+/// transformation leaves round-off proportional to the integral magnitude
+/// rather than at an absolute floor: measured worst-case asymmetry runs from
+/// 3e-15 relative (cc-pVDZ) to 9e-12 relative (cc-pVQZ), while a genuinely
+/// reduced-symmetry tensor breaks the symmetry at O(1) relative magnitude.
+inline constexpr double two_body_symmetry_tolerance = 1e-8;
+
+using TwoBodyKey = std::array<std::size_t, 4>;
+
+/// Permutation symmetry of a two-body tensor, in increasing strength.
+///
+/// The three generators have different standing.  a+_p a+_r a_s a_q is
+/// invariant under (p,q) <-> (r,s), so the operator depends only on the
+/// bra-ket average gbar_pqrs = (g_pqrs + g_rspq) / 2: bra-ket symmetry is a
+/// gauge choice, not a property of the physics.  Given that average,
+/// (pq|rs) = (qp|sr) is exactly Hermiticity of the operator, and the
+/// independent bra swap (pq|rs) = (qp|rs) additionally requires real orbitals.
+///
+/// Genuine electron-repulsion integrals over real orbitals therefore always
+/// reach `EightFold`.  `FourFold` is the general Hermitian two-body operator,
+/// which is what downfolding and effective-Hamiltonian constructions produce.
+enum class TwoBodySymmetry {
+  NonHermitian,        ///< gbar_pqrs != gbar_qpsr: no Hermitian operator
+  NotBraKetSymmetric,  ///< g_pqrs != g_rspq: Hermitian, but g != gbar
+  FourFold,            ///< (pq|rs) = (qp|sr) = (rs|pq) = (sr|qp)
+  EightFold,           ///< additionally (pq|rs) = (qp|rs) = (pq|sr)
+};
+
+/// Classify `integrals`, a row-major (pq|rs) tensor of extent `n` per index.
+inline TwoBodySymmetry classify_two_body_symmetry(const double* integrals,
+                                                  std::size_t n,
+                                                  double relative_tolerance) {
+  const std::size_t count = n * n * n * n;
+  double scale = 0.0;
+  for (std::size_t i = 0; i < count; ++i) {
+    scale = std::max(scale, std::abs(integrals[i]));
+  }
+  const double tolerance = relative_tolerance * scale;
+
+  auto idx = [n](std::size_t p, std::size_t q, std::size_t r, std::size_t s) {
+    return ((p * n + q) * n + r) * n + s;
+  };
+  auto equal = [tolerance](double lhs, double rhs) {
+    return std::abs(lhs - rhs) <= tolerance;
+  };
+
+  bool braket_symmetric = true;
+  bool eightfold = true;
+  for (std::size_t p = 0; p < n; ++p) {
+    for (std::size_t q = 0; q < n; ++q) {
+      for (std::size_t r = 0; r < n; ++r) {
+        for (std::size_t s = 0; s < n; ++s) {
+          const double value = integrals[idx(p, q, r, s)];
+          const double swapped = integrals[idx(r, s, p, q)];
+          // Hermiticity and the 8-fold test apply to the bra-ket average,
+          // since that is all the operator sees.
+          const double mean = 0.5 * (value + swapped);
+          if (!equal(mean, 0.5 * (integrals[idx(q, p, s, r)] +
+                                  integrals[idx(s, r, q, p)]))) {
+            return TwoBodySymmetry::NonHermitian;
+          }
+          if (braket_symmetric && !equal(value, swapped)) {
+            braket_symmetric = false;
+          }
+          if (eightfold && !equal(mean, 0.5 * (integrals[idx(q, p, r, s)] +
+                                               integrals[idx(r, s, q, p)]))) {
+            eightfold = false;
+          }
+        }
+      }
+    }
+  }
+  // Both evaluation strategies read the stored tensor directly in the
+  // cross-spin channel, so a Hermitian operator in the wrong gauge still has
+  // to be symmetrized by the caller before it can be mapped.
+  if (!braket_symmetric) return TwoBodySymmetry::NotBraKetSymmetric;
+  return eightfold ? TwoBodySymmetry::EightFold : TwoBodySymmetry::FourFold;
+}
+
+/// Whether every three-center factor is symmetric in its orbital pair.
+///
+/// Factors are column-major `[n^2 x naux]` with the pair index in row-major
+/// order, so element (pq, Q) lives at `factors[p * n + q + Q * n^2]`.  The
+/// reconstruction sum_Q L^Q_pq L^Q_rs is bra-ket symmetric by construction but
+/// carries the full eightfold symmetry only when each L^Q is symmetric.
+inline bool cholesky_factors_are_pair_symmetric(const double* factors,
+                                                std::size_t n, std::size_t naux,
+                                                double relative_tolerance) {
+  const std::size_t n2 = n * n;
+  double scale = 0.0;
+  for (std::size_t i = 0; i < n2 * naux; ++i) {
+    scale = std::max(scale, std::abs(factors[i]));
+  }
+  const double tolerance = relative_tolerance * scale;
+
+  for (std::size_t aux = 0; aux < naux; ++aux) {
+    const double* factor = factors + aux * n2;
+    for (std::size_t p = 0; p < n; ++p) {
+      for (std::size_t q = p + 1; q < n; ++q) {
+        if (std::abs(factor[p * n + q] - factor[q * n + p]) > tolerance) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+/// Representative shared by all eight permutations of (p,q,r,s).  It is also
+/// the lexicographic minimum of the class, which sparse ingestion relies on to
+/// pick a deterministic representative value.
+inline TwoBodyKey eightfold_canonical(TwoBodyKey k) {
+  if (k[0] > k[1]) std::swap(k[0], k[1]);
+  if (k[2] > k[3]) std::swap(k[2], k[3]);
+  if (k[0] > k[2] || (k[0] == k[2] && k[1] > k[3])) {
+    std::swap(k[0], k[2]);
+    std::swap(k[1], k[3]);
+  }
+  return k;
+}
+
+/// Number of *distinct* index tuples in the permutation class of a canonical
+/// key: repeated indices make some of the eight permutations coincide.
+inline std::size_t eightfold_class_size(const TwoBodyKey& canonical) {
+  const std::size_t bra = canonical[0] == canonical[1] ? 1 : 2;
+  const std::size_t ket = canonical[2] == canonical[3] ? 1 : 2;
+  const std::size_t swap =
+      canonical[0] == canonical[2] && canonical[1] == canonical[3] ? 1 : 2;
+  return bra * ket * swap;
+}
+
+/// Sparse counterpart of @ref classify_two_body_symmetry.
+///
+/// Consumers of sparse data — the mapping engine and ordinary FCIDUMP readers
+/// alike — expand one stored record over its whole permutation class, while
+/// the container implies zero everywhere nothing is stored.  The two readings
+/// agree only when a class is stored exactly once (unambiguously a
+/// representative) or in full; in between, the expansion would overwrite the
+/// implied zeros.
+template <class Entries>
+bool sparse_entries_have_eightfold_symmetry(const Entries& entries,
+                                            double relative_tolerance) {
+  std::map<TwoBodyKey, double> stored;
+  double scale = 0.0;
+  for (const auto& [idx, value] : entries) {
+    stored[{static_cast<std::size_t>(idx[0]), static_cast<std::size_t>(idx[1]),
+            static_cast<std::size_t>(idx[2]),
+            static_cast<std::size_t>(idx[3])}] = value;
+    scale = std::max(scale, std::abs(value));
+  }
+  const double tolerance = relative_tolerance * scale;
+
+  std::map<TwoBodyKey, std::pair<double, std::size_t>> classes;
+  for (const auto& [key, value] : stored) {
+    auto [it, inserted] =
+        classes.try_emplace(eightfold_canonical(key), value, 1);
+    if (inserted) continue;
+    if (std::abs(it->second.first - value) > tolerance) return false;
+    ++it->second.second;
+  }
+  for (const auto& [key, aggregate] : classes) {
+    if (aggregate.second != 1 &&
+        aggregate.second != eightfold_class_size(key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace qdk::chemistry::data::detail

--- a/cpp/tests/test_hamiltonian.cpp
+++ b/cpp/tests/test_hamiltonian.cpp
@@ -1767,6 +1767,114 @@ TEST_F(HamiltonianTest, FCIDUMPSerialization) {
   EXPECT_TRUE(fcidump_content == reference_fcidump_contents);
 }
 
+TEST_F(HamiltonianTest, FCIDUMPAcceptsNumericallyEightfoldTwoBodySymmetry) {
+  // Integral transformations leave round-off proportional to the integral
+  // magnitude, so the symmetry test has to scale with the tensor rather than
+  // compare against an absolute floor.
+  const double magnitude = 1.0e6;
+  Eigen::VectorXd near_symmetric_two_body = magnitude * two_body;
+  near_symmetric_two_body(1) += 1e-9 * magnitude;
+
+  Hamiltonian h(std::make_unique<CanonicalFourCenterHamiltonianContainer>(
+      one_body, near_symmetric_two_body, orbitals, core_energy, inactive_fock));
+
+  EXPECT_NO_THROW(h.to_fcidump_file("test.hamiltonian.fcidump", 1, 1));
+}
+
+TEST_F(HamiltonianTest, FCIDUMPRejectsFourFoldTwoBodySymmetry) {
+  Eigen::VectorXd fourfold_two_body = Eigen::VectorXd::Zero(16);
+  auto idx = [](size_t p, size_t q, size_t r, size_t s) {
+    return ((p * 2 + q) * 2 + r) * 2 + s;
+  };
+  fourfold_two_body(idx(0, 1, 0, 1)) = 0.7;
+  fourfold_two_body(idx(1, 0, 1, 0)) = 0.7;
+  fourfold_two_body(idx(1, 0, 0, 1)) = -0.2;
+  fourfold_two_body(idx(0, 1, 1, 0)) = -0.2;
+
+  Hamiltonian h(std::make_unique<CanonicalFourCenterHamiltonianContainer>(
+      one_body, fourfold_two_body, orbitals, core_energy, inactive_fock));
+
+  const std::string filename = "test.hamiltonian.fcidump";
+  {
+    std::ofstream file(filename);
+    file << "existing content";
+  }
+
+  try {
+    h.to_fcidump_file(filename, 1, 1);
+    FAIL() << "Expected four-fold-symmetric FCIDUMP export to be rejected";
+  } catch (const std::runtime_error& error) {
+    EXPECT_NE(std::string(error.what()).find("8-fold"), std::string::npos);
+  }
+
+  std::ifstream file(filename);
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  EXPECT_EQ(buffer.str(), "existing content");
+}
+
+TEST_F(HamiltonianTest, FCIDUMPRejectsBraKetAsymmetricTwoBody) {
+  // Symmetric under (pq|rs) = (qp|rs) = (pq|sr) but not under (pq|rs) =
+  // (rs|pq), so the writer's ij <= kl record loop would drop the distinction.
+  Eigen::VectorXd asymmetric_two_body = Eigen::VectorXd::Zero(16);
+  auto idx = [](size_t p, size_t q, size_t r, size_t s) {
+    return ((p * 2 + q) * 2 + r) * 2 + s;
+  };
+  asymmetric_two_body(idx(0, 0, 1, 1)) = 0.4;
+  asymmetric_two_body(idx(1, 1, 0, 0)) = 0.9;
+
+  Hamiltonian h(std::make_unique<CanonicalFourCenterHamiltonianContainer>(
+      one_body, asymmetric_two_body, orbitals, core_energy, inactive_fock));
+
+  EXPECT_THROW(h.to_fcidump_file("test.hamiltonian.fcidump", 1, 1),
+               std::runtime_error);
+}
+
+TEST_F(HamiltonianTest, SparseContainerFCIDUMPRejectsFourFoldTwoBodySymmetry) {
+  Eigen::SparseMatrix<double> sparse_one_body(2, 2);
+  sparse_one_body.insert(0, 0) = 1.0;
+  sparse_one_body.insert(1, 1) = 1.0;
+  sparse_one_body.makeCompressed();
+
+  // (01|01) and (10|01) share a permutation class but disagree, so ordinary
+  // FCIDUMP readers would expand contradictory records.
+  SparseHamiltonianContainer::TwoBodyMap two_body_map;
+  two_body_map[{0, 1, 0, 1}] = 0.7;
+  two_body_map[{1, 0, 0, 1}] = -0.2;
+
+  Hamiltonian h(std::make_unique<SparseHamiltonianContainer>(
+      sparse_one_body, two_body_map, core_energy));
+
+  const std::string filename = "test.sparse.hamiltonian.fcidump";
+  std::filesystem::remove(filename);
+
+  EXPECT_THROW(h.to_fcidump_file(filename, 1, 1), std::runtime_error);
+  EXPECT_FALSE(std::filesystem::exists(filename));
+}
+
+TEST_F(HamiltonianTest, SparseContainerFCIDUMPRejectsPartialPermutationClass) {
+  Eigen::SparseMatrix<double> sparse_one_body(2, 2);
+  sparse_one_body.insert(0, 0) = 1.0;
+  sparse_one_body.insert(1, 1) = 1.0;
+  sparse_one_body.makeCompressed();
+
+  // Two of the four distinct members of one class, with (10|01) and (01|10)
+  // left implicitly zero.  The records agree, but a reader that reconstructs
+  // all eight permutations would fill in those zeros with 0.7.
+  SparseHamiltonianContainer::TwoBodyMap two_body_map;
+  two_body_map[{0, 1, 0, 1}] = 0.7;
+  two_body_map[{1, 0, 1, 0}] = 0.7;
+
+  Hamiltonian h(std::make_unique<SparseHamiltonianContainer>(
+      sparse_one_body, two_body_map, core_energy));
+
+  const std::string filename = "test.sparse.hamiltonian.fcidump";
+  std::filesystem::remove(filename);
+
+  EXPECT_THROW(h.to_fcidump_file(filename, 1, 1), std::runtime_error);
+  EXPECT_FALSE(std::filesystem::exists(filename));
+}
+
 TEST_F(HamiltonianTest, FCIDUMPSerializationUnrestrictedThrowsError) {
   // Create unrestricted orbitals for this test
   auto unrestricted_orbitals =

--- a/cpp/tests/test_majorana_mapping.cpp
+++ b/cpp/tests/test_majorana_mapping.cpp
@@ -4,7 +4,10 @@
 
 #include <gtest/gtest.h>
 
+#include <Eigen/Dense>
+#include <algorithm>
 #include <complex>
+#include <cstdint>
 #include <qdk/chemistry/data/majorana_mapping.hpp>
 #include <stdexcept>
 #include <string>
@@ -59,10 +62,137 @@ void expect_real_term(
   EXPECT_NEAR(it->second.imag(), 0.0, 1e-12);
 }
 
+// ── Ground-truth reference for the mapping ─────────────────────────
+//
+// Comparing sorted eigenvalues makes the check independent of qubit and mode
+// ordering: relabeling either is a unitary conjugation, so the spectrum is
+// invariant.  That lets the reference below be built straight from the second
+// quantized Hamiltonian without reproducing the engine's mode layout.
+
+std::vector<double> mapped_spectrum(const MajoranaMapResult& result,
+                                    std::size_t num_qubits) {
+  const std::size_t dim = std::size_t{1} << num_qubits;
+  Eigen::MatrixXcd matrix = Eigen::MatrixXcd::Zero(dim, dim);
+  for (std::size_t t = 0; t < result.words.size(); ++t) {
+    const std::string label = sparse_to_dense_le(result.words[t], num_qubits);
+    // Every Pauli word maps each basis state to exactly one other state, so
+    // the term is applied column by column instead of built by Kronecker
+    // products.
+    for (std::size_t column = 0; column < dim; ++column) {
+      std::size_t row = column;
+      std::complex<double> phase = result.coefficients[t];
+      for (std::size_t qubit = 0; qubit < num_qubits; ++qubit) {
+        const bool set = ((column >> qubit) & std::size_t{1}) != 0;
+        switch (label[num_qubits - 1 - qubit]) {
+          case 'X':
+            row ^= std::size_t{1} << qubit;
+            break;
+          case 'Y':
+            row ^= std::size_t{1} << qubit;
+            phase *= std::complex<double>(0.0, set ? -1.0 : 1.0);
+            break;
+          case 'Z':
+            if (set) phase = -phase;
+            break;
+          default:
+            break;
+        }
+      }
+      matrix(static_cast<Eigen::Index>(row),
+             static_cast<Eigen::Index>(column)) += phase;
+    }
+  }
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXcd> solver(matrix);
+  const auto& values = solver.eigenvalues();
+  return std::vector<double>(values.data(), values.data() + values.size());
+}
+
+// Spectrum of
+//   H = core + sum_{pq,sigma} h_pq a+_{p sigma} a_{q sigma}
+//     + 1/2 sum_{pqrs,sigma tau} (pq|rs) a+_{p sigma} a+_{r tau}
+//                                        a_{s tau} a_{q sigma}
+// built directly in the occupation-number basis, sharing no code with the
+// mapping engine.  Mode 2*p + spin, bit `mode` of the basis index.
+std::vector<double> fock_spectrum(const double* h1, const double* eri,
+                                  std::size_t n, double core_energy) {
+  const std::size_t modes = 2 * n;
+  const std::size_t dim = std::size_t{1} << modes;
+
+  // Returns false when the operator annihilates the state.
+  auto apply = [](std::size_t& state, double& sign, std::size_t mode,
+                  bool dagger) {
+    const bool occupied = ((state >> mode) & std::size_t{1}) != 0;
+    if (dagger == occupied) return false;
+    int below = 0;
+    for (std::size_t m = 0; m < mode; ++m) {
+      below += static_cast<int>((state >> m) & std::size_t{1});
+    }
+    if (below % 2 != 0) sign = -sign;
+    state ^= std::size_t{1} << mode;
+    return true;
+  };
+
+  Eigen::MatrixXd matrix = core_energy * Eigen::MatrixXd::Identity(dim, dim);
+  for (std::size_t column = 0; column < dim; ++column) {
+    for (std::size_t p = 0; p < n; ++p) {
+      for (std::size_t q = 0; q < n; ++q) {
+        for (std::size_t spin = 0; spin < 2; ++spin) {
+          std::size_t state = column;
+          double sign = 1.0;
+          if (!apply(state, sign, 2 * q + spin, false)) continue;
+          if (!apply(state, sign, 2 * p + spin, true)) continue;
+          matrix(static_cast<Eigen::Index>(state),
+                 static_cast<Eigen::Index>(column)) += sign * h1[p * n + q];
+        }
+      }
+    }
+    for (std::size_t p = 0; p < n; ++p) {
+      for (std::size_t q = 0; q < n; ++q) {
+        for (std::size_t r = 0; r < n; ++r) {
+          for (std::size_t s = 0; s < n; ++s) {
+            const double value = eri[((p * n + q) * n + r) * n + s];
+            if (value == 0.0) continue;
+            for (std::size_t sigma = 0; sigma < 2; ++sigma) {
+              for (std::size_t tau = 0; tau < 2; ++tau) {
+                std::size_t state = column;
+                double sign = 1.0;
+                if (!apply(state, sign, 2 * q + sigma, false)) continue;
+                if (!apply(state, sign, 2 * s + tau, false)) continue;
+                if (!apply(state, sign, 2 * r + tau, true)) continue;
+                if (!apply(state, sign, 2 * p + sigma, true)) continue;
+                matrix(static_cast<Eigen::Index>(state),
+                       static_cast<Eigen::Index>(column)) += 0.5 * sign * value;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> solver(matrix);
+  const auto& values = solver.eigenvalues();
+  return std::vector<double>(values.data(), values.data() + values.size());
+}
+
+void expect_matches_fock_reference(const MajoranaMapResult& result,
+                                   std::size_t num_qubits, const double* h1,
+                                   const double* eri, std::size_t n_spatial,
+                                   double core_energy) {
+  const auto mapped = mapped_spectrum(result, num_qubits);
+  const auto reference = fock_spectrum(h1, eri, n_spatial, core_energy);
+  ASSERT_EQ(mapped.size(), reference.size());
+  for (std::size_t i = 0; i < mapped.size(); ++i) {
+    EXPECT_NEAR(mapped[i], reference[i], 1e-10)
+        << "Eigenvalue " << i << " disagrees with the Fock-space reference";
+  }
+}
+
 }  // namespace qdk::chemistry::tests::test_support
 
 namespace test_support = qdk::chemistry::tests::test_support;
 using test_support::collect_terms;
+using test_support::expect_matches_fock_reference;
 using test_support::expect_real_term;
 
 TEST(MajoranaMapEngineTest, MapsOneBodyUnrestrictedJordanWignerHamiltonian) {
@@ -159,6 +289,225 @@ TEST(MajoranaMapEngineTest, SpinSymmetricMatchesUnrestricted) {
     EXPECT_NEAR(coeff.imag(), it->second.imag(), 1e-10)
         << "Imag mismatch at " << label;
   }
+}
+
+TEST(MajoranaMapEngineTest, SpinSummedPathMatchesFockSpaceReference) {
+  auto mapping = MajoranaMapping::jordan_wigner(4);
+  const double h1[4] = {1.0, 0.3, 0.3, 0.5};
+  double eri[16] = {};
+  auto idx = [](std::size_t p, std::size_t q, std::size_t r, std::size_t s) {
+    return ((p * 2 + q) * 2 + r) * 2 + s;
+  };
+  // Fully 8-fold symmetric, so the spin-summed fast path is selected.
+  for (std::size_t p = 0; p < 2; ++p) {
+    for (std::size_t q = 0; q < 2; ++q) {
+      for (std::size_t r = 0; r < 2; ++r) {
+        for (std::size_t s = 0; s < 2; ++s) {
+          eri[idx(p, q, r, s)] =
+              0.3 + 0.1 * static_cast<double>((p + q) * (r + s));
+        }
+      }
+    }
+  }
+
+  auto result = majorana_map_hamiltonian(mapping, 0.5, h1, h1, eri, eri, eri,
+                                         /*n_spatial=*/2,
+                                         /*spin_symmetric=*/true,
+                                         /*threshold=*/0.0,
+                                         /*integral_threshold=*/0.0);
+
+  expect_matches_fock_reference(result, mapping.num_qubits(), h1, eri, 2, 0.5);
+}
+
+TEST(MajoranaMapEngineTest, FourFoldTwoBodyMatchesFockSpaceReference) {
+  auto mapping = MajoranaMapping::jordan_wigner(4);
+  const double h1[4] = {1.0, 0.3, 0.3, 0.5};
+  double eri[16] = {};
+  auto idx = [](std::size_t p, std::size_t q, std::size_t r, std::size_t s) {
+    return ((p * 2 + q) * 2 + r) * 2 + s;
+  };
+
+  // Four-fold symmetry: (pq|rs) = (qp|sr) = (rs|pq) = (sr|qp), but
+  // (01|01) != (10|01), so independent bra/ket swaps are not valid.
+  eri[idx(0, 1, 0, 1)] = 0.7;
+  eri[idx(1, 0, 1, 0)] = 0.7;
+  eri[idx(1, 0, 0, 1)] = -0.2;
+  eri[idx(0, 1, 1, 0)] = -0.2;
+
+  auto result = majorana_map_hamiltonian(mapping, 0.5, h1, h1, eri, eri, eri,
+                                         /*n_spatial=*/2,
+                                         /*spin_symmetric=*/true,
+                                         /*threshold=*/0.0,
+                                         /*integral_threshold=*/0.0);
+
+  expect_matches_fock_reference(result, mapping.num_qubits(), h1, eri, 2, 0.5);
+}
+
+TEST(MajoranaMapEngineTest, RejectsBraKetAsymmetricStorage) {
+  auto mapping = MajoranaMapping::jordan_wigner(4);
+  const double h1[4] = {1.0, 0.3, 0.3, 0.5};
+  double eri[16] = {};
+  auto idx = [](std::size_t p, std::size_t q, std::size_t r, std::size_t s) {
+    return ((p * 2 + q) * 2 + r) * 2 + s;
+  };
+
+  // Hermitian, and its bra-ket average is fully 8-fold, but the cross-spin
+  // channel reads the stored tensor directly, so the caller has to average.
+  eri[idx(0, 0, 1, 1)] = 0.4;
+  eri[idx(1, 1, 0, 0)] = 0.9;
+
+  try {
+    majorana_map_hamiltonian(mapping, 0.5, h1, h1, eri, eri, eri,
+                             /*n_spatial=*/2, /*spin_symmetric=*/true,
+                             /*threshold=*/0.0, /*integral_threshold=*/0.0);
+    FAIL() << "Expected bra-ket-asymmetric storage to be rejected";
+  } catch (const std::invalid_argument& error) {
+    EXPECT_NE(std::string(error.what()).find("bra-ket average"),
+              std::string::npos);
+  }
+}
+
+TEST(MajoranaMapEngineTest, BraKetAverageOfRejectedStorageMapsExactly) {
+  auto mapping = MajoranaMapping::jordan_wigner(4);
+  const double h1[4] = {1.0, 0.3, 0.3, 0.5};
+  double eri[16] = {};
+  auto idx = [](std::size_t p, std::size_t q, std::size_t r, std::size_t s) {
+    return ((p * 2 + q) * 2 + r) * 2 + s;
+  };
+  // The remedy the rejection above asks for: same operator, mapped exactly.
+  eri[idx(0, 0, 1, 1)] = 0.65;
+  eri[idx(1, 1, 0, 0)] = 0.65;
+
+  auto result = majorana_map_hamiltonian(mapping, 0.5, h1, h1, eri, eri, eri,
+                                         /*n_spatial=*/2,
+                                         /*spin_symmetric=*/true,
+                                         /*threshold=*/0.0,
+                                         /*integral_threshold=*/0.0);
+
+  expect_matches_fock_reference(result, mapping.num_qubits(), h1, eri, 2, 0.5);
+}
+
+TEST(MajoranaMapEngineTest, RejectsNonHermitianTwoBody) {
+  auto mapping = MajoranaMapping::jordan_wigner(4);
+  const double h1[4] = {1.0, 0.3, 0.3, 0.5};
+  double eri[16] = {};
+  auto idx = [](std::size_t p, std::size_t q, std::size_t r, std::size_t s) {
+    return ((p * 2 + q) * 2 + r) * 2 + s;
+  };
+
+  // Bra-ket symmetric, so no gauge freedom is left, but (pq|rs) != (qp|sr):
+  // the operator it denotes is not Hermitian.
+  eri[idx(0, 1, 0, 0)] = 0.25;
+  eri[idx(0, 0, 0, 1)] = 0.25;
+  eri[idx(1, 0, 0, 0)] = -0.25;
+  eri[idx(0, 0, 1, 0)] = -0.25;
+
+  try {
+    majorana_map_hamiltonian(mapping, 0.5, h1, h1, eri, eri, eri,
+                             /*n_spatial=*/2, /*spin_symmetric=*/true,
+                             /*threshold=*/0.0, /*integral_threshold=*/0.0);
+    FAIL() << "Expected a non-Hermitian two-body tensor to be rejected";
+  } catch (const std::invalid_argument& error) {
+    EXPECT_NE(std::string(error.what()).find("non-Hermitian"),
+              std::string::npos);
+  }
+}
+
+TEST(MajoranaMapEngineTest, SymmetryToleranceScalesWithIntegralMagnitude) {
+  auto mapping = MajoranaMapping::jordan_wigner(4);
+  const double h1[4] = {1.0, 0.3, 0.3, 0.5};
+  // Round-off left by an integral transformation is relative to the integral
+  // magnitude, so a large tensor perturbed far below that relative scale must
+  // still be accepted.  An absolute tolerance rejects this, and with it the
+  // ordinary RHF Hamiltonians whose asymmetry grows with the basis.
+  const double magnitude = 1.0e6;
+  double eri[16] = {};
+  for (double& value : eri) value = magnitude;
+  eri[1] += 1.0e-9 * magnitude;
+
+  EXPECT_NO_THROW(majorana_map_hamiltonian(mapping, 0.0, h1, h1, eri, eri, eri,
+                                           /*n_spatial=*/2,
+                                           /*spin_symmetric=*/true,
+                                           /*threshold=*/0.0,
+                                           /*integral_threshold=*/0.0));
+}
+
+TEST(MajoranaMapEngineTest, CholeskyRejectsPairAsymmetricFactors) {
+  auto mapping = MajoranaMapping::jordan_wigner(4);
+  const double h1[4] = {1.0, 0.3, 0.3, 0.5};
+
+  // One antisymmetric factor: sum_Q L_pq L_rs stays bra-ket symmetric but
+  // loses the p<->q symmetry the spin-summed path needs, and confirming the
+  // weaker 4-fold symmetry would mean materializing the dense tensor.
+  const double three_center[4] = {0.0, 0.6, -0.6, 0.0};
+
+  try {
+    majorana_map_hamiltonian_cholesky(mapping, 0.0, h1, h1, three_center,
+                                      three_center, /*n_spatial=*/2,
+                                      /*naux=*/1, /*spin_symmetric=*/true,
+                                      /*threshold=*/0.0,
+                                      /*integral_threshold=*/0.0);
+    FAIL() << "Expected pair-asymmetric three-center factors to be rejected";
+  } catch (const std::invalid_argument& error) {
+    EXPECT_NE(std::string(error.what()).find("pair"), std::string::npos);
+  }
+}
+
+TEST(MajoranaMapEngineTest, SparseRejectsDisagreeingPermutationClass) {
+  auto mapping = MajoranaMapping::jordan_wigner(4);
+  const double h1[4] = {1.0, 0.3, 0.3, 0.5};
+
+  // Same permutation class as (0,1,0,1), but a different value: the sparse
+  // path keeps one representative per class, so this cannot be represented.
+  const int indices[8] = {0, 1, 0, 1, 1, 0, 0, 1};
+  const double values[2] = {0.7, -0.2};
+
+  try {
+    majorana_map_hamiltonian_sparse(mapping, 0.5, h1, h1, indices, values,
+                                    /*num_entries=*/2, /*n_spatial=*/2,
+                                    /*spin_symmetric=*/true,
+                                    /*threshold=*/1e-12,
+                                    /*integral_threshold=*/1e-12);
+    FAIL() << "Expected reduced-symmetry sparse input to be rejected";
+  } catch (const std::invalid_argument& error) {
+    EXPECT_NE(std::string(error.what()).find("8-fold"), std::string::npos);
+  }
+}
+
+TEST(MajoranaMapEngineTest, SparseRejectsPartiallyStoredPermutationClass) {
+  auto mapping = MajoranaMapping::jordan_wigner(4);
+  const double h1[4] = {1.0, 0.3, 0.3, 0.5};
+
+  // (01|01) and (10|10) are two of the four distinct members of one class;
+  // the caller means the other two to be zero, but symmetry expansion would
+  // overwrite them, so the intent is ambiguous rather than representable.
+  const int indices[8] = {0, 1, 0, 1, 1, 0, 1, 0};
+  const double values[2] = {0.7, 0.7};
+
+  try {
+    majorana_map_hamiltonian_sparse(mapping, 0.5, h1, h1, indices, values,
+                                    /*num_entries=*/2, /*n_spatial=*/2,
+                                    /*spin_symmetric=*/true,
+                                    /*threshold=*/1e-12,
+                                    /*integral_threshold=*/1e-12);
+    FAIL() << "Expected a partially stored permutation class to be rejected";
+  } catch (const std::invalid_argument& error) {
+    EXPECT_NE(std::string(error.what()).find("permutation class"),
+              std::string::npos);
+  }
+}
+
+TEST(MajoranaMapEngineTest, SparseAcceptsRedundantSymmetryRelatedStorage) {
+  auto mapping = MajoranaMapping::jordan_wigner(4);
+  const double h1[4] = {1.0, 0.3, 0.3, 0.5};
+
+  const int indices[8] = {0, 0, 1, 1, 1, 1, 0, 0};
+  const double values[2] = {0.7, 0.7};
+
+  EXPECT_NO_THROW(majorana_map_hamiltonian_sparse(
+      mapping, 0.5, h1, h1, indices, values, /*num_entries=*/2,
+      /*n_spatial=*/2, /*spin_symmetric=*/true, /*threshold=*/1e-12,
+      /*integral_threshold=*/1e-12));
 }
 
 TEST(MajoranaMapEngineTest, TwoBodyIntegralsProduceAdditionalTerms) {

--- a/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
+++ b/docs/source/user/comprehensive/algorithms/qubit_mapper.rst
@@ -218,23 +218,31 @@ compressed form:
   the zero entries are ever touched. Stored entries are canonicalized under the
   8-fold integral symmetry before mapping, so the result does not depend on
   which symmetry-related permutations of an integral the container stores, nor
-  on their order.
+  on their order. Because one representative is expanded over its whole
+  permutation class, each class must be stored exactly once or in full; a
+  partially stored class raises, since the expansion would overwrite the zeros
+  implied at its missing positions.
 - :class:`~qdk_chemistry.data.CholeskyHamiltonianContainer` — the three-center
   (Cholesky / density-fitted) factors are kept in their
   :math:`O(N^2 \cdot n_\text{aux})` form and the auxiliary index is contracted
   in integral space, one ``(pq|.)`` row at a time (a vectorized matrix-vector
   product per orbital pair). The dense four-center tensor is never built and
   peak additional memory is a single :math:`N^2`-length row, making this path
-  suitable for systems whose dense ERI tensor does not fit in memory.
+  suitable for systems whose dense ERI tensor does not fit in memory. The
+  reconstruction :math:`\sum_Q L^Q_{pq} L^Q_{rs}` carries the 8-fold symmetry
+  only when every factor is symmetric in its orbital pair, which is validated.
 
 In all cases the result is a :class:`~qdk_chemistry.data.QubitOperator` that
 is numerically equivalent — term-by-term, to within ``1e-12`` — to the dense
 :class:`~qdk_chemistry.data.CanonicalFourCenterHamiltonianContainer` path for
-the same integrals. The behaviour of ``run()`` and the shape of the returned
-operator are unchanged, and the selection is fully automatic based on the
-container type. The
+integrals the container can represent. The behaviour of ``run()`` and the shape
+of the returned operator are unchanged, and the selection is fully automatic
+based on the container type. The
 :class:`~qdk_chemistry.data.CanonicalFourCenterHamiltonianContainer` continues
-to use the dense path.
+to use the dense path, which additionally accepts two-body tensors carrying
+only the 4-fold subgroup :math:`(pq|rs) = (qp|sr) = (rs|pq)` -- the general
+Hermitian two-body operator, as produced by downfolding. Electron-repulsion
+integrals over real orbitals always satisfy the full 8-fold symmetry.
 
 .. rubric:: Settings
 

--- a/python/src/pybind11/data/hamiltonian.cpp
+++ b/python/src/pybind11/data/hamiltonian.cpp
@@ -542,6 +542,7 @@ Raises:
     RuntimeError: If I/O error occurs, the Hamiltonian is unrestricted, or its
         two-body integrals lack the 8-fold permutation symmetry that FCIDUMP
         readers reconstruct.
+    ValueError: If the active space has differing alpha and beta sizes.
 )",
       py::arg("filename"), py::arg("nalpha"), py::arg("nbeta"));
 
@@ -770,6 +771,7 @@ Raises:
     RuntimeError: If I/O error occurs, the Hamiltonian is unrestricted, or its
         two-body integrals lack the 8-fold permutation symmetry that FCIDUMP
         readers reconstruct.
+    ValueError: If the active space has differing alpha and beta sizes.
 )",
       py::arg("filename"), py::arg("nalpha"), py::arg("nbeta"));
 
@@ -1356,6 +1358,7 @@ Raises:
     RuntimeError: If I/O error occurs, the Hamiltonian is unrestricted, or its
         two-body integrals lack the 8-fold permutation symmetry that FCIDUMP
         readers reconstruct.
+    ValueError: If the active space has differing alpha and beta sizes.
 
 Examples:
     >>> hamiltonian.to_fcidump_file("water.fcidump", 5, 5)

--- a/python/src/pybind11/data/hamiltonian.cpp
+++ b/python/src/pybind11/data/hamiltonian.cpp
@@ -537,6 +537,11 @@ Args:
     filename (str): Path to FCIDUMP file to create/overwrite
     nalpha (int): Number of alpha electrons
     nbeta (int): Number of beta electrons
+
+Raises:
+    RuntimeError: If I/O error occurs, the Hamiltonian is unrestricted, or its
+        two-body integrals lack the 8-fold permutation symmetry that FCIDUMP
+        readers reconstruct.
 )",
       py::arg("filename"), py::arg("nalpha"), py::arg("nbeta"));
 
@@ -760,6 +765,11 @@ Args:
     filename (str): Path to FCIDUMP file to create/overwrite
     nalpha (int): Number of alpha electrons
     nbeta (int): Number of beta electrons
+
+Raises:
+    RuntimeError: If I/O error occurs, the Hamiltonian is unrestricted, or its
+        two-body integrals lack the 8-fold permutation symmetry that FCIDUMP
+        readers reconstruct.
 )",
       py::arg("filename"), py::arg("nalpha"), py::arg("nbeta"));
 
@@ -981,6 +991,11 @@ Args:
     filename (str): Path to the output file.
     nalpha (int): Number of alpha electrons.
     nbeta (int): Number of beta electrons.
+
+Raises:
+    RuntimeError: If I/O error occurs, the Hamiltonian is unrestricted, or a
+        two-body permutation class is stored partially or with disagreeing
+        values, which FCIDUMP readers would expand into contradictory records.
 )",
       py::arg("filename"), py::arg("nalpha"), py::arg("nbeta"));
 
@@ -1338,7 +1353,9 @@ Args:
     nbeta (int): Number of beta electrons
 
 Raises:
-    RuntimeError: If I/O error occurs
+    RuntimeError: If I/O error occurs, the Hamiltonian is unrestricted, or its
+        two-body integrals lack the 8-fold permutation symmetry that FCIDUMP
+        readers reconstruct.
 
 Examples:
     >>> hamiltonian.to_fcidump_file("water.fcidump", 5, 5)

--- a/python/src/pybind11/data/majorana_mapping.cpp
+++ b/python/src/pybind11/data/majorana_mapping.cpp
@@ -345,8 +345,13 @@ Returns:
 Map a fermionic Hamiltonian to qubit Pauli terms using Majorana loops.
 
 When ``spin_symmetric`` is true, uses a spin-summed fast path that assumes
-identical integrals across spin channels (restricted orbitals). When false,
-handles each spin channel independently (unrestricted orbitals).
+identical integrals across spin channels (restricted orbitals). That path also
+needs 8-fold permutation symmetry; tensors carrying only the 4-fold subgroup
+``(pq|rs) == (qp|sr) == (rs|pq)`` fall back to the general spin-channel path.
+A Hermitian tensor not stored with ``(pq|rs) == (rs|pq)`` raises ``ValueError``
+-- that swap leaves the operator unchanged, so use the bra-ket average -- as
+does a genuinely non-Hermitian tensor. When false, handles each spin channel
+independently (unrestricted orbitals).
 
 Returns ``(words, coefficients)`` where ``words`` is a list of sparse
 Pauli words.
@@ -378,10 +383,10 @@ other container uses the dense path.
 For Cholesky and dense containers, the returned ``(words, coefficients)``
 match the dense path for the same underlying integrals.  For sparse
 containers, stored entries are canonicalized and symmetry-expanded before
-mapping, so results agree with the dense path when integrals are stored
-canonically or symmetry-complete (as for in-repo model builders); the
-sparse fast path is more robust when only non-canonical symmetry
-representatives are stored.
+mapping, so each permutation class must be stored exactly once (unambiguously
+a representative) or in full; a partially stored class raises ``ValueError``
+because the expansion would overwrite the zeros implied at its missing
+positions.
 
 The Hamiltonian's constant energy shift (nuclear repulsion / frozen core)
 is intentionally **not** included in the mapped operator, matching the

--- a/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
+++ b/python/src/qdk_chemistry/algorithms/qubit_mapper/qdk_qubit_mapper.py
@@ -71,8 +71,18 @@ class QdkQubitMapper(QubitMapper):
     output :class:`~qdk_chemistry.data.QubitOperator`, not for dispatch.
 
     Both restricted (RHF) and unrestricted (UHF) Hamiltonians are supported.
-    For unrestricted systems, the engine handles all four spin-channel ERI
-    blocks (aa, ab, ba, bb) independently.
+    Restricted two-body tensors with 8-fold permutation symmetry use a
+    spin-summed fast path. Tensors carrying only the 4-fold subgroup
+    ``(pq|rs) == (qp|sr) == (rs|pq)`` -- the general Hermitian two-body
+    operator, as produced by downfolding -- use the general spin-channel path,
+    which reproduces them exactly. A tensor that is Hermitian but not stored
+    with ``(pq|rs) == (rs|pq)`` raises: that swap leaves the operator
+    unchanged, so replacing it by its bra-ket average is enough. A genuinely
+    non-Hermitian tensor also raises. Cholesky containers additionally require
+    pair-symmetric three-center factors, and sparse containers require each
+    permutation class to be stored once or in full. For unrestricted systems,
+    the engine handles all four spin-channel ERI blocks (aa, ab, ba, bb)
+    independently.
 
     The two-body integrals are consumed in the native storage format of the
     Hamiltonian's container (the C++ engine dispatches on the container type):
@@ -89,7 +99,7 @@ class QdkQubitMapper(QubitMapper):
     * All other containers use the dense engine path.
 
     In all cases the result is numerically equivalent (term-by-term, to within
-    ``1e-12``) to the dense path.
+    ``1e-12``) to the dense path for integrals each container can represent.
 
     The mapper uses canonical blocked spin-orbital ordering internally:
     qubits 0..N-1 for alpha spin, qubits N..2N-1 for beta spin (where N is the

--- a/python/tests/test_qdk_qubit_mapper.py
+++ b/python/tests/test_qdk_qubit_mapper.py
@@ -17,6 +17,7 @@ from qdk_chemistry.data import (
     MajoranaMapping,
     Orbitals,
     QubitOperator,
+    SparseHamiltonianContainer,
 )
 from qdk_chemistry.plugins.qiskit import QDK_CHEMISTRY_HAS_QISKIT_NATURE
 
@@ -89,6 +90,79 @@ class TestQdkQubitMapper:
         assert len(result.pauli_strings) > 0
         assert len(result.coefficients) == len(result.pauli_strings)
         assert result.coefficients.dtype == complex
+
+    def test_restricted_fourfold_two_body_dispatches_to_general_path(self) -> None:
+        """A tensor with only 4-fold symmetry maps instead of raising.
+
+        The coefficients are checked against a Fock-space reference in
+        cpp/tests/test_majorana_mapping.cpp; here it is dispatch and the
+        Hermiticity of the public result that matter.
+        """
+        n_orbitals = 2
+        one_body = np.array([[1.0, 0.3], [0.3, 0.5]])
+        two_body = np.zeros((n_orbitals,) * 4)
+        two_body[0, 1, 0, 1] = 0.7
+        two_body[1, 0, 1, 0] = 0.7
+        two_body[1, 0, 0, 1] = -0.2
+        two_body[0, 1, 1, 0] = -0.2
+
+        hamiltonian = _make_hamiltonian(one_body, two_body.ravel(), create_test_orbitals(n_orbitals))
+        mapper = create("qubit_mapper", "qdk")
+        result = mapper.run(hamiltonian, MajoranaMapping.jordan_wigner(num_modes=2 * n_orbitals))
+
+        assert result.num_qubits == 2 * n_orbitals
+        for coefficient in result.coefficients:
+            assert abs(coefficient.imag) < 1e-12
+
+    def test_restricted_rejects_braket_asymmetric_storage(self) -> None:
+        """The swap leaves the operator alone, but the engine reads the stored tensor."""
+        one_body = np.array([[1.0, 0.3], [0.3, 0.5]])
+        two_body = np.zeros((2,) * 4)
+        two_body[0, 0, 1, 1] = 0.4
+        two_body[1, 1, 0, 0] = 0.9
+
+        hamiltonian = _make_hamiltonian(one_body, two_body.ravel(), create_test_orbitals(2))
+        mapper = create("qubit_mapper", "qdk")
+        with pytest.raises(ValueError, match="bra-ket average"):
+            mapper.run(hamiltonian, MajoranaMapping.jordan_wigner(num_modes=4))
+
+        # The remedy the message asks for is accepted.
+        averaged = 0.5 * (two_body + two_body.transpose(2, 3, 0, 1))
+        fixed = _make_hamiltonian(one_body, averaged.ravel(), create_test_orbitals(2))
+        assert mapper.run(fixed, MajoranaMapping.jordan_wigner(num_modes=4)).num_qubits == 4
+
+    def test_restricted_rejects_non_hermitian_two_body(self) -> None:
+        """No gauge freedom left, and (pq|rs) != (qp|sr): the operator is not Hermitian."""
+        one_body = np.array([[1.0, 0.3], [0.3, 0.5]])
+        two_body = np.zeros((2,) * 4)
+        two_body[0, 1, 0, 0] = two_body[0, 0, 0, 1] = 0.25
+        two_body[1, 0, 0, 0] = two_body[0, 0, 1, 0] = -0.25
+
+        hamiltonian = _make_hamiltonian(one_body, two_body.ravel(), create_test_orbitals(2))
+
+        mapper = create("qubit_mapper", "qdk")
+        with pytest.raises(ValueError, match="non-Hermitian"):
+            mapper.run(hamiltonian, MajoranaMapping.jordan_wigner(num_modes=4))
+
+    def test_sparse_container_rejects_disagreeing_permutation_class(self) -> None:
+        """Sparse storage keeps one representative per permutation class, so it cannot lose one."""
+        one_body = np.array([[1.0, 0.3], [0.3, 0.5]])
+        two_body = {(0, 1, 0, 1): 0.7, (1, 0, 0, 1): -0.2}
+        hamiltonian = Hamiltonian(SparseHamiltonianContainer(one_body, two_body, 0.0))
+
+        mapper = create("qubit_mapper", "qdk")
+        with pytest.raises(ValueError, match="8-fold"):
+            mapper.run(hamiltonian, MajoranaMapping.jordan_wigner(num_modes=4))
+
+    def test_sparse_container_rejects_partially_stored_permutation_class(self) -> None:
+        """Unstored members mean zero, but symmetry expansion would overwrite them."""
+        one_body = np.array([[1.0, 0.3], [0.3, 0.5]])
+        two_body = {(0, 1, 0, 1): 0.7, (1, 0, 1, 0): 0.7}
+        hamiltonian = Hamiltonian(SparseHamiltonianContainer(one_body, two_body, 0.0))
+
+        mapper = create("qubit_mapper", "qdk")
+        with pytest.raises(ValueError, match="permutation class"):
+            mapper.run(hamiltonian, MajoranaMapping.jordan_wigner(num_modes=4))
 
     def test_number_operator(self) -> None:
         """Test JW transform of number operator: a†a = (I - Z) / 2."""


### PR DESCRIPTION
Fixes #684. Unblocks #619.

## Summary

The spin-summed fast path (`majorana_map_impl`) assumes 8-fold permutation symmetry of the two-body integrals, and nothing validated it — `spin_symmetric=true` went straight there. A tensor carrying only the 4-fold symmetry of #684 was therefore silently mapped to a different Hamiltonian, and `to_fcidump_file` likewise wrote only the `ij <= kl` triangle without checking the tensor could be reconstructed from it.

This adds the missing validation. The subtlety is that the general spin-channel path is not a blanket fallback for everything lacking 8-fold symmetry: it merges the alpha-beta and beta-alpha channels under `(pq|rs) = (rs|pq)`, which together with the `(pq|rs) = (qp|sr)` fold makes it exact on the 4-fold subgroup and silently *symmetrizing* outside it. So the input is classified rather than tested against a single predicate.

## The classification

A two-body tensor can carry three independent index symmetries, and they mean different things:

- `(pq|rs) = (rs|pq)` — electron exchange. This one does not change the operator at all: any part of the tensor that is antisymmetric under it cancels out, so it is purely a question of how the tensor is *stored*.
- `(pq|rs) = (qp|sr)` — Hermiticity of the Hamiltonian.
- `(pq|rs) = (qp|rs)` — the Coulomb bra swap, which holds only for real orbitals.

The first two are the 4-fold subgroup of #684, and any Hermitian two-body operator has them; adding the third gives the 8-fold symmetry of ordinary ERIs. Four cases follow, and no others are possible — see [`classify_two_body_symmetry`](https://github.com/microsoft/qdk-chemistry/blob/9c6c1c1de09a3837ba40ea0c8508a90c541a08f3/cpp/src/qdk/chemistry/data/two_body_symmetry.hpp#L45):

| Class | Input | Behavior |
|---|---|---|
| `EightFold` | ordinary ERIs over real orbitals | spin-summed fast path, as before |
| `FourFold` | any Hermitian two-body operator — SW-PT2, downfolding | general path, exact |
| `NotBraKetSymmetric` | the right operator, stored without the exchange symmetry | rejected; message says to average the tensor |
| `NonHermitian` | not a Hermitian operator at all | rejected |

## Per container

- **Cholesky.** `sum_Q L^Q_pq L^Q_rs` is 8-fold only when every factor is pair-symmetric, so that is now validated instead of forwarding the flag unchecked. Establishing the weaker 4-fold property would require materializing the dense tensor this path exists to avoid, so asymmetric factors are rejected rather than redirected.
- **Sparse.** An unstored entry means zero, but the engine expands one stored representative over its whole permutation class. Each class must now be stored once or in full; partial storage is ambiguous and rejected.
- **FCIDUMP.** Readers reconstruct all eight permutations while the writer emits only the `ij <= kl` triangle, so reduced-symmetry tensors cannot round-trip. The check runs before the destination is opened, leaving an existing file untouched on refusal. `SparseHamiltonianContainer` overrides `to_fcidump_file` and needed the sparse form of the check.

## Tolerance

The comparison is relative to the largest integral in the tensor, because round-off from a four-index transformation scales with integral magnitude rather than sitting at an absolute floor — measured `3e-15` relative (cc-pVDZ) rising to `9e-12` (cc-pVQZ). An absolute threshold would reject ordinary closed-shell RHF Hamiltonians produced by this library's own SCF, which #684 requires to keep working, and would simultaneously stop detecting genuine asymmetry in small-magnitude tensors.

## Behavior changes

`majorana_map_hamiltonian` and `to_fcidump_file` (base and sparse override) gain throwing preconditions — the "reject unsupported inputs explicitly" half of #684. Inputs reaching those throws were previously being mis-mapped or mis-exported, so this converts wrong answers into diagnostics; no input that previously produced a correct result is affected.

## Notes for review

- The new tests check the mapped operator against a Fock-space reference built in the occupation-number basis, sharing no code with the engine, comparing sorted eigenvalues so the check is independent of qubit and mode ordering. Comparing `spin_symmetric=true` against `false` would not work here, since the classifier redirects the former to the latter for exactly the tensors under test.
- The unrestricted path makes the same exchange assumption on the `aabb` block, unchecked — the buffer API has no `eri_bbaa` to validate against. Pre-existing and orthogonal, so deliberately out of scope.
- Other consumers were audited for the same assumption, prompted by a question about the CI solvers. They do not assume 8-fold — MACIS uses only the exchange swap `(pq|rs) = (rs|pq)`, and CAS-CI reproduces a 4-fold-only tensor to `3.5e-15` against exact diagonalization. MP2, `Ansatz` and the localizers are likewise safe. So 4-fold is already the library-wide contract; this PR encodes it rather than introducing it.
