### PR TITLE
Raise the qdk floor to 1.31.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -125,7 +125,7 @@ If you chose the minimal `pip install qdk-chemistry` above, you can add specific
 | `openfermion-extras` | OpenFermion ecosystem packages | openfermion |
 | `networkx-extras` | NetworkX ecosystem packages | networkx |
 | `docs` | [Sphinx documentation build tools](docs/README.md) | sphinx, sphinx-rtd-theme, myst-parser, breathe, sphinx-autodoc-typehints, sphinx-inline-tabs, sphinxcontrib-napoleon, sphinxcontrib-bibtex, sphinx_copybutton |
-| `qre` | Quantum Resource Estimator support | qdk[qre,jupyter]>=1.30.0 |
+| `qre` | Quantum Resource Estimator support | qdk[qre,jupyter]>=1.31.0 |
 | `dev` | Development and testing tools | pytest, ruff, mypy, and related tooling |
 | `test` | Testing tools and optional runtime dependencies; does not include `docs` | qdk-chemistry[coverage,jupyter,mcp,networkx-extras,openfermion-extras,plugins,qiskit-extras,qre], nbclient, nbformat, pennylane, rdkit, requests>=2.33.0 |
 | `all` | Union of all defined extras | coverage, dev, docs, jupyter, mcp, networkx-extras, openfermion-extras, plugins, qiskit-extras, qre, test |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "matplotlib>=3.10.0",
   "argcomplete>=3.0.0",
   "ruamel-yaml>=0.18.10",
-  "qdk[jupyter]>=1.30.0",
+  "qdk[jupyter]>=1.31.0",
   "pybind11-stubgen>=2.5.1",
   "h5py>=3.0.0",
 ]
@@ -95,7 +95,7 @@ docs = [
 jupyter = [
   "ipykernel>=6.0",
   "pandas>=2.0.0",
-  "qdk[jupyter]>=1.30.0",
+  "qdk[jupyter]>=1.31.0",
 ]
 mcp = [
   "mcp>=2,<3"
@@ -122,7 +122,7 @@ qiskit-extras = [
   "requests>=2.33.0"
 ]
 qre = [
-  "qdk[qre,jupyter]>=1.30.0"
+  "qdk[qre,jupyter]>=1.31.0"
 ]
 test = [
   "qdk-chemistry[coverage,discovery,jupyter,networkx-extras,openfermion-extras,plugins,qiskit-extras,qre]",

--- a/python/tests/test_optional_dependency_extras.py
+++ b/python/tests/test_optional_dependency_extras.py
@@ -27,7 +27,7 @@ def test_jupyter_extra_excludes_plugins_and_includes_widget_support():
     jupyter_block = _get_optional_extra_block(pyproject_text, "jupyter")
     assert '"ipykernel>=6.0"' in jupyter_block
     assert '"pandas>=2.0.0"' in jupyter_block
-    assert '"qdk[jupyter]>=1.30.0"' in jupyter_block
+    assert '"qdk[jupyter]>=1.31.0"' in jupyter_block
     assert "qdk-chemistry[plugins]" not in jupyter_block
 
 


### PR DESCRIPTION
Raises the `qdk` floor from 1.30.0 to 1.31.0.

The resource-estimation path needs `qdk.qre` to accept a context, which 1.30.0 does not provide. The pin is a floor rather than an equality, so a resolver was already free to pick 1.31 and mostly did — what this fixes is an environment that holds qdk at exactly 1.30, where the failure surfaces from inside `qre` rather than as an unmet requirement.

Split out of #539, where it was an orthogonal change riding along with the SOSSA work.

### Changes

All three pins move together, plus the two places that restate them:

| file | change |
| :-- | :-- |
| `python/pyproject.toml` | base dependency, `docs` extra, `qre` extra |
| `INSTALL.md` | the optional-extras table |
| `python/tests/test_optional_dependency_extras.py` | the assertion pinning the declared string |

5 lines across 3 files. `git grep 1.30.0` returns nothing afterwards, so no stale reference is left behind. The `check-version-alignment` hook inspects qdk-chemistry's own version metadata rather than this dependency pin, so it is unaffected.
