### PR TITLE
Harden Windows wheel runtime prerequisite

### DIFF
--- a/.pipelines/pip-scripts/check-wheel-dll-imports.py
+++ b/.pipelines/pip-scripts/check-wheel-dll-imports.py
@@ -118,11 +118,7 @@ def _main() -> int:
         print(f"ERROR: cannot inspect {wheel}: {exc}")
         return 1
 
-    packaged_dlls = {
-        PurePosixPath(name).name.upper()
-        for name in binaries
-        if name.lower().endswith(".dll")
-    }
+    packaged_dlls = {PurePosixPath(name).name.upper() for name in binaries}
     unresolved: list[tuple[str, str]] = []
     for name, (regular, delayed) in imports.items():
         print(f"DLL imports for {name}:")

--- a/.pipelines/pip-scripts/check-wheel-dll-imports.py
+++ b/.pipelines/pip-scripts/check-wheel-dll-imports.py
@@ -1,0 +1,160 @@
+"""Reject Windows wheels with unresolved native DLL dependencies."""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path, PurePosixPath
+from zipfile import BadZipFile, ZipFile
+
+import pefile
+
+_ALLOWED_SYSTEM_DLLS = frozenset(
+    {
+        "ADVAPI32.DLL",
+        "BCRYPT.DLL",
+        "COMBASE.DLL",
+        "CRYPT32.DLL",
+        "GDI32.DLL",
+        "IPHLPAPI.DLL",
+        "KERNEL32.DLL",
+        "KERNELBASE.DLL",
+        "NORMALIZ.DLL",
+        "NTDLL.DLL",
+        "OLE32.DLL",
+        "OLEAUT32.DLL",
+        "RPCRT4.DLL",
+        "SECUR32.DLL",
+        "SHELL32.DLL",
+        "SHLWAPI.DLL",
+        "UCRTBASE.DLL",
+        "USER32.DLL",
+        "USERENV.DLL",
+        "VERSION.DLL",
+        "WINHTTP.DLL",
+        "WINMM.DLL",
+        "WS2_32.DLL",
+    }
+)
+_PYTHON_DLL = re.compile(r"PYTHON\d+(?:_D)?\.DLL")
+_VC_REDIST_DLLS = frozenset(
+    {
+        "CONCRT140.DLL",
+        "MSVCP140.DLL",
+        "MSVCP140_1.DLL",
+        "MSVCP140_2.DLL",
+        "MSVCP140_ATOMIC_WAIT.DLL",
+        "MSVCP140_CODECVT_IDS.DLL",
+        "VCRUNTIME140.DLL",
+        "VCRUNTIME140_1.DLL",
+    }
+)
+
+
+def _imports(binary: bytes) -> tuple[list[str], list[str]]:
+    """Return regular and delay-loaded DLL imports from a PE image."""
+    try:
+        image = pefile.PE(data=binary, fast_load=False)
+    except pefile.PEFormatError as exc:
+        raise ValueError(f"invalid PE image: {exc}") from exc
+
+    regular: set[str] = set()
+    delayed: set[str] = set()
+    try:
+        for entry in getattr(image, "DIRECTORY_ENTRY_IMPORT", ()):
+            regular.add(entry.dll.decode("ascii").upper())
+        for entry in getattr(image, "DIRECTORY_ENTRY_DELAY_IMPORT", ()):
+            delayed.add(entry.dll.decode("ascii").upper())
+    finally:
+        image.close()
+    return sorted(regular), sorted(delayed)
+
+
+def _is_prerequisite_dll(dll: str) -> bool:
+    """Return whether the documented Windows prerequisites supply a DLL."""
+    return (
+        dll in _ALLOWED_SYSTEM_DLLS
+        or dll in _VC_REDIST_DLLS
+        or dll.startswith(("API-MS-WIN-", "EXT-MS-WIN-"))
+        or _PYTHON_DLL.fullmatch(dll) is not None
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wheel", type=Path, help="Windows wheel to inspect")
+    return parser.parse_args()
+
+
+def _main() -> int:
+    """Validate the wheel and return a process exit code."""
+    wheel = _parse_args().wheel
+    try:
+        with ZipFile(wheel) as archive:
+            binaries = [
+                name
+                for name in archive.namelist()
+                if name.lower().endswith((".dll", ".pyd"))
+            ]
+            extensions = [
+                name
+                for name in binaries
+                if PurePosixPath(name).name.startswith("_core.")
+                and name.lower().endswith(".pyd")
+            ]
+            if len(extensions) != 1:
+                print(
+                    f"ERROR: expected exactly one _core*.pyd in {wheel}, found {len(extensions)}"
+                )
+                return 1
+            imports = {name: _imports(archive.read(name)) for name in binaries}
+    except (BadZipFile, FileNotFoundError, ValueError) as exc:
+        print(f"ERROR: cannot inspect {wheel}: {exc}")
+        return 1
+
+    packaged_dlls = {
+        PurePosixPath(name).name.upper()
+        for name in binaries
+        if name.lower().endswith(".dll")
+    }
+    unresolved: list[tuple[str, str]] = []
+    for name, (regular, delayed) in imports.items():
+        print(f"DLL imports for {name}:")
+        for dll in regular:
+            print(f"  {dll}")
+            if not _is_prerequisite_dll(dll) and dll not in packaged_dlls:
+                unresolved.append((name, dll))
+        for dll in delayed:
+            print(f"  {dll} (delay-loaded)")
+            if not _is_prerequisite_dll(dll) and dll not in packaged_dlls:
+                unresolved.append((name, dll))
+
+    core_regular, _ = imports[extensions[0]]
+    if "VCRUNTIME140.DLL" not in core_regular:
+        print("ERROR: _core is not linked to CPython's dynamic MSVC runtime.")
+        return 1
+
+    if unresolved:
+        print(
+            "ERROR: wheel has DLL imports not supplied by Windows, CPython, "
+            "the Visual C++ Redistributable, or the wheel:"
+        )
+        for name, dll in unresolved:
+            print(f"  {name}: {dll}")
+        return 1
+
+    print(
+        "All native DLL imports are supplied by Windows, CPython, "
+        "the Visual C++ Redistributable, or the wheel."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/.pipelines/pip-scripts/test-pip-wheels-windows.ps1
+++ b/.pipelines/pip-scripts/test-pip-wheels-windows.ps1
@@ -3,9 +3,10 @@
     Install the built Windows wheel and run pytest.
 
 .DESCRIPTION
-    Bootstraps a Python test environment (conda, or a plain venv on platforms
-    conda does not package), installs the wheel with its [test] extras,
-    generates a Component Governance PipReport (non-fatal), and runs pytest.
+    Bootstraps a Python test environment using ms-ensureconda, or a plain venv
+    on platforms conda does not package. Audits the wheel's native DLL imports,
+    installs the base wheel using binary distributions only, verifies a clean
+    import, then installs [test] extras and runs pytest.
 #>
 param(
     [string]$SrcDir        = (Resolve-Path "$PSScriptRoot\..\.." -ErrorAction Stop),
@@ -21,8 +22,8 @@ $ErrorActionPreference = 'Stop'
 $pythonDir = "$SrcDir\python"
 
 # ─── 1. Bootstrap the Python test environment ────────────────────────────────
-# conda everywhere except Windows ARM64, where conda has no usable win-arm64
-# packages; there the wheel is tested in a venv on top of the agent interpreter.
+# ms-ensureconda everywhere except Windows ARM64, where conda has no usable
+# win-arm64 packages; there the wheel is tested in a venv.
 if ($PythonEnv -eq 'venv') {
     Write-Host "=== Set up venv test environment (Python $PythonVersion) ==="
     $runExe = & "$PSScriptRoot\bootstrap-venv.ps1" -EnvName testenv -PythonVersion $PythonVersion
@@ -37,16 +38,29 @@ if ($PythonEnv -eq 'venv') {
     $runNoCapArgs = @('run', '-n', 'testenv', '--no-capture-output', 'python')
 }
 
-# ─── 2. Install wheel with test dependencies ──────────────────────────────────
-Write-Host "=== Install wheel with test dependencies ==="
+# ─── 2. Audit wheel DLL imports ───────────────────────────────────────────────
 $wheels = Get-ChildItem "$pythonDir\repaired_wheelhouse\qdk_chemistry*.whl"
 if ($wheels.Count -ne 1) {
     throw "Expected exactly 1 wheel, found $($wheels.Count): $($wheels.Name -join ', ')"
 }
 $wheel = $wheels[0].FullName
-Write-Host "Installing: $wheel"
 & $runExe @runArgs -m pip install --upgrade pip
 if ($LASTEXITCODE -ne 0) { throw "pip upgrade failed ($LASTEXITCODE)" }
+& $runExe @runArgs -m pip install pefile==2024.8.26
+if ($LASTEXITCODE -ne 0) { throw "pefile install failed ($LASTEXITCODE)" }
+& $runExe @runArgs "$PSScriptRoot\check-wheel-dll-imports.py" $wheel
+if ($LASTEXITCODE -ne 0) { throw "Windows wheel DLL import validation failed ($LASTEXITCODE)" }
+
+# ─── 3. Validate the normal end-user installation path ───────────────────────
+Write-Host "=== Install base wheel using binary distributions only ==="
+Write-Host "Installing: $wheel"
+& $runExe @runArgs -m pip install --only-binary=:all: $wheel
+if ($LASTEXITCODE -ne 0) { throw "minimal pip install failed ($LASTEXITCODE)" }
+& $runExe @runArgs -I -c "import qdk_chemistry; print(qdk_chemistry.__version__)"
+if ($LASTEXITCODE -ne 0) { throw "minimal qdk_chemistry import failed ($LASTEXITCODE)" }
+
+# ─── 4. Install wheel with test dependencies ──────────────────────────────────
+Write-Host "=== Install wheel with test dependencies ==="
 & $runExe @runArgs -m pip install "$wheel[test]"
 if ($LASTEXITCODE -ne 0) { throw "pip install wheel[test] failed ($LASTEXITCODE)" }
 if ($Triplet -ne 'arm64-windows-static-md') {
@@ -54,7 +68,7 @@ if ($Triplet -ne 'arm64-windows-static-md') {
     if ($LASTEXITCODE -ne 0) { throw "MCP installation smoke test failed ($LASTEXITCODE)" }
 }
 
-# ─── 3. Component Governance PipReport (non-fatal) ───────────────────────────
+# ─── 5. Component Governance PipReport (non-fatal) ───────────────────────────
 Write-Host "=== Generate Component Governance PipReport ==="
 try {
     $manifestDir = "$pythonDir\build\test-manifest"
@@ -71,7 +85,7 @@ try {
     Write-Warning "PipReport generation failed (non-fatal): $_"
 }
 
-# ─── 4. Run pytest ────────────────────────────────────────────────────────────
+# ─── 6. Run pytest ────────────────────────────────────────────────────────────
 Write-Host "=== Running pytest suite ==="
 $env:QSHARP_PYTHON_TELEMETRY      = 'false'
 $env:QDK_CHEMISTRY_RUN_SLOW_TESTS = $RunSlowTests

--- a/.pipelines/templates/test-pip-wheels-windows.yml
+++ b/.pipelines/templates/test-pip-wheels-windows.yml
@@ -17,8 +17,8 @@ parameters:
 
 steps:
 # Windows ARM64 tests in a venv on the agent's own interpreter; every other
-# target uses the policy-default conda path, and conda brings its own Python.
-# See the note in build-pip-wheels-windows.yml for why ARM64 cannot use
+# target uses the policy-default ms-ensureconda path, and conda brings its own
+# Python. See the note in build-pip-wheels-windows.yml for why ARM64 cannot use
 # UsePythonVersion@0.
 - ${{ if eq(parameters.arch, 'arm64') }}:
   - pwsh: >-
@@ -36,7 +36,7 @@ steps:
       -PythonEnv $pythonEnv `
       -Triplet '$(VCPKG_TRIPLET)' `
       -RunSlowTests '${{ parameters.runSlowTests }}'
-  displayName: Test wheel (Windows, Python ${{ parameters.pythonVersion }})
+  displayName: Audit and test wheel (Windows, Python ${{ parameters.pythonVersion }})
   condition: ${{ parameters.condition }}
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,6 +29,11 @@ Prebuilt wheels are published for the following platforms:
 | macOS | arm64 (Apple Silicon) | |
 | Windows | x86_64, arm64 | See [Windows notes](#notes-for-windows-users) |
 
+Native Windows installations require the current
+[Microsoft Visual C++ v14 Redistributable](https://learn.microsoft.com/cpp/windows/latest-supported-vc-redist)
+for the Python architecture. Install it once before importing QDK/Chemistry. Microsoft centrally
+services the installed runtime.
+
 On Windows you can either install natively or work inside the
 [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/windows/wsl/install). Both are
 supported: WSL uses the Linux wheels and the Linux instructions throughout this document, and is the
@@ -170,6 +175,7 @@ to native Windows installs; none of them apply under
 
 | Topic | Detail |
 |-------|--------|
+| Visual C++ runtime | Install the current [Microsoft Visual C++ v14 Redistributable](https://learn.microsoft.com/cpp/windows/latest-supported-vc-redist) for the Python architecture. It is a machine-level prerequisite and may require administrator approval. |
 | PySCF plugin | PySCF publishes no Windows wheels, so the `plugins` extra installs no PySCF and the PySCF plugin is unavailable. The native implementations are unaffected. |
 | arm64 dependencies and extras | MCP is omitted from the `all` and `test` extras because its `cryptography` dependency publishes no win-arm64 wheel. A base, `all`, or `test` install therefore needs neither Rust nor a source build of `cryptography`; installing the `mcp` extra explicitly may require an ARM64 Rust toolchain, MSVC C/C++ build tools, and ARM64 OpenSSL development libraries. Qiskit (and Qiskit Aer, Nature, IBM Runtime), PennyLane and RDKit are skipped because they require `rustworkx`, which also publishes no win-arm64 wheel. The Microsoft Discovery backend (`azure-ai-discovery`, `azure-identity`, `azure-storage-blob`) is skipped as well. The features that depend on those skipped extras are unavailable. |
 | OpenMP | Shared-memory threading via OpenMP is disabled on Windows. |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,9 +30,9 @@ Prebuilt wheels are published for the following platforms:
 | Windows | x86_64, arm64 | See [Windows notes](#notes-for-windows-users) |
 
 Native Windows installations require the current
-[Microsoft Visual C++ v14 Redistributable](https://learn.microsoft.com/cpp/windows/latest-supported-vc-redist)
-for the Python architecture. Install it once before importing QDK/Chemistry. Microsoft centrally
-services the installed runtime.
+[Microsoft Visual C++ v14 Redistributable](https://learn.microsoft.com/cpp/windows/latest-supported-vc-redist).
+The [x64 installer](https://aka.ms/vc14/vc_redist.x64.exe) includes both x64 and ARM64 runtimes.
+Install it once before importing QDK/Chemistry. Microsoft centrally services the installed runtime.
 
 On Windows you can either install natively or work inside the
 [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/windows/wsl/install). Both are
@@ -175,7 +175,7 @@ to native Windows installs; none of them apply under
 
 | Topic | Detail |
 |-------|--------|
-| Visual C++ runtime | Install the current [Microsoft Visual C++ v14 Redistributable](https://learn.microsoft.com/cpp/windows/latest-supported-vc-redist) for the Python architecture. It is a machine-level prerequisite and may require administrator approval. |
+| Visual C++ runtime | Install the current [Microsoft Visual C++ v14 Redistributable x64 package](https://aka.ms/vc14/vc_redist.x64.exe), which includes both x64 and ARM64 runtimes. It is a machine-level prerequisite and may require administrator approval. |
 | PySCF plugin | PySCF publishes no Windows wheels, so the `plugins` extra installs no PySCF and the PySCF plugin is unavailable. The native implementations are unaffected. |
 | arm64 dependencies and extras | MCP is omitted from the `all` and `test` extras because its `cryptography` dependency publishes no win-arm64 wheel. A base, `all`, or `test` install therefore needs neither Rust nor a source build of `cryptography`; installing the `mcp` extra explicitly may require an ARM64 Rust toolchain, MSVC C/C++ build tools, and ARM64 OpenSSL development libraries. Qiskit (and Qiskit Aer, Nature, IBM Runtime), PennyLane and RDKit are skipped because they require `rustworkx`, which also publishes no win-arm64 wheel. The Microsoft Discovery backend (`azure-ai-discovery`, `azure-identity`, `azure-storage-blob`) is skipped as well. The features that depend on those skipped extras are unavailable. |
 | OpenMP | Shared-memory threading via OpenMP is disabled on Windows. |

--- a/python/src/qdk_chemistry/__init__.py
+++ b/python/src/qdk_chemistry/__init__.py
@@ -51,12 +51,12 @@ def _import_core() -> None:
     try:
         importlib.import_module("qdk_chemistry._core")
     except ImportError as exc:
-        if _sys.platform == "win32" and "DLL load failed" in str(exc):
+        if _sys.platform == "win32":
             raise ImportError(
                 "QDK/Chemistry requires the current Microsoft Visual C++ v14 "
-                "Redistributable on Windows. Install it for "
-                "your Python architecture, restart Python, and try again: "
-                "https://learn.microsoft.com/cpp/windows/latest-supported-vc-redist"
+                "Redistributable on Windows. Install the x64 package (which also "
+                "includes ARM64), restart Python, and try again: "
+                "https://aka.ms/vc14/vc_redist.x64.exe"
             ) from exc
         raise
 

--- a/python/src/qdk_chemistry/__init__.py
+++ b/python/src/qdk_chemistry/__init__.py
@@ -50,6 +50,8 @@ def _import_core() -> None:
     """Import the native extension with an actionable Windows failure message."""
     try:
         importlib.import_module("qdk_chemistry._core")
+    except ModuleNotFoundError:
+        raise
     except ImportError as exc:
         if _sys.platform == "win32":
             raise ImportError(

--- a/python/src/qdk_chemistry/__init__.py
+++ b/python/src/qdk_chemistry/__init__.py
@@ -45,12 +45,30 @@ import subprocess
 import sys
 import warnings
 
+
+def _import_core() -> None:
+    """Import the native extension with an actionable Windows failure message."""
+    try:
+        importlib.import_module("qdk_chemistry._core")
+    except ImportError as exc:
+        if _sys.platform == "win32" and "DLL load failed" in str(exc):
+            raise ImportError(
+                "QDK/Chemistry requires the current Microsoft Visual C++ v14 "
+                "Redistributable on Windows. Install it for "
+                "your Python architecture, restart Python, and try again: "
+                "https://learn.microsoft.com/cpp/windows/latest-supported-vc-redist"
+            ) from exc
+        raise
+
+
+_import_core()
+
 # Import some tools for convenience
-import qdk_chemistry.constants
-from qdk_chemistry._core import DuplicateRegistrationError as _DuplicateRegistrationError
-from qdk_chemistry._core import QDKChemistryConfig
-from qdk_chemistry.utils import Logger, telemetry_events
-from qdk_chemistry.utils.telemetry import TELEMETRY_ENABLED
+import qdk_chemistry.constants  # noqa: E402
+from qdk_chemistry._core import DuplicateRegistrationError as _DuplicateRegistrationError  # noqa: E402
+from qdk_chemistry._core import QDKChemistryConfig  # noqa: E402
+from qdk_chemistry.utils import Logger, telemetry_events  # noqa: E402
+from qdk_chemistry.utils.telemetry import TELEMETRY_ENABLED  # noqa: E402
 
 if TELEMETRY_ENABLED:
     telemetry_events.on_qdk_chemistry_import()

--- a/python/tests/test_wheel_dll_imports.py
+++ b/python/tests/test_wheel_dll_imports.py
@@ -1,0 +1,62 @@
+"""Tests for packaged native dependencies in the Windows wheel audit."""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from zipfile import ZipFile
+
+import pytest
+
+
+@pytest.mark.parametrize("extension", ["dll", "pyd"])
+@pytest.mark.parametrize("delayed", [False, True])
+@pytest.mark.parametrize("packaged", [False, True])
+def test_wheel_native_dependency_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    extension: str,
+    delayed: bool,
+    packaged: bool,
+) -> None:
+    """Resolve regular and delay-loaded dependencies only when their binaries are shipped."""
+    script = Path(__file__).resolve().parents[2] / ".pipelines" / "pip-scripts" / "check-wheel-dll-imports.py"
+    spec = importlib.util.spec_from_file_location("qdk_wheel_dll_imports_test_module", script)
+    assert spec is not None
+    assert spec.loader is not None
+    audit = importlib.util.module_from_spec(spec)
+    # PE parsing is mocked; these cases need neither pefile nor native binaries.
+    monkeypatch.setitem(sys.modules, "pefile", ModuleType("pefile"))
+    spec.loader.exec_module(audit)
+
+    dependency = f"Helper.{extension}"
+    wheel = tmp_path / "test.whl"
+    with ZipFile(wheel, "w") as archive:
+        archive.writestr("qdk_chemistry/_core.pyd", b"core")
+        if packaged:
+            archive.writestr(f"qdk_chemistry/{dependency}", b"helper")
+
+    def imports(binary: bytes) -> tuple[list[str], list[str]]:
+        if binary == b"helper":
+            return [], []
+        assert binary == b"core"
+        if delayed:
+            return ["VCRUNTIME140.DLL"], [dependency.upper()]
+        return ["VCRUNTIME140.DLL", dependency.upper()], []
+
+    monkeypatch.setattr(audit, "_imports", imports)
+    monkeypatch.setattr(sys, "argv", [str(script), str(wheel)])
+
+    assert audit._main() == (0 if packaged else 1)
+    output = capsys.readouterr().out
+    if packaged:
+        assert "All native DLL imports are supplied" in output
+    else:
+        assert "ERROR: wheel has DLL imports not supplied" in output
+        assert dependency.upper() in output

--- a/python/tests/test_windows_import_error.py
+++ b/python/tests/test_windows_import_error.py
@@ -13,16 +13,18 @@ import pytest
 
 
 @pytest.mark.parametrize("system", ["win32", "linux", "darwin"])
+@pytest.mark.parametrize("error_type", [ImportError, ModuleNotFoundError])
 def test_native_import_error_diagnostic(
     monkeypatch: pytest.MonkeyPatch,
     system: str,
+    error_type: type[ImportError],
 ) -> None:
-    """Report the bundled Windows runtime prerequisite and preserve non-Windows errors."""
+    """Report Windows load failures without masking missing modules or non-Windows errors."""
     spec = importlib.util.find_spec("qdk_chemistry")
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    original = ImportError("localized native extension loader error")
+    original = error_type("localized native extension loader error", name="qdk_chemistry._core")
     import_module = importlib.import_module
 
     def fail_import(name: str, package: str | None = None) -> ModuleType:
@@ -36,10 +38,10 @@ def test_native_import_error_diagnostic(
     with pytest.raises(ImportError) as caught:
         spec.loader.exec_module(module)
 
-    if system == "win32":
+    if system == "win32" and error_type is ImportError:
         assert "Visual C++ v14" in str(caught.value)
         assert "includes ARM64" in str(caught.value)
-        assert str(caught.value).endswith("https://aka.ms/vc14/vc_redist.x64.exe")
+        assert "https://aka.ms/vc14/vc_redist.x64.exe" in str(caught.value)
         assert caught.value.__cause__ is original
     else:
         assert caught.value is original

--- a/python/tests/test_windows_import_error.py
+++ b/python/tests/test_windows_import_error.py
@@ -1,0 +1,34 @@
+"""Tests for the Windows native-extension import diagnostic."""
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from types import SimpleNamespace
+
+import pytest
+
+import qdk_chemistry
+
+
+def test_windows_dll_load_error_identifies_redistributable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Report the machine prerequisite when Windows cannot load the extension."""
+    original = ImportError("DLL load failed while importing _core: The specified module could not be found.")
+
+    def fail_import(_: str) -> None:
+        raise original
+
+    monkeypatch.setattr(
+        qdk_chemistry,
+        "importlib",
+        SimpleNamespace(import_module=fail_import),
+    )
+    monkeypatch.setattr(qdk_chemistry, "_sys", SimpleNamespace(platform="win32"))
+
+    with pytest.raises(ImportError, match="Visual C\\+\\+ v14") as caught:
+        qdk_chemistry._import_core()
+
+    assert caught.value.__cause__ is original

--- a/python/tests/test_windows_import_error.py
+++ b/python/tests/test_windows_import_error.py
@@ -5,30 +5,41 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from types import SimpleNamespace
+import importlib
+import importlib.util
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
-import qdk_chemistry
 
-
-def test_windows_dll_load_error_identifies_redistributable(
+@pytest.mark.parametrize("system", ["win32", "linux", "darwin"])
+def test_native_import_error_diagnostic(
     monkeypatch: pytest.MonkeyPatch,
+    system: str,
 ) -> None:
-    """Report the machine prerequisite when Windows cannot load the extension."""
-    original = ImportError("DLL load failed while importing _core: The specified module could not be found.")
+    """Report the bundled Windows runtime prerequisite and preserve non-Windows errors."""
+    spec = importlib.util.find_spec("qdk_chemistry")
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    original = ImportError("localized native extension loader error")
+    import_module = importlib.import_module
 
-    def fail_import(_: str) -> None:
+    def fail_import(name: str, package: str | None = None) -> ModuleType:
+        if name != "qdk_chemistry._core":
+            return import_module(name, package)
+        monkeypatch.setattr(module, "_sys", SimpleNamespace(platform=system))
         raise original
 
-    monkeypatch.setattr(
-        qdk_chemistry,
-        "importlib",
-        SimpleNamespace(import_module=fail_import),
-    )
-    monkeypatch.setattr(qdk_chemistry, "_sys", SimpleNamespace(platform="win32"))
+    monkeypatch.setattr(importlib, "import_module", fail_import)
 
-    with pytest.raises(ImportError, match="Visual C\\+\\+ v14") as caught:
-        qdk_chemistry._import_core()
+    with pytest.raises(ImportError) as caught:
+        spec.loader.exec_module(module)
 
-    assert caught.value.__cause__ is original
+    if system == "win32":
+        assert "Visual C++ v14" in str(caught.value)
+        assert "includes ARM64" in str(caught.value)
+        assert str(caught.value).endswith("https://aka.ms/vc14/vc_redist.x64.exe")
+        assert caught.value.__cause__ is original
+    else:
+        assert caught.value is original


### PR DESCRIPTION
## Summary

- Document the Microsoft Visual C++ v14 Redistributable as the Windows wheel runtime prerequisite.
- Replace the generic native-extension loader failure with an actionable Windows installation message.
- Preserve the policy-default `ms-ensureconda` test environment on x64 and the existing venv exception on ARM64.
- Add a binary-only base installation and root-package import before test extras.
- Audit every PE import and reject dependencies outside Windows, CPython, the exact release VC++ v14 runtime set, or the wheel itself.

## Rationale

The 2.2.0 Windows wheels link against `MSVCP140.dll` and `VCRUNTIME140*.dll`, but existing CI did not state or validate that runtime boundary. A clean Windows ARM64 VM therefore failed during `import qdk_chemistry` until the VC++ Redistributable was installed.

This keeps `/MD` to match CPython and relies on Microsoft's centrally serviced Redistributable. It does not statically link the CRT or ship a private runtime copy inside the wheel.

## Validation

- Azure release-wheel pipeline run [179669](https://dev.azure.com/ms-azurequantum/AzureQuantum/_build/results?buildId=179669&view=results) succeeded for CPython 3.13 on Windows x64 and ARM64.
- x64 used `ms-ensureconda==2026.6.1`; ARM64 retained the existing venv path.
- Both generated wheels passed the exact PE dependency audit and binary-only base install/root import.
- Windows ARM64: 3007 passed, 369 skipped.
- Windows x64: 3220 passed, 188 skipped.
- The new import-diagnostic test passed on both architectures.
- All staged pre-commit hooks passed.

The separately reported active-space tutorial cube-label issue was already fixed by #640 and is not changed here.